### PR TITLE
feat: add portfolio command base infrastructure (PR #1 for Issue #105)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,6 +89,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: DashboardCommands,
     },
+    /// Portfolio - view portfolio summary and performance
+    Portfolio {
+        #[command(subcommand)]
+        command: PortfolioCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -302,6 +307,19 @@ pub enum DashboardCommands {
         /// Filter by specific symbols (comma-separated)
         #[arg(short, long)]
         symbols: Option<String>,
+        /// Enable verbose output with more details
+        #[arg(short, long)]
+        verbose: bool,
+        /// Watch mode: refresh every N seconds
+        #[arg(short, long)]
+        watch: Option<u64>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PortfolioCommands {
+    /// Get portfolio summary and performance
+    Snapshot {
         /// Enable verbose output with more details
         #[arg(short, long)]
         verbose: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,9 @@ async fn execute_command(
         Commands::Dashboard { command } => {
             commands::handle_dashboard(command, output).await?;
         }
+        Commands::Portfolio { command } => {
+            commands::handle_portfolio(command, output).await?;
+        }
     }
     Ok(())
 }
@@ -164,6 +167,7 @@ async fn handle_dry_run(command: &Commands, output: OutputFormat) -> Result<(), 
         Commands::Margin { .. } => "⚠️  WOULD MODIFY MARGIN - POSITION IMPACT",
         Commands::Stream { .. } => "Would start real-time data stream",
         Commands::Dashboard { .. } => "Would fetch dashboard data (read-only, safe to execute)",
+        Commands::Portfolio { .. } => "Would fetch portfolio data (read-only, safe to execute)",
     };
 
     let dry_run_info = serde_json::json!({

--- a/src/models.rs
+++ b/src/models.rs
@@ -584,6 +584,24 @@ pub struct DashboardSnapshot {
     pub market: Vec<MarketData>,
 }
 
+/// Portfolio snapshot - portfolio summary and performance
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PortfolioSnapshot {
+    /// Snapshot timestamp (ISO 8601)
+    pub timestamp: String,
+    /// Total portfolio value in USD
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub total_value_usd: String,
+    /// PnL in the last 24 hours
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub total_pnl_24h: String,
+    /// Total realized PnL (unrealized)
+    #[serde(deserialize_with = "string_or_number_to_string")]
+    pub total_pnl_realized: String,
+    /// Open positions
+    pub positions: Vec<Position>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Add portfolio command base infrastructure for Issue #105.

## Changes

- **Add PortfolioCommands enum** (cli.rs): Portfolio subcommand with ,  flags
- **Add handle_portfolio function** (commands.rs): Framework function for portfolio data retrieval
- **Add PortfolioSnapshot struct** (models.rs): Contains timestamp, total_value_usd, total_pnl_24h, total_pnl_realized, positions
- **Update main.rs**: Add command processing for Portfolio

## Testing

- ✅ cargo fmt passed
- ✅ cargo clippy passed  
- ✅ cargo build passed