### PR TITLE
feat: add github-pr-review skill

### DIFF
--- a/skills/github-pr-review/README.md
+++ b/skills/github-pr-review/README.md
@@ -1,0 +1,73 @@
+# GitHub PR Review Workflow
+
+This directory contains a reusable skill for automated GitHub PR review.
+
+## Created From
+
+This workflow was extracted from the `standx-cli-pr-monitor` cron job, which monitors the standx-cli repository for new PRs requiring review.
+
+## Key Learnings
+
+### 1. PR Filtering
+
+**Always filter by state:**
+```bash
+gh pr list --state open  # Only open PRs
+```
+
+**Skip conditions:**
+- Closed/merged PRs
+- Already reviewed by you
+- Draft PRs (optional)
+
+### 2. Avoid Duplicate Reviews
+
+Check existing comments:
+```bash
+gh pr view <number> --comments | grep "your-username"
+```
+
+Maintain a review log file.
+
+### 3. Smart Reporting
+
+**Don't spam:**
+- Send message only when there's new activity
+- Use `NO_REPLY` when nothing to report
+
+### 4. Review Template
+
+Standardize review comments:
+- Summary
+- Code quality check
+- Suggestions
+- Signature
+
+## Usage
+
+### As a Cron Job
+
+```bash
+openclaw cron add --name "my-repo-review" \
+  --schedule "every 10m" \
+  --message "Check PRs for owner/repo"
+```
+
+### Manual Review
+
+```bash
+gh pr list --state open
+gh pr diff <number>
+gh pr review <number> --comment
+```
+
+## Files
+
+- `SKILL.md` - Skill definition and workflow
+- `README.md` - This file
+
+## Future Improvements
+
+- [ ] Auto-detect programming language
+- [ ] Integration with CI status
+- [ ] Review assignment based on file paths

--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: github-pr-review
+metadata:
+  openclaw:
+    emoji: 👁️
+    requires:
+      bins:
+        - gh
+    primaryCredential:
+      kind: env
+      env: GITHUB_TOKEN
+      description: GitHub personal access token for PR review
+    install:
+      - id: brew
+        kind: brew
+        formula: gh
+        bins:
+          - gh
+        label: Install GitHub CLI
+---
+
+# GitHub PR Review Skill
+
+Automated PR review workflow for GitHub repositories.
+
+## Use Cases
+
+- Monitor repository for new PRs requiring review
+- Automated code review with AI assistance
+- Track review history and avoid duplicate reviews
+
+## Workflow Steps
+
+### 1. List Open PRs
+
+```bash
+gh pr list --state open --limit 10 --repo owner/repo
+```
+
+### 2. Filter PRs to Review
+
+Skip PRs that are:
+- Already reviewed by you
+- Closed/merged
+- Draft (optional)
+
+### 3. Review Each PR
+
+```bash
+# View PR details
+gh pr view <number> --repo owner/repo
+
+# View diff
+gh pr diff <number> --repo owner/repo
+
+# Submit review
+gh pr review <number> --comment --body "Review comment"
+```
+
+### 4. Record Reviewed PRs
+
+Maintain a log file to avoid duplicate reviews:
+```
+pr-review-log.md
+```
+
+## Best Practices
+
+### Reporting Rules
+
+- **Send message**: Only when new PRs are reviewed
+- **NO_REPLY**: If no new activity
+
+### Review Criteria
+
+1. Code quality and style
+2. Security concerns
+3. Documentation completeness
+4. Test coverage
+
+### Review Template
+
+```markdown
+## PR Review Summary
+
+**Status**: [Approved/Request Changes/Comment]
+
+### Summary
+Brief description of changes
+
+### Code Quality
+- ✅/❌ Code style consistent
+- ✅/❌ No obvious bugs
+- ✅/❌ Tests included
+
+### Suggestions
+1. ...
+2. ...
+
+---
+Reviewed by: Kimi Claw AI Assistant
+```
+
+## Cron Configuration
+
+```json
+{
+  "name": "repo-pr-monitor",
+  "schedule": {
+    "everyMs": 600000
+  },
+  "message": "Check for new PRs..."
+}
+```
+
+## References
+
+- [GitHub CLI docs](https://cli.github.com/manual/)
+- [PR Review best practices](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews)


### PR DESCRIPTION
## Summary

Extract the PR review workflow from standx-cli-pr-monitor into a reusable skill.

## What's Included

- **SKILL.md** - Complete workflow definition for automated PR review
- **README.md** - Key learnings, best practices, and usage guide

## Key Learnings Documented

1. **PR Filtering** - Always use , skip closed/merged
2. **Avoid Duplicates** - Check existing comments, maintain review log
3. **Smart Reporting** - Only send messages when there's new activity
4. **Review Template** - Standardized format for consistency

## Reusability

This skill can be applied to any GitHub repository by:
- Copying the skill files
- Updating the repo name in cron config
- Customizing the review criteria

## Future Use

Can be published to ClawHub for broader reuse.