### PR TITLE
fix(dashboard): avoid duplicate get_balance() call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,7 +2088,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "standx-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",


### PR DESCRIPTION
## Fix

- Call get_balance() once and reuse the result
- Show login prompt during the call instead of after

## Issue

Reported by Lance: get_balance() was called twice