### PR TITLE
fix: remove duplicate Portfolio command definition

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,11 +101,6 @@ pub enum Commands {
         #[command(subcommand)]
         command: PortfolioCommands,
     },
-    /// Portfolio - view portfolio summary and performance
-    Portfolio {
-        #[command(subcommand)]
-        command: PortfolioCommands,
-    },
 }
 
 #[derive(Subcommand, Debug)]


### PR DESCRIPTION
## Summary

Fix merge conflict residue from PR #106 that caused duplicate Portfolio enum variant in Commands.

## Changes

- Remove duplicate  command definition in 

## Problem

After merging PR #106, the  enum had two identical  variants, which would cause compilation error.

## Fix

Removed the duplicate variant, keeping only one.