### PR TITLE
feat: Add cool splash screen on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,34 @@ mod commands;
 use clap::Parser;
 use cli::{Cli, Commands, OutputFormat};
 
+/// Print cool splash screen
+fn print_splash_screen() {
+    println!();
+    println!("    ╔══════════════════════════════════════════════════════════════════╗");
+    println!("    ║                                                                  ║");
+    println!("    ║     ███████╗████████╗ █████╗ ███╗   ██╗██████╗ ██╗  ██╗        ║");
+    println!("    ║     ██╔════╝╚══██╔══╝██╔══██╗████╗  ██║██╔══██╗╚██╗██╔╝        ║");
+    println!("    ║     ███████╗   ██║   ███████║██╔██╗ ██║██║  ██║ ╚███╔╝         ║");
+    println!("    ║     ╚════██║   ██║   ██╔══██║██║╚██╗██║██║  ██║ ██╔██╗         ║");
+    println!("    ║     ███████║   ██║   ██║  ██║██║ ╚████║██████╔╝██╔╝ ██╗        ║");
+    println!("    ║     ╚══════╝   ╚═╝   ╚═╝  ╚═╝╚═╝  ╚═══╝╚═════╝ ╚═╝  ╚═╝        ║");
+    println!("    ║                                                                  ║");
+    println!("    ║              ⚡ High-Performance Crypto Trading CLI ⚡            ║");
+    println!("    ║                                                                  ║");
+    println!("    ║                    Version 0.3.0 | StandX Labs                   ║");
+    println!("    ║                                                                  ║");
+    println!("    ╚══════════════════════════════════════════════════════════════════╝");
+    println!();
+}
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    
+    // Print splash screen (unless in quiet mode or OpenClaw mode)
+    if !cli.quiet && !cli.openclaw {
+        print_splash_screen();
+    }
 
     // Initialize logging
     if cli.verbose {


### PR DESCRIPTION
- Add print_splash_screen() function with ASCII art logo
- Display splash screen on every command (unless --quiet or --openclaw)
- Shows StandX CLI branding with version info