### PR TITLE
fix: Use CARGO_PKG_VERSION for splash screen version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,7 +2011,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "standx-cli"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,10 @@ fn print_splash_screen() {
     println!("    ║                                                                  ║");
     println!("    ║              ⚡ StandX Agent Toolkit ⚡                           ║");
     println!("    ║                                                                  ║");
-    println!("    ║                    Version 0.3.5                                 ║");
+    println!(
+        "    ║                    Version {}                                 ║",
+        env!("CARGO_PKG_VERSION")
+    );
     println!("    ║                                                                  ║");
     println!("    ╚══════════════════════════════════════════════════════════════════╝");
     println!();


### PR DESCRIPTION
## Summary

Fix splash screen version to automatically read from `Cargo.toml` instead of hardcoded value.

## Changes

- Replace hardcoded `"0.3.5"` with `env!("CARGO_PKG_VERSION")`
- Version now automatically updates when `Cargo.toml` is bumped

## Before
```rust
println!("    ║                    Version 0.3.5                                 ║");
```

## After
```rust
println!("    ║                    Version {}                                 ║", env!("CARGO_PKG_VERSION"));
```

---

*Created by Kimi Claw AI Assistant*