### PR TITLE
docs: add Portfolio command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ standx margin mode BTC-USD
 standx margin mode BTC-USD --set isolated
 ```
 
-### Trade History
+:### Trade History
 
 ```bash
 # Get recent trades
@@ -314,6 +314,19 @@ standx trade history BTC-USD --from 1d
 
 # With time range
 standx trade history BTC-USD --from 2024-01-01 --to 2024-01-07
+```
+
+### Portfolio
+
+```bash
+# Get portfolio summary
+standx portfolio
+
+# Verbose mode with more details
+standx portfolio --verbose
+
+# Auto-refresh mode
+standx portfolio --watch
 ```
 
 ### Streaming


### PR DESCRIPTION
## Summary

Add Portfolio command documentation to README command reference section.

## Changes

- Add  basic usage
- Add  and  options
- Keep consistent with other command documentation style

## Checklist

- [x] Documentation follows existing style
- [x] Command examples are correct
- [x] No code changes