### PR TITLE
fix(depth): improve spread display to show dollar amount and percentage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,7 +2088,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "standx-cli"
-version = "0.6.2"
+version = "0.6.3-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/src/models.rs
+++ b/src/models.rs
@@ -158,11 +158,18 @@ impl OrderBook {
     }
 
     /// Get spread between best bid and ask
+    /// Returns format: "$X.XX (Y.YY%)"
     pub fn spread(&self) -> Option<String> {
         match (self.best_bid(), self.best_ask()) {
             (Some(bid), Some(ask)) => {
                 if let (Ok(b), Ok(a)) = (bid.parse::<f64>(), ask.parse::<f64>()) {
-                    Some(format!("{:.2}", a - b))
+                    let spread_value = a - b;
+                    let spread_percent = if a > 0.0 {
+                        (spread_value / a) * 100.0
+                    } else {
+                        0.0
+                    };
+                    Some(format!("${:.2} ({:.2}%)", spread_value, spread_percent))
                 } else {
                     None
                 }
@@ -699,7 +706,7 @@ mod tests {
 
         assert_eq!(book.best_bid(), Some("68000"));
         assert_eq!(book.best_ask(), Some("68100"));
-        assert_eq!(book.spread(), Some("100.00".to_string()));
+        assert_eq!(book.spread(), Some("$100.00 (0.15%)".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes Issue #118 - Depth Spread Display Optimization.

## Problem

Previously, spread showed only price difference (e.g., "3.00"), which wasn't intuitive for high-value assets like BTC.

## Solution

Now displays both dollar amount and percentage:
- Before: 
- After: 

## Test

