### PR TITLE
fix: Update FundingRate model to match API response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,7 +1974,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "standx-cli"
-version = "0.3.1"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/models.rs
+++ b/src/models.rs
@@ -198,10 +198,19 @@ impl KlineResponse {
 /// Funding rate information
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FundingRate {
+    pub id: i64,
     pub symbol: String,
     #[serde(deserialize_with = "string_or_number_to_string")]
     pub funding_rate: String,
-    pub next_funding_time: String,
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub mark_price: String,
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub index_price: String,
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub premium: String,
+    pub time: String,
+    pub created_at: String,
+    pub updated_at: String,
 }
 
 /// Order side

--- a/src/output.rs
+++ b/src/output.rs
@@ -125,25 +125,34 @@ impl Tabled for Trade {
 
 /// Format funding rate for display
 impl Tabled for FundingRate {
-    const LENGTH: usize = 100;
+    const LENGTH: usize = 6;
 
     fn fields(&self) -> Vec<std::borrow::Cow<'_, str>> {
         vec![
-            self.symbol.clone().into(),
-            self.funding_rate.clone().into(),
-            self.next_funding_time
+            self.time.split('T').next().unwrap_or(&self.time).into(),
+            self.time
                 .split('T')
+                .nth(1)
+                .unwrap_or("")
+                .split('.')
                 .next()
-                .unwrap_or(&self.next_funding_time)
+                .unwrap_or("")
                 .into(),
+            self.funding_rate.clone().into(),
+            self.mark_price.clone().into(),
+            self.index_price.clone().into(),
+            self.premium.clone().into(),
         ]
     }
 
     fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "Symbol".into(),
+            "Date".into(),
+            "Time".into(),
             "Funding Rate".into(),
-            "Next Funding".into(),
+            "Mark Price".into(),
+            "Index Price".into(),
+            "Premium".into(),
         ]
     }
 }


### PR DESCRIPTION
## Problem

The `standx market funding` command was returning HTTP request failed error because the `FundingRate` model did not match the actual API response structure.

## Root Cause

The `FundingRate` struct was missing most fields returned by the API and included a non-existent field `next_funding_time`.

## Changes

### Model Updates (src/models.rs)
- Added missing fields: `id`, `mark_price`, `index_price`, `premium`, `time`, `created_at`, `updated_at`
- Removed non-existent field: `next_funding_time`
- All numeric fields use `string_or_number_to_string` deserializer

### Display Updates (src/output.rs)
- Updated `Tabled` implementation to show 6 columns:
  - Date (from time field)
  - Time (from time field)
  - Funding Rate
  - Mark Price
  - Index Price
  - Premium

## Testing

```bash
$ standx market funding BTC-USD --days 7
+------------+-----------+--------------+------------+-------------+---------------------------------+
| Date       | Time      | Funding Rate | Mark Price | Index Price | Premium                         |
+------------+-----------+--------------+------------+-------------+---------------------------------+
| 2026-02-19 | 06:00:00Z | 0.00001250   | 66860.79   | 66873.87    | -0.0001940084218567860116569525 |
| 2026-02-19 | 07:00:00Z | 0.00001250   | 67135.50   | 67151.06    | -0.0002141721376214265889536497 |
...
```

## API Response Format

```json
{
  "id": 4224,
  "symbol": "BTC-USD",
  "funding_rate": "0.00001250",
  "mark_price": "66860.79",
  "index_price": "66873.87",
  "premium": "-0.000194...",
  "time": "2026-02-19T06:00:00Z",
  "created_at": "2026-02-19T06:00:00Z",
  "updated_at": "2026-02-19T06:00:00Z"
}
```

---

*Created by Kimi Claw AI Assistant*