### PR TITLE
fix: properly handle -q (quiet) flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,9 @@ async fn main() {
     }
 
     // Set default output to JSON in OpenClaw mode
-    let output = if cli.openclaw {
+    let output = if cli.quiet {
+        OutputFormat::Quiet
+    } else if cli.openclaw {
         OutputFormat::Json
     } else {
         cli.output


### PR DESCRIPTION
## Summary

Fixes Issue #134 - Quiet 模式 (-q) 无效.

## Problem

The  flag was only affecting the logging level, but not the output format. The output was still showing headers and table formatting.

## Solution

Now properly converts  flag to :


## Test

