### PR TITLE
fix: Update Position model to match API response

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 #[derive(Error, Debug, Serialize)]
 #[serde(tag = "error_type")]
 pub enum Error {
-    #[error("HTTP request failed")]
+    #[error("HTTP request failed: {code} - {message}")]
     #[serde(rename = "HTTP_ERROR")]
     Http {
         code: u16,
@@ -22,7 +22,7 @@ pub enum Error {
     #[serde(rename = "JSON_ERROR")]
     Json { message: String },
 
-    #[error("API error")]
+    #[error("API error: {code} - {message}")]
     #[serde(rename = "API_ERROR")]
     Api {
         code: u16,

--- a/src/models.rs
+++ b/src/models.rs
@@ -342,22 +342,42 @@ impl tabled::Tabled for Order {
 /// Position information
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Position {
+    pub id: i64,
     pub symbol: String,
-    pub side: PositionSide,
     #[serde(deserialize_with = "string_or_number_to_string")]
-    pub quantity: String,
+    pub qty: String,
     #[serde(deserialize_with = "string_or_number_to_string")]
     pub entry_price: String,
     #[serde(deserialize_with = "string_or_number_to_string")]
-    pub mark_price: String,
+    pub entry_value: String,
     #[serde(deserialize_with = "string_or_number_to_string")]
-    pub liquidation_price: String,
+    pub holding_margin: String,
     #[serde(deserialize_with = "string_or_number_to_string")]
-    pub margin: String,
+    pub initial_margin: String,
     #[serde(deserialize_with = "string_or_number_to_string")]
     pub leverage: String,
     #[serde(deserialize_with = "string_or_number_to_string")]
-    pub unrealized_pnl: String,
+    pub mark_price: String,
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub margin_asset: String,
+    pub margin_mode: String,
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub position_value: String,
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub realized_pnl: String,
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub required_margin: String,
+    pub status: String,
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub upnl: String,
+    pub time: String,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub liq_price: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mmr: Option<String>,
+    pub user: String,
 }
 
 impl tabled::Tabled for Position {
@@ -366,25 +386,25 @@ impl tabled::Tabled for Position {
     fn fields(&self) -> Vec<std::borrow::Cow<'_, str>> {
         vec![
             self.symbol.clone().into(),
-            format!("{:?}", self.side).into(),
-            self.quantity.clone().into(),
+            self.qty.clone().into(),
             self.entry_price.clone().into(),
             self.mark_price.clone().into(),
-            self.liquidation_price.clone().into(),
+            self.liq_price.clone().unwrap_or_default().into(),
             self.leverage.clone().into(),
-            self.unrealized_pnl.clone().into(),
+            self.margin_mode.clone().into(),
+            self.upnl.clone().into(),
         ]
     }
 
     fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             "Symbol".into(),
-            "Side".into(),
-            "Quantity".into(),
+            "Qty".into(),
             "Entry Price".into(),
             "Mark Price".into(),
             "Liq Price".into(),
             "Leverage".into(),
+            "Margin Mode".into(),
             "Unrealized PnL".into(),
         ]
     }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -23,6 +23,7 @@ pub enum WsState {
 
 /// WebSocket message wrapper
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum WsMessage {
     Connected,
     Disconnected,


### PR DESCRIPTION
## Summary

Fix Position model to match actual API response format from `/api/query_positions`.

## Problem

The Position struct had incorrect field names that didn't match the API response:
- `quantity` vs `qty`
- `liquidation_price` vs `liq_price`
- `margin` vs `holding_margin`/`initial_margin`
- `unrealized_pnl` vs `upnl`
- Missing many fields returned by API

This caused deserialization errors when calling `standx account positions`.

## Changes

### Position Model

**Added fields:**
- `id: i64`
- `qty: String` (replaces `quantity`)
- `entry_value: String`
- `holding_margin: String`
- `initial_margin: String`
- `margin_asset: String`
- `margin_mode: String`
- `position_value: String`
- `realized_pnl: String`
- `required_margin: String`
- `status: String`
- `upnl: String` (replaces `unrealized_pnl`)
- `time: String`
- `created_at: String`
- `updated_at: String`
- `liq_price: Option<String>` (replaces `liquidation_price`)
- `mmr: Option<String>`
- `user: String`

**Removed fields:**
- `side: PositionSide` (not in API response)
- `quantity: String` (renamed to `qty`)
- `liquidation_price: String` (renamed to `liq_price`)
- `margin: String` (replaced by specific margin fields)
- `unrealized_pnl: String` (renamed to `upnl`)

### Table Display

Updated columns to show:
- Symbol, Qty, Entry Price, Mark Price
- Liq Price, Leverage, Margin Mode, Unrealized PnL

### WebSocket

Added `#[allow(clippy::large_enum_variant)]` to `WsMessage` enum since Position is now larger.

## Testing

```bash
$ standx account positions
+---------+-----+-------------+------------+-----------+----------+-------------+----------------+
| Symbol  | Qty | Entry Price | Mark Price | Liq Price | Leverage | Margin Mode | Unrealized PnL |
+---------+-----+-------------+------------+-----------+----------+-------------+----------------+
| BTC-USD | 0   | 0           | 67974.71   |           | 20       | isolated    | 0              |
+---------+-----+-------------+------------+-----------+----------+-------------+----------------+
```

---

*Created by Kimi Claw AI Assistant*