### PR TITLE
fix: Kline API response parsing

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -274,7 +274,18 @@ impl StandXClient {
             });
         }
 
-        let data = response.json::<Vec<Kline>>().await?;
+        let response_wrapper = response.json::<crate::models::KlineResponse>().await?;
+
+        if response_wrapper.s != "ok" {
+            return Err(Error::Api {
+                code: 500,
+                message: format!("Kline API returned status: {}", response_wrapper.s),
+                endpoint: Some("/api/kline/history".to_string()),
+                retryable: false,
+            });
+        }
+
+        let data = response_wrapper.to_klines();
         Ok(data)
     }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -160,6 +160,41 @@ pub struct Kline {
     pub volume: String,
 }
 
+/// Kline API response wrapper
+#[derive(Debug, Clone, Deserialize)]
+pub struct KlineResponse {
+    pub s: String,
+    #[serde(default)]
+    pub t: Vec<i64>,
+    #[serde(default)]
+    pub o: Vec<f64>,
+    #[serde(default)]
+    pub h: Vec<f64>,
+    #[serde(default)]
+    pub l: Vec<f64>,
+    #[serde(default)]
+    pub c: Vec<f64>,
+    #[serde(default)]
+    pub v: Vec<f64>,
+}
+
+impl KlineResponse {
+    pub fn to_klines(self) -> Vec<Kline> {
+        let mut klines = Vec::new();
+        for i in 0..self.t.len() {
+            klines.push(Kline {
+                time: self.t[i].to_string(),
+                open: self.o[i].to_string(),
+                high: self.h[i].to_string(),
+                low: self.l[i].to_string(),
+                close: self.c[i].to_string(),
+                volume: self.v[i].to_string(),
+            });
+        }
+        klines
+    }
+}
+
 /// Funding rate information
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FundingRate {


### PR DESCRIPTION
## Problem\nKline command was failing because the API response format was not correctly handled.\n\nAPI returns:\n```json\n{\n  "s": "ok",\n  "t": [timestamp1, timestamp2, ...],\n  "o": [open1, open2, ...],\n  "h": [high1, high2, ...],\n  "l": [low1, low2, ...],\n  "c": [close1, close2, ...],\n  "v": [volume1, volume2, ...]\n}\n```\n\nBut code was trying to deserialize as `Vec<Kline>`.\n\n## Solution\n- Add `KlineResponse` struct to handle API response format\n- Add `to_klines()` method to convert to `Vec<Kline>`\n- Update client to use new response wrapper\n\n## Testing\nTested all resolution parameters:\n- ✅ 1 minute: `-r 1`\n- ✅ 5 minute: `-r 5`\n- ✅ 1 hour: `-r 60`\n- ✅ 1 day: `-r 1D`\n\nFixes ISSUE-2.1