### PR TITLE
feat: add maker bot (standx maker run) for SIP-5A community maker yield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Maker bot: `standx maker run <SYMBOL>`** (alias `mk`) — two-sided quoting loop targeting SIP-5A community maker yield
+  - Anti-flicker reconcile: quotes rest inside the eligibility band and only re-quote when mark drifts past `--refresh-bps`
+  - Flags: `--spread-bps`, `--band-bps`, `--size`, `--levels`, `--level-step-bps`, `--refresh-bps`, `--interval`, `--max-position`
+  - **Paper mode by default** (full loop, prints intended actions, no orders); `--live` implements real post-only quoting but is locked behind `STANDX_ENABLE_LIVE_MAKER=1` pending supervised production testing
+  - Live safety rails: startup cancel-all, exchange open-orders as reconciliation truth, cancel-all-with-retry + verification on exit, fail-safe stop after 3 consecutive API errors
+  - JSON-lines output for agents (`--output json` / `--openclaw`)
+  - Pure quoting/reconcile core in `standx_sdk::maker` with 15 unit tests
+- `TimeInForce::Alo` (post-only / add-liquidity-only), matching the backend enum; `standx order create --tif ALO` now supported
+- Block trade commands: `standx block list` / `standx block watch`
+
 ### Changed
 - **Workspace split: `standx-sdk` extracted as an independent crate**
   - `crates/standx-sdk` (v0.1.0): REST client, WebSocket streams, models, auth/signing, errors — reusable by any Rust agent/bot; zero presentation dependencies by default (table rendering behind the optional `tabled` feature)
@@ -15,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unused dependencies: `comfy-table`, `once_cell`, `config`, `keyring` (and the vestigial `no-keyring` feature)
 
 ### Fixed
+- Kline streaming: handle symbol/interval in parent message
 - `order create`: removed `-q` short flag (collided with global `--quiet`; clap panics on the collision in debug builds). Use `--qty`.
 - Deflaked env-var tests (config + credentials) by serializing them with a lock
 - Version integration test no longer hardcodes the version number

--- a/README.md
+++ b/README.md
@@ -348,6 +348,41 @@ standx stream balance    # Balance updates
 standx stream fills      # Fill updates
 ```
 
+### Maker Bot (SIP-5A Community Maker Yield)
+
+A simple two-sided quoting loop optimized for
+[SIP-5A](https://docs.standx.com/sip/sip-5a-community-maker-yield): it keeps
+quotes resting inside the eligibility band (uptime is what earns) and only
+re-quotes when mark price drifts past a threshold — no flicker-cancelling.
+
+```bash
+# Paper mode (default): runs the full loop, prints intended actions,
+# places NO orders. Safe to run without credentials.
+standx maker run BTC-USD --size 0.001 --interval 3
+
+# Tune the strategy
+standx maker run BTC-USD \
+  --spread-bps 5      # half-spread from mark price
+  --band-bps 20       # never quote outside mark ± band
+  --refresh-bps 3     # anti-flicker: re-quote only after this much drift
+  --levels 2          # quote levels per side
+  --max-position 0.05 # suppress the side that would exceed this
+
+# Machine-readable JSON lines (one object per action)
+standx maker run BTC-USD --output json
+
+# Live mode places real post-only (ALO) orders and requires a private key.
+# It is currently locked behind STANDX_ENABLE_LIVE_MAKER=1 until
+# supervised production testing completes.
+standx maker run BTC-USD --live
+```
+
+In live mode the bot manages **all** orders on the quoted symbol (it starts
+with a cancel-all and cancels unknown orders as stale), cancels everything on
+exit (with retries and verification), and stops quoting after 3 consecutive
+API errors (fail-safe). Paper mode does not simulate fills, so position
+stays 0.
+
 ---
 
 ## 💡 Use Cases

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -120,6 +120,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: BlockCommands,
     },
+    /// Market-maker bot (SIP-5A community maker yield)
+    #[command(visible_alias = "mk")]
+    Maker {
+        #[command(subcommand)]
+        command: MakerCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -374,7 +380,45 @@ pub enum BlockCommands {
     },
 }
 
-#[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
+#[derive(Subcommand, Debug)]
+pub enum MakerCommands {
+    /// Run the maker quoting loop (paper mode by default; --live to place orders)
+    Run {
+        /// Symbol to quote (e.g., BTC-USD)
+        symbol: String,
+        /// Half-spread from mark price in basis points
+        #[arg(long, default_value = "5")]
+        spread_bps: f64,
+        /// Eligibility band guard in bps: never quote outside mark ± band
+        #[arg(long, default_value = "20")]
+        band_bps: f64,
+        /// Per-side, per-level order quantity
+        #[arg(long, default_value = "0.01")]
+        size: f64,
+        /// Number of quote levels per side
+        #[arg(long, default_value = "1")]
+        levels: u32,
+        /// Spacing between levels in bps (when levels > 1)
+        #[arg(long, default_value = "2")]
+        level_step_bps: f64,
+        /// Anti-flicker: re-quote only when mark moved more than this (bps)
+        /// since the order was placed
+        #[arg(long, default_value = "3")]
+        refresh_bps: f64,
+        /// Loop interval in seconds
+        #[arg(short, long, default_value = "5")]
+        interval: u64,
+        /// Max absolute position; suppress the side that would exceed it
+        #[arg(long, default_value = "0.05")]
+        max_position: f64,
+        /// Place real orders (without this flag the bot runs in paper mode:
+        /// full loop, prints intended actions, no orders placed)
+        #[arg(long)]
+        live: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum OutputFormat {
     #[default]
     Table,

--- a/crates/standx-cli/src/commands.rs
+++ b/crates/standx-cli/src/commands.rs
@@ -110,6 +110,7 @@ pub async fn handle_order(command: OrderCommands) -> Result<()> {
                 "GTC" => TimeInForce::Gtc,
                 "IOC" => TimeInForce::Ioc,
                 "FOK" => TimeInForce::Fok,
+                "ALO" => TimeInForce::Alo,
                 _ => TimeInForce::Gtc,
             });
 
@@ -1483,6 +1484,709 @@ async fn build_portfolio_output(
     };
 
     Ok(rendered)
+}
+
+// ============================================================================
+// Maker bot (SIP-5A community maker yield)
+// ============================================================================
+
+/// Env var gating live order placement. The live path ships code-complete but
+/// locked until it has been supervised-tested against production.
+const LIVE_MAKER_ENV: &str = "STANDX_ENABLE_LIVE_MAKER";
+
+/// Why the maker loop stopped.
+enum MakerExit {
+    CtrlC,
+    /// Too many consecutive API errors — fail safe, not open.
+    FailSafe(String),
+}
+
+/// Pending place awaiting order-id adoption (live mode): create_order only
+/// returns a request id, so new open orders are matched back to recent
+/// places by (side, price, qty) on the next cycle.
+struct PendingPlace {
+    side: OrderSide,
+    price: f64,
+    qty: f64,
+    level: u32,
+    ref_mark: f64,
+    cycle: u64,
+}
+
+/// Handle maker commands
+pub async fn handle_maker(
+    command: MakerCommands,
+    output_format: OutputFormat,
+    _verbose: bool,
+) -> Result<()> {
+    match command {
+        MakerCommands::Run {
+            symbol,
+            spread_bps,
+            band_bps,
+            size,
+            levels,
+            level_step_bps,
+            refresh_bps,
+            interval,
+            max_position,
+            live,
+        } => {
+            run_maker(
+                symbol,
+                MakerRunArgs {
+                    spread_bps,
+                    band_bps,
+                    size,
+                    levels,
+                    level_step_bps,
+                    refresh_bps,
+                    interval,
+                    max_position,
+                    live,
+                },
+                output_format,
+            )
+            .await
+        }
+    }
+}
+
+struct MakerRunArgs {
+    spread_bps: f64,
+    band_bps: f64,
+    size: f64,
+    levels: u32,
+    level_step_bps: f64,
+    refresh_bps: f64,
+    interval: u64,
+    max_position: f64,
+    live: bool,
+}
+
+async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputFormat) -> Result<()> {
+    use standx_sdk::maker::{self, MakerConfig, RestingQuote};
+
+    let client = StandXClient::new()?;
+
+    // ---- Startup: symbol metadata + invariants (fail fast) ----
+    let infos = client.get_symbol_info().await?;
+    let info = infos
+        .iter()
+        .find(|i| i.symbol.eq_ignore_ascii_case(&symbol))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown symbol '{}'. Available: {}",
+                symbol,
+                infos
+                    .iter()
+                    .map(|i| i.symbol.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+    if info.status != "trading" {
+        return Err(anyhow::anyhow!(
+            "Symbol {} is not trading (status: {})",
+            info.symbol,
+            info.status
+        ));
+    }
+    let symbol = info.symbol.clone(); // canonical casing
+
+    let min_order_qty: f64 = info.min_order_qty.parse().unwrap_or(0.0);
+    let cfg = MakerConfig {
+        spread_bps: args.spread_bps,
+        band_bps: args.band_bps,
+        level_step_bps: args.level_step_bps,
+        refresh_bps: args.refresh_bps,
+        levels: args.levels.max(1),
+        size: args.size,
+        max_position: args.max_position,
+        price_decimals: info.price_tick_decimals,
+        qty_decimals: info.qty_tick_decimals,
+        min_order_qty,
+    };
+
+    if cfg.spread_bps <= 0.0 {
+        return Err(anyhow::anyhow!("--spread-bps must be > 0"));
+    }
+    if cfg.band_bps <= cfg.spread_bps {
+        return Err(anyhow::anyhow!(
+            "--band-bps ({}) must be greater than --spread-bps ({}): quotes clamped to the band edge would sit exactly at the boundary",
+            cfg.band_bps,
+            cfg.spread_bps
+        ));
+    }
+    let rounded_size = maker::round_to_decimals(cfg.size, cfg.qty_decimals);
+    if rounded_size < cfg.min_order_qty || rounded_size <= 0.0 {
+        return Err(anyhow::anyhow!(
+            "--size {} (rounded to {} at {} decimals) is below min order qty {} for {}",
+            cfg.size,
+            rounded_size,
+            cfg.qty_decimals,
+            cfg.min_order_qty,
+            symbol
+        ));
+    }
+    if cfg.refresh_bps >= cfg.spread_bps {
+        eprintln!(
+            "⚠️  --refresh-bps ({}) >= --spread-bps ({}): quotes will be held through large drifts",
+            cfg.refresh_bps, cfg.spread_bps
+        );
+    }
+    if cfg.levels > 1
+        && cfg.spread_bps + (cfg.levels - 1) as f64 * cfg.level_step_bps >= cfg.band_bps
+    {
+        eprintln!("⚠️  outer quote levels exceed the band and will be clamped/collapsed");
+    }
+
+    // ---- Live gating & clean start ----
+    if args.live {
+        if std::env::var(LIVE_MAKER_ENV).ok().as_deref() != Some("1") {
+            return Err(anyhow::anyhow!(
+                "live mode not yet enabled: it has not been supervised-tested against production. Set {}=1 to unlock (at your own risk).",
+                LIVE_MAKER_ENV
+            ));
+        }
+        let creds = Credentials::load()?;
+        if creds.is_expired() {
+            return Err(anyhow::anyhow!(
+                "Credentials expired. Run 'standx auth login' first."
+            ));
+        }
+        if creds.private_key.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Live mode requires a private key for order signing. Run 'standx auth login' with --private-key."
+            ));
+        }
+        // Start from a clean book so reconciliation isn't confused by
+        // leftovers from a previous run. The bot owns ALL orders on this
+        // symbol while running.
+        client.cancel_all_orders(&symbol).await?;
+    }
+
+    let mode = if args.live { "LIVE" } else { "PAPER" };
+    if output_format == OutputFormat::Table {
+        println!("┌──────────────────────────────────────────────────────────┐");
+        println!("│ standx maker — {} mode on {}", mode, symbol);
+        println!(
+            "│ spread {}bps | band {}bps | refresh {}bps | {} level(s)",
+            cfg.spread_bps, cfg.band_bps, cfg.refresh_bps, cfg.levels
+        );
+        println!(
+            "│ size {} | max-position {} | interval {}s",
+            cfg.size, cfg.max_position, args.interval
+        );
+        println!(
+            "│ ticks: price {}dp, qty {}dp | min qty {}",
+            cfg.price_decimals, cfg.qty_decimals, cfg.min_order_qty
+        );
+        if !args.live {
+            println!("│ paper mode: no orders are placed; fills are NOT simulated");
+            println!("│ (position stays 0). Add --live for real quoting.");
+        } else {
+            println!(
+                "│ ⚠️  LIVE: the bot manages ALL orders on {} — manual",
+                symbol
+            );
+            println!("│ orders on this symbol will be cancelled as stale.");
+        }
+        println!("│ Ctrl+C to stop (cancels all resting orders on exit)");
+        println!("└──────────────────────────────────────────────────────────┘");
+    }
+
+    // ---- Loop state ----
+    let mut cycle: u64 = 0;
+    let mut resting: Vec<RestingQuote> = Vec::new(); // paper-mode book
+    let mut adopted: HashMap<String, (u32, f64, u64)> = HashMap::new(); // id -> (level, ref_mark, cycle)
+    let mut pending: Vec<PendingPlace> = Vec::new();
+    let mut consecutive_errors: u32 = 0;
+    let mut total_places: u64 = 0;
+    let mut total_cancels: u64 = 0;
+    let mut total_holds: u64 = 0;
+
+    let exit = loop {
+        // Work phase raced against Ctrl+C so a slow API call can be
+        // interrupted (mirrors run_watch_loop).
+        let work = maker_cycle(
+            &client,
+            &symbol,
+            &cfg,
+            args.live,
+            cycle,
+            &mut resting,
+            &mut adopted,
+            &mut pending,
+            output_format,
+        );
+        let cycle_result = tokio::select! {
+            _ = signal::ctrl_c() => break MakerExit::CtrlC,
+            result = work => result,
+        };
+
+        match cycle_result {
+            Ok((places, cancels, holds)) => {
+                consecutive_errors = 0;
+                total_places += places;
+                total_cancels += cancels;
+                total_holds += holds;
+            }
+            Err(e) => {
+                consecutive_errors += 1;
+                eprintln!("⚠️  maker cycle failed ({}/3): {}", consecutive_errors, e);
+                if consecutive_errors >= 3 {
+                    break MakerExit::FailSafe(e.to_string());
+                }
+            }
+        }
+
+        cycle += 1;
+
+        tokio::select! {
+            _ = signal::ctrl_c() => break MakerExit::CtrlC,
+            _ = tokio::time::sleep(Duration::from_secs(args.interval)) => {}
+        }
+    };
+
+    // ---- Cleanup on ALL exit paths ----
+    if output_format == OutputFormat::Table {
+        println!(
+            "\n👋 Stopping maker (ran {} cycles: {} places, {} cancels, {} holds)",
+            cycle, total_places, total_cancels, total_holds
+        );
+    }
+    if args.live {
+        cancel_all_with_retry(&client, &symbol, 3).await?;
+    }
+
+    match exit {
+        MakerExit::CtrlC => Ok(()),
+        MakerExit::FailSafe(e) => Err(anyhow::anyhow!(
+            "maker stopped after 3 consecutive errors (fail-safe): {}",
+            e
+        )),
+    }
+}
+
+/// One reconcile cycle. Returns (places, cancels, holds) counts.
+#[allow(clippy::too_many_arguments)]
+async fn maker_cycle(
+    client: &StandXClient,
+    symbol: &str,
+    cfg: &standx_sdk::maker::MakerConfig,
+    live: bool,
+    cycle: u64,
+    resting: &mut Vec<standx_sdk::maker::RestingQuote>,
+    adopted: &mut HashMap<String, (u32, f64, u64)>,
+    pending: &mut Vec<PendingPlace>,
+    output_format: OutputFormat,
+) -> Result<(u64, u64, u64)> {
+    use standx_sdk::maker::{
+        compute_desired_quotes, format_decimals, reconcile, Action, RestingQuote,
+    };
+
+    // 1. Market snapshot.
+    let (price, depth) = tokio::join!(
+        client.get_symbol_price(symbol),
+        client.get_depth(symbol, Some(5))
+    );
+    let price = price?;
+    let depth = depth?;
+    let mark: f64 = price
+        .mark_price
+        .parse()
+        .map_err(|_| anyhow::anyhow!("unparseable mark price: {}", price.mark_price))?;
+    let best_bid: Option<f64> = depth.best_bid().and_then(|s| s.parse().ok());
+    let best_ask: Option<f64> = depth.best_ask().and_then(|s| s.parse().ok());
+
+    if live && (best_bid.is_none() || best_ask.is_none()) {
+        // Fail-safe: without a touch we cannot guarantee no-cross pricing.
+        eprintln!("⚠️  empty order book on {}; skipping this cycle", symbol);
+        return Ok((0, 0, 0));
+    }
+
+    // 2. Rebuild resting + position from the exchange (live) or keep the
+    //    simulated book (paper).
+    let position: f64;
+    if live {
+        let (orders, positions) = tokio::join!(
+            client.get_open_orders(Some(symbol)),
+            client.get_positions(Some(symbol))
+        );
+        let orders = orders?;
+        let positions = positions?;
+
+        position = positions
+            .iter()
+            .filter(|p| p.symbol.eq_ignore_ascii_case(symbol))
+            .map(|p| {
+                let qty: f64 = p.qty.parse().unwrap_or(0.0);
+                match p.side {
+                    Some(OrderSide::Sell) => -qty,
+                    _ => qty,
+                }
+            })
+            .sum();
+
+        let tick = cfg.price_tick();
+        *resting = orders
+            .into_iter()
+            .map(|o| {
+                let price: f64 = o.price.parse().unwrap_or(0.0);
+                let qty: f64 = o.qty.parse().unwrap_or(0.0);
+                let (level, ref_mark, placed_at_cycle) = match adopted.get(&o.id) {
+                    Some(&meta) => meta,
+                    None => {
+                        // Try to adopt from a recent place by (side, price, qty).
+                        let matched = pending.iter().position(|p| {
+                            p.side == o.side
+                                && (p.price - price).abs() < tick / 2.0
+                                && (p.qty - qty).abs() < f64::EPSILON.max(qty * 1e-6)
+                        });
+                        let meta = match matched {
+                            Some(idx) => {
+                                let p = pending.remove(idx);
+                                (p.level, p.ref_mark, p.cycle)
+                            }
+                            // Unknown order (manual or unmatched): sentinel
+                            // level so reconcile cancels it as stale — the
+                            // bot owns all orders on this symbol.
+                            None => (u32::MAX, mark, cycle),
+                        };
+                        adopted.insert(o.id.clone(), meta);
+                        meta
+                    }
+                };
+                RestingQuote {
+                    order_id: Some(o.id),
+                    side: o.side,
+                    level,
+                    price,
+                    qty,
+                    ref_mark,
+                    placed_at_cycle,
+                }
+            })
+            .collect();
+        // Places older than 2 cycles never showed up as open orders —
+        // likely rejected (e.g. ALO would-cross) or instantly filled.
+        pending.retain(|p| cycle.saturating_sub(p.cycle) <= 2);
+        adopted.retain(|id, _| resting.iter().any(|r| r.order_id.as_deref() == Some(id)));
+    } else {
+        position = 0.0; // fills are not simulated in paper mode
+    }
+
+    // 3. Decide.
+    let desired = compute_desired_quotes(cfg, mark, best_bid, best_ask, position);
+    let actions = reconcile(cfg, mark, best_bid, best_ask, &desired, resting, cycle);
+
+    // 4. Execute.
+    let mut places: u64 = 0;
+    let mut cancels: u64 = 0;
+    let mut holds: u64 = 0;
+    for action in &actions {
+        match action {
+            Action::Cancel {
+                order_id,
+                side,
+                level,
+                ..
+            } => {
+                cancels += 1;
+                if live {
+                    if let Some(id) = order_id {
+                        client.cancel_order(symbol, id).await?;
+                        adopted.remove(id);
+                    }
+                } else {
+                    resting.retain(|r| !(r.side == *side && r.level == *level));
+                }
+            }
+            Action::Place(q) => {
+                places += 1;
+                if live {
+                    client
+                        .create_order(CreateOrderParams {
+                            symbol: symbol.to_string(),
+                            side: q.side,
+                            order_type: OrderType::Limit,
+                            quantity: format_decimals(q.qty, cfg.qty_decimals),
+                            price: Some(format_decimals(q.price, cfg.price_decimals)),
+                            // Post-only: reject instead of taking if the
+                            // price would cross by arrival time.
+                            time_in_force: Some(TimeInForce::Alo),
+                            reduce_only: false,
+                            stop_price: None,
+                            sl_price: None,
+                            tp_price: None,
+                        })
+                        .await?;
+                    pending.push(PendingPlace {
+                        side: q.side,
+                        price: q.price,
+                        qty: q.qty,
+                        level: q.level,
+                        ref_mark: mark,
+                        cycle,
+                    });
+                } else {
+                    resting.push(RestingQuote {
+                        order_id: None,
+                        side: q.side,
+                        level: q.level,
+                        price: q.price,
+                        qty: q.qty,
+                        ref_mark: mark,
+                        placed_at_cycle: cycle,
+                    });
+                }
+            }
+            Action::Hold { .. } => holds += 1,
+        }
+    }
+
+    // 5. Emit.
+    emit_maker_cycle(
+        output_format,
+        live,
+        symbol,
+        cycle,
+        mark,
+        best_bid,
+        best_ask,
+        position,
+        &actions,
+        cfg,
+    );
+
+    Ok((places, cancels, holds))
+}
+
+/// Cancel-all with retries; verifies the book is actually clean afterwards.
+async fn cancel_all_with_retry(client: &StandXClient, symbol: &str, attempts: u32) -> Result<()> {
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 1..=attempts {
+        match client.cancel_all_orders(symbol).await {
+            Ok(()) => {
+                last_err = None;
+                break;
+            }
+            Err(e) => {
+                eprintln!(
+                    "⚠️  cancel-all attempt {}/{} failed: {}",
+                    attempt, attempts, e
+                );
+                last_err = Some(e.into());
+                if attempt < attempts {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                }
+            }
+        }
+    }
+
+    // Verify: a failed cancel leaves live orders unattended.
+    match client.get_open_orders(Some(symbol)).await {
+        Ok(orders) if orders.is_empty() => {
+            println!("✅ All {} orders cancelled", symbol);
+            Ok(())
+        }
+        Ok(orders) => {
+            let ids: Vec<_> = orders.iter().map(|o| o.id.as_str()).collect();
+            Err(anyhow::anyhow!(
+                "⚠️  RESIDUAL ORDERS on {} after cancel-all: [{}] — cancel manually with 'standx order cancel-all {}'",
+                symbol,
+                ids.join(", "),
+                symbol
+            ))
+        }
+        Err(e) => match last_err {
+            Some(cancel_err) => Err(anyhow::anyhow!(
+                "cancel-all failed ({}) and verification failed ({}) — check open orders manually",
+                cancel_err,
+                e
+            )),
+            None => Err(anyhow::anyhow!(
+                "cancel-all succeeded but verification failed ({}) — check open orders manually",
+                e
+            )),
+        },
+    }
+}
+
+/// Per-cycle output: one human line + indented actions, or JSON lines.
+#[allow(clippy::too_many_arguments)]
+fn emit_maker_cycle(
+    output_format: OutputFormat,
+    live: bool,
+    symbol: &str,
+    cycle: u64,
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    position: f64,
+    actions: &[standx_sdk::maker::Action],
+    cfg: &standx_sdk::maker::MakerConfig,
+) {
+    use standx_sdk::maker::{format_decimals, Action};
+
+    let mode = if live { "live" } else { "paper" };
+    let counts = actions.iter().fold((0, 0, 0), |mut acc, a| {
+        match a {
+            Action::Place(_) => acc.1 += 1,
+            Action::Cancel { .. } => acc.2 += 1,
+            Action::Hold { .. } => acc.0 += 1,
+        }
+        acc
+    });
+    let (holds, places, cancels) = counts;
+
+    match output_format {
+        OutputFormat::Json => {
+            let ts = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            for a in actions {
+                let obj = match a {
+                    Action::Place(q) => serde_json::json!({
+                        "ts": ts, "cycle": cycle, "mode": mode, "symbol": symbol,
+                        "mark": format_decimals(mark, cfg.price_decimals),
+                        "action": "place", "side": q.side, "level": q.level,
+                        "price": format_decimals(q.price, cfg.price_decimals),
+                        "qty": format_decimals(q.qty, cfg.qty_decimals),
+                    }),
+                    Action::Cancel {
+                        order_id,
+                        side,
+                        level,
+                        price,
+                        reason,
+                    } => serde_json::json!({
+                        "ts": ts, "cycle": cycle, "mode": mode, "symbol": symbol,
+                        "mark": format_decimals(mark, cfg.price_decimals),
+                        "action": "cancel", "side": side, "level": level,
+                        "price": format_decimals(*price, cfg.price_decimals),
+                        "reason": reason.as_str(), "order_id": order_id,
+                    }),
+                    Action::Hold {
+                        side,
+                        level,
+                        price,
+                        age_cycles,
+                        drift_bps,
+                    } => serde_json::json!({
+                        "ts": ts, "cycle": cycle, "mode": mode, "symbol": symbol,
+                        "mark": format_decimals(mark, cfg.price_decimals),
+                        "action": "hold", "side": side, "level": level,
+                        "price": format_decimals(*price, cfg.price_decimals),
+                        "age_cycles": age_cycles,
+                        "drift_bps": (drift_bps * 100.0).round() / 100.0,
+                    }),
+                };
+                println!("{}", obj);
+            }
+            println!(
+                "{}",
+                serde_json::json!({
+                    "ts": ts, "cycle": cycle, "mode": mode, "symbol": symbol,
+                    "action": "cycle_summary",
+                    "mark": format_decimals(mark, cfg.price_decimals),
+                    "best_bid": best_bid, "best_ask": best_ask,
+                    "position": position,
+                    "holds": holds, "places": places, "cancels": cancels,
+                })
+            );
+        }
+        OutputFormat::Quiet => {
+            // Only mutations and their reasons.
+            for a in actions {
+                match a {
+                    Action::Place(q) => println!(
+                        "place {} L{} @ {}",
+                        side_str(q.side),
+                        q.level,
+                        format_decimals(q.price, cfg.price_decimals)
+                    ),
+                    Action::Cancel {
+                        side,
+                        level,
+                        price,
+                        reason,
+                        ..
+                    } => println!(
+                        "cancel {} L{} @ {} ({})",
+                        side_str(*side),
+                        level,
+                        format_decimals(*price, cfg.price_decimals),
+                        reason.as_str()
+                    ),
+                    Action::Hold { .. } => {}
+                }
+            }
+        }
+        _ => {
+            let now = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "[{}] #{} mark={} bid={} ask={} pos={} | hold={} place={} cancel={}",
+                now,
+                cycle,
+                format_decimals(mark, cfg.price_decimals),
+                best_bid
+                    .map(|b| format_decimals(b, cfg.price_decimals))
+                    .unwrap_or_else(|| "-".into()),
+                best_ask
+                    .map(|a| format_decimals(a, cfg.price_decimals))
+                    .unwrap_or_else(|| "-".into()),
+                position,
+                holds,
+                places,
+                cancels
+            );
+            for a in actions {
+                match a {
+                    Action::Place(q) => println!(
+                        "    PLACE  {} L{} @ {} x {}",
+                        side_str(q.side),
+                        q.level,
+                        format_decimals(q.price, cfg.price_decimals),
+                        format_decimals(q.qty, cfg.qty_decimals)
+                    ),
+                    Action::Cancel {
+                        side,
+                        level,
+                        price,
+                        reason,
+                        ..
+                    } => println!(
+                        "    CANCEL {} L{} @ {} ({})",
+                        side_str(*side),
+                        level,
+                        format_decimals(*price, cfg.price_decimals),
+                        reason.as_str()
+                    ),
+                    Action::Hold {
+                        side,
+                        level,
+                        price,
+                        age_cycles,
+                        drift_bps,
+                    } => println!(
+                        "    HOLD   {} L{} @ {} (age {} cycles, drift {:.1}bps)",
+                        side_str(*side),
+                        level,
+                        format_decimals(*price, cfg.price_decimals),
+                        age_cycles,
+                        drift_bps
+                    ),
+                }
+            }
+        }
+    }
+}
+
+fn side_str(side: OrderSide) -> &'static str {
+    match side {
+        OrderSide::Buy => "buy ",
+        OrderSide::Sell => "sell",
+    }
 }
 
 #[cfg(test)]

--- a/crates/standx-cli/src/main.rs
+++ b/crates/standx-cli/src/main.rs
@@ -161,6 +161,9 @@ async fn execute_command(
         Commands::Block { command } => {
             commands::handle_block(command, output).await?;
         }
+        Commands::Maker { command } => {
+            commands::handle_maker(command, output, verbose).await?;
+        }
     }
     Ok(())
 }
@@ -180,13 +183,16 @@ async fn handle_dry_run(command: &Commands, output: OutputFormat) -> Result<(), 
         Commands::Dashboard { .. } => "Would fetch dashboard data (read-only, safe to execute)",
         Commands::Portfolio { .. } => "Would fetch portfolio data (read-only, safe to execute)",
         Commands::Block { .. } => "Would fetch block trades (authenticated, read-only)",
+        Commands::Maker { .. } => {
+            "⚠️  WOULD RUN MAKER BOT - PLACES/CANCELS ORDERS WITH --live (paper mode without)"
+        }
     };
 
     let dry_run_info = serde_json::json!({
         "dry_run": true,
         "command": format!("{:?}", command),
         "description": description,
-        "would_execute": !matches!(command, Commands::Order { .. } | Commands::Leverage { .. } | Commands::Margin { .. }),
+        "would_execute": !matches!(command, Commands::Order { .. } | Commands::Leverage { .. } | Commands::Margin { .. } | Commands::Maker { .. }),
         "note": "Remove --dry-run to execute"
     });
 

--- a/crates/standx-sdk/src/client/order.rs
+++ b/crates/standx-sdk/src/client/order.rs
@@ -60,6 +60,7 @@ impl StandXClient {
                 TimeInForce::Gtc => "gtc",
                 TimeInForce::Ioc => "ioc",
                 TimeInForce::Fok => "fok",
+                TimeInForce::Alo => "alo",
             })
             .unwrap_or("gtc");
 

--- a/crates/standx-sdk/src/lib.rs
+++ b/crates/standx-sdk/src/lib.rs
@@ -40,6 +40,7 @@
 pub mod auth;
 pub mod client;
 pub mod error;
+pub mod maker;
 pub mod models;
 pub mod websocket;
 

--- a/crates/standx-sdk/src/maker.rs
+++ b/crates/standx-sdk/src/maker.rs
@@ -1,0 +1,635 @@
+//! Pure quoting & reconcile logic for market making (SIP-5A maker yield).
+//!
+//! No I/O in this module: every function takes plain values and returns
+//! decisions, so the whole strategy is unit-testable without a network.
+//!
+//! The core idea is an **anti-flicker** loop: SIP-5A rewards uptime (orders
+//! resting on the book inside an eligibility band around mark price) and
+//! penalizes flicker-cancels. So resting quotes are HELD as long as they stay
+//! inside the band; re-quoting happens only when mark price drifts more than
+//! `refresh_bps` from the mark recorded when the order was placed.
+//!
+//! Numeric representation: prices/quantities are `f64` internally and
+//! formatted to the symbol's tick decimals only at the API edge
+//! ([`format_decimals`]). This matches the rest of the codebase (which does
+//! ad-hoc f64 math on the API's string values); if symbols with more than ~8
+//! price decimals ever list, revisit with a decimal type.
+
+use crate::models::OrderSide;
+
+/// Static per-run configuration (CLI args + symbol metadata).
+#[derive(Debug, Clone)]
+pub struct MakerConfig {
+    /// Half-spread from mark price, in basis points, for level 0.
+    pub spread_bps: f64,
+    /// Eligibility band: never quote outside `mark * (1 ± band_bps/1e4)`.
+    pub band_bps: f64,
+    /// Spacing between quote levels, in basis points.
+    pub level_step_bps: f64,
+    /// Anti-flicker threshold: re-quote only when mark has drifted more than
+    /// this (bps) from the mark recorded at placement time.
+    pub refresh_bps: f64,
+    /// Number of quote levels per side.
+    pub levels: u32,
+    /// Per-side, per-level order quantity.
+    pub size: f64,
+    /// Max absolute position; the side that would grow it further is
+    /// suppressed once exceeded.
+    pub max_position: f64,
+    /// Price precision (decimal places) from `SymbolInfo.price_tick_decimals`.
+    pub price_decimals: u32,
+    /// Quantity precision (decimal places) from `SymbolInfo.qty_tick_decimals`.
+    pub qty_decimals: u32,
+    /// Minimum order quantity from `SymbolInfo.min_order_qty`.
+    pub min_order_qty: f64,
+}
+
+impl MakerConfig {
+    /// One price tick: `10^-price_decimals`.
+    pub fn price_tick(&self) -> f64 {
+        10f64.powi(-(self.price_decimals as i32))
+    }
+}
+
+/// A quote we want resting on the book (prices/qtys already tick-rounded).
+#[derive(Debug, Clone, PartialEq)]
+pub struct DesiredQuote {
+    pub side: OrderSide,
+    pub level: u32,
+    pub price: f64,
+    pub qty: f64,
+}
+
+/// A quote currently resting (a real order in live mode, simulated in paper
+/// mode).
+#[derive(Debug, Clone)]
+pub struct RestingQuote {
+    /// Exchange order id (None in paper mode / before adoption).
+    pub order_id: Option<String>,
+    pub side: OrderSide,
+    pub level: u32,
+    pub price: f64,
+    pub qty: f64,
+    /// Mark price when this quote was placed — the anti-flicker anchor.
+    pub ref_mark: f64,
+    pub placed_at_cycle: u64,
+}
+
+/// Why a resting quote is being cancelled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelReason {
+    /// Mark drifted more than `refresh_bps` from the quote's `ref_mark`.
+    MarkMovedBeyondRefresh,
+    /// The resting price left the eligibility band (earns nothing there).
+    OutsideBand,
+    /// The resting price now crosses the touch (would fill as taker).
+    WouldCross,
+    /// The quote's side is suppressed by the max-position limit.
+    SideSuppressed,
+    /// No desired quote exists at this (side, level) anymore.
+    Stale,
+}
+
+impl CancelReason {
+    /// Snake-case label for machine-readable output.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CancelReason::MarkMovedBeyondRefresh => "mark_moved",
+            CancelReason::OutsideBand => "outside_band",
+            CancelReason::WouldCross => "would_cross",
+            CancelReason::SideSuppressed => "side_suppressed",
+            CancelReason::Stale => "stale",
+        }
+    }
+}
+
+/// One reconcile decision.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Action {
+    Place(DesiredQuote),
+    Cancel {
+        order_id: Option<String>,
+        side: OrderSide,
+        level: u32,
+        price: f64,
+        reason: CancelReason,
+    },
+    Hold {
+        side: OrderSide,
+        level: u32,
+        price: f64,
+        age_cycles: u64,
+        /// Current drift from the quote's ref_mark, in bps (for display).
+        drift_bps: f64,
+    },
+}
+
+/// Round half-up to `decimals` decimal places.
+pub fn round_to_decimals(value: f64, decimals: u32) -> f64 {
+    let factor = 10f64.powi(decimals as i32);
+    (value * factor).round() / factor
+}
+
+/// Round DOWN to `decimals` decimal places (used for buy prices).
+pub fn floor_to_decimals(value: f64, decimals: u32) -> f64 {
+    let factor = 10f64.powi(decimals as i32);
+    // Nudge by a hair to avoid f64 representation artifacts like
+    // 99.90 * 100 = 9989.999999... flooring to 99.89.
+    ((value * factor) + 1e-9).floor() / factor
+}
+
+/// Round UP to `decimals` decimal places (used for sell prices).
+pub fn ceil_to_decimals(value: f64, decimals: u32) -> f64 {
+    let factor = 10f64.powi(decimals as i32);
+    ((value * factor) - 1e-9).ceil() / factor
+}
+
+/// Format for API strings with exactly `decimals` decimal places.
+pub fn format_decimals(value: f64, decimals: u32) -> String {
+    format!("{:.*}", decimals as usize, value)
+}
+
+/// Absolute difference between `a` and `b` in basis points of `b`.
+/// Returns 0.0 when `b` is 0 (avoids division blowup on degenerate input).
+pub fn bps_diff(a: f64, b: f64) -> f64 {
+    if b == 0.0 {
+        return 0.0;
+    }
+    ((a - b) / b).abs() * 10_000.0
+}
+
+/// Compute the desired quote set for the current market snapshot.
+///
+/// Applies, in order: the spread/level ladder, the band clamp, the no-cross
+/// clamp, directional tick rounding (with band re-entry), the min-qty filter,
+/// and max-position side suppression. Quotes that fail a guard are dropped;
+/// duplicate prices after clamping/rounding are collapsed (outer level wins
+/// nothing — the inner level is kept).
+pub fn compute_desired_quotes(
+    cfg: &MakerConfig,
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    position: f64,
+) -> Vec<DesiredQuote> {
+    let mut out = Vec::new();
+    if mark <= 0.0 {
+        return out;
+    }
+
+    let qty = round_to_decimals(cfg.size, cfg.qty_decimals);
+    if qty < cfg.min_order_qty || qty <= 0.0 {
+        return out;
+    }
+
+    let tick = cfg.price_tick();
+    let band_lo = mark * (1.0 - cfg.band_bps / 1e4);
+    let band_hi = mark * (1.0 + cfg.band_bps / 1e4);
+
+    let suppress_buy = position >= cfg.max_position;
+    let suppress_sell = position <= -cfg.max_position;
+
+    for side in [OrderSide::Buy, OrderSide::Sell] {
+        if (side == OrderSide::Buy && suppress_buy) || (side == OrderSide::Sell && suppress_sell) {
+            continue;
+        }
+        let mut last_price: Option<f64> = None;
+        for level in 0..cfg.levels {
+            let offset_bps = cfg.spread_bps + level as f64 * cfg.level_step_bps;
+            let mut price = match side {
+                OrderSide::Buy => mark * (1.0 - offset_bps / 1e4),
+                OrderSide::Sell => mark * (1.0 + offset_bps / 1e4),
+            };
+
+            // Band clamp: quoting outside the band earns nothing, so clamp
+            // back to the edge (still eligible).
+            price = price.clamp(band_lo, band_hi);
+
+            // No-cross clamp: without relying solely on ALO rejection, never
+            // price through the touch. One tick of safety margin.
+            match side {
+                OrderSide::Buy => {
+                    if let Some(ask) = best_ask {
+                        price = price.min(ask - tick);
+                    }
+                }
+                OrderSide::Sell => {
+                    if let Some(bid) = best_bid {
+                        price = price.max(bid + tick);
+                    }
+                }
+            }
+
+            // Directional tick rounding: away from mark, so rounding never
+            // pushes us through the touch.
+            price = match side {
+                OrderSide::Buy => floor_to_decimals(price, cfg.price_decimals),
+                OrderSide::Sell => ceil_to_decimals(price, cfg.price_decimals),
+            };
+
+            // Rounding may have pushed the price just outside the band —
+            // nudge one tick back toward mark.
+            if price < band_lo {
+                price = floor_to_decimals(price + tick, cfg.price_decimals);
+            } else if price > band_hi {
+                price = ceil_to_decimals(price - tick, cfg.price_decimals);
+            }
+
+            if price <= 0.0 {
+                continue;
+            }
+
+            // Collapse duplicate levels (clamping can flatten the ladder).
+            if last_price == Some(price) {
+                continue;
+            }
+            last_price = Some(price);
+
+            out.push(DesiredQuote {
+                side,
+                level,
+                price,
+                qty,
+            });
+        }
+    }
+
+    out
+}
+
+/// Diff desired vs resting quotes, applying the anti-flicker hold rule.
+///
+/// Decision table per resting quote (checked in order):
+///
+/// | # | Condition                                        | Action                        |
+/// |---|--------------------------------------------------|-------------------------------|
+/// | 1 | side suppressed by max-position                  | Cancel (SideSuppressed)       |
+/// | 2 | no desired quote at (side, level)                | Cancel (Stale)                |
+/// | 3 | price outside current band                       | Cancel (OutsideBand)          |
+/// | 4 | price crosses current touch                      | Cancel (WouldCross)           |
+/// | 5 | mark drifted > refresh_bps from ref_mark         | Cancel (MarkMovedBeyondRefresh) |
+/// | 6 | otherwise                                        | Hold (anti-flicker)           |
+///
+/// Every desired quote without a surviving resting counterpart yields a
+/// `Place`. The returned Vec orders all Cancels before all Places so the
+/// executor frees margin before re-placing; Holds come last.
+pub fn reconcile(
+    cfg: &MakerConfig,
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    desired: &[DesiredQuote],
+    resting: &[RestingQuote],
+    cycle: u64,
+) -> Vec<Action> {
+    let band_lo = mark * (1.0 - cfg.band_bps / 1e4);
+    let band_hi = mark * (1.0 + cfg.band_bps / 1e4);
+
+    let desired_has = |side: OrderSide, level: u32| -> bool {
+        desired.iter().any(|d| d.side == side && d.level == level)
+    };
+    // A side with zero desired quotes this cycle is suppressed (either by
+    // max-position or because every quote failed a guard).
+    let side_live = |side: OrderSide| -> bool { desired.iter().any(|d| d.side == side) };
+
+    let mut cancels = Vec::new();
+    let mut holds = Vec::new();
+    // (side, level) pairs covered by a surviving (held) resting quote.
+    let mut covered: Vec<(OrderSide, u32)> = Vec::new();
+
+    for r in resting {
+        let reason = if !side_live(r.side) {
+            Some(CancelReason::SideSuppressed)
+        } else if !desired_has(r.side, r.level) {
+            Some(CancelReason::Stale)
+        } else if r.price < band_lo || r.price > band_hi {
+            Some(CancelReason::OutsideBand)
+        } else if match r.side {
+            OrderSide::Buy => best_ask.map(|a| r.price >= a).unwrap_or(false),
+            OrderSide::Sell => best_bid.map(|b| r.price <= b).unwrap_or(false),
+        } {
+            Some(CancelReason::WouldCross)
+        } else if bps_diff(mark, r.ref_mark) > cfg.refresh_bps {
+            Some(CancelReason::MarkMovedBeyondRefresh)
+        } else {
+            None
+        };
+
+        match reason {
+            Some(reason) => cancels.push(Action::Cancel {
+                order_id: r.order_id.clone(),
+                side: r.side,
+                level: r.level,
+                price: r.price,
+                reason,
+            }),
+            None => {
+                covered.push((r.side, r.level));
+                holds.push(Action::Hold {
+                    side: r.side,
+                    level: r.level,
+                    price: r.price,
+                    age_cycles: cycle.saturating_sub(r.placed_at_cycle),
+                    drift_bps: bps_diff(mark, r.ref_mark),
+                });
+            }
+        }
+    }
+
+    let places: Vec<Action> = desired
+        .iter()
+        .filter(|d| !covered.contains(&(d.side, d.level)))
+        .map(|d| Action::Place(d.clone()))
+        .collect();
+
+    // Cancels first (free margin), then places, then holds (display only).
+    let mut actions = cancels;
+    actions.extend(places);
+    actions.extend(holds);
+    actions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// mark=100-friendly config: 2 price decimals, 4 qty decimals.
+    fn cfg() -> MakerConfig {
+        MakerConfig {
+            spread_bps: 10.0,
+            band_bps: 20.0,
+            level_step_bps: 2.0,
+            refresh_bps: 3.0,
+            levels: 1,
+            size: 0.01,
+            max_position: 0.05,
+            price_decimals: 2,
+            qty_decimals: 4,
+            min_order_qty: 0.001,
+        }
+    }
+
+    fn resting(side: OrderSide, level: u32, price: f64, ref_mark: f64) -> RestingQuote {
+        RestingQuote {
+            order_id: Some("1".into()),
+            side,
+            level,
+            price,
+            qty: 0.01,
+            ref_mark,
+            placed_at_cycle: 0,
+        }
+    }
+
+    fn find<'a>(quotes: &'a [DesiredQuote], side: OrderSide, level: u32) -> &'a DesiredQuote {
+        quotes
+            .iter()
+            .find(|q| q.side == side && q.level == level)
+            .expect("quote missing")
+    }
+
+    // 1. Basic two-sided quoting.
+    #[test]
+    fn basic_two_sided() {
+        let quotes = compute_desired_quotes(&cfg(), 100.0, Some(99.99), Some(100.01), 0.0);
+        assert_eq!(quotes.len(), 2);
+        assert_eq!(find(&quotes, OrderSide::Buy, 0).price, 99.90);
+        assert_eq!(find(&quotes, OrderSide::Sell, 0).price, 100.10);
+        assert_eq!(find(&quotes, OrderSide::Buy, 0).qty, 0.01);
+    }
+
+    // 2. Spread wider than band: clamp to band edges, not dropped.
+    #[test]
+    fn band_clamp() {
+        let mut c = cfg();
+        c.spread_bps = 30.0; // > band 20
+        let quotes = compute_desired_quotes(&c, 100.0, Some(99.5), Some(100.5), 0.0);
+        assert_eq!(find(&quotes, OrderSide::Buy, 0).price, 99.80);
+        assert_eq!(find(&quotes, OrderSide::Sell, 0).price, 100.20);
+    }
+
+    // 3. Directional tick rounding: buy floors, sell ceils.
+    #[test]
+    fn tick_rounding_directional() {
+        let mut c = cfg();
+        c.price_decimals = 1;
+        c.spread_bps = 5.0;
+        // mark=100.03: raw buy = 99.979985 -> floor(1dp) 99.9
+        //              raw sell = 100.080015 -> ceil(1dp) 100.1
+        let quotes = compute_desired_quotes(&c, 100.03, None, None, 0.0);
+        assert_eq!(find(&quotes, OrderSide::Buy, 0).price, 99.9);
+        assert_eq!(find(&quotes, OrderSide::Sell, 0).price, 100.1);
+        assert_eq!(format_decimals(99.9, 1), "99.9");
+    }
+
+    // 4. Rounding that exits the band is nudged back inside.
+    #[test]
+    fn rounding_reenters_band() {
+        let mut c = cfg();
+        c.price_decimals = 0; // whole-number ticks
+        c.spread_bps = 20.0; // == band: raw buy exactly at band edge 99.8
+        c.band_bps = 20.0;
+        // raw buy = 99.8, floor(0dp) = 99 < band_lo 99.8 -> nudge +1 tick = 100
+        // (floor(99.8+1) = 100)... still >= band_lo, inside band.
+        let quotes = compute_desired_quotes(&c, 100.0, None, None, 0.0);
+        let buy = find(&quotes, OrderSide::Buy, 0);
+        assert!(buy.price >= 99.8, "price {} left the band", buy.price);
+        assert_eq!(buy.price, 100.0);
+    }
+
+    // 5. No-cross clamp on both sides.
+    #[test]
+    fn no_cross_clamp() {
+        // Best ask (99.85) sits BELOW our raw buy (99.90): buy must clamp
+        // down to ask - tick.
+        let quotes = compute_desired_quotes(&cfg(), 100.0, Some(99.83), Some(99.85), 0.0);
+        let buy = find(&quotes, OrderSide::Buy, 0);
+        let sell = find(&quotes, OrderSide::Sell, 0);
+        // buy clamped to ask - tick = 99.84
+        assert_eq!(buy.price, 99.84);
+        // sell raw 100.10 already > bid + tick; unchanged
+        assert_eq!(sell.price, 100.10);
+
+        // Symmetric: bid above our raw sell forces sell up to bid + tick.
+        let quotes = compute_desired_quotes(&cfg(), 100.0, Some(100.15), Some(100.20), 0.0);
+        let sell = find(&quotes, OrderSide::Sell, 0);
+        assert_eq!(sell.price, 100.16);
+    }
+
+    // 6. Size below min_order_qty -> no quotes at all.
+    #[test]
+    fn min_qty_rejection() {
+        let mut c = cfg();
+        c.size = 0.00001; // rounds to 0.0000 at 4dp -> below min 0.001
+        let quotes = compute_desired_quotes(&c, 100.0, None, None, 0.0);
+        assert!(quotes.is_empty());
+    }
+
+    // 7. Max-position suppression, both directions.
+    #[test]
+    fn max_position_suppresses_buy() {
+        let quotes = compute_desired_quotes(&cfg(), 100.0, None, None, 0.05);
+        assert!(quotes.iter().all(|q| q.side == OrderSide::Sell));
+        assert_eq!(quotes.len(), 1);
+    }
+
+    #[test]
+    fn max_position_suppresses_sell() {
+        let quotes = compute_desired_quotes(&cfg(), 100.0, None, None, -0.05);
+        assert!(quotes.iter().all(|q| q.side == OrderSide::Buy));
+        assert_eq!(quotes.len(), 1);
+    }
+
+    // 8. Anti-flicker: drift within refresh threshold -> Hold.
+    #[test]
+    fn reconcile_hold_within_refresh() {
+        let c = cfg();
+        let mark = 100.02; // 2 bps from ref 100.0, refresh = 3
+        let desired = compute_desired_quotes(&c, mark, None, None, 0.0);
+        let rest = vec![
+            resting(OrderSide::Buy, 0, 99.90, 100.0),
+            resting(OrderSide::Sell, 0, 100.10, 100.0),
+        ];
+        let actions = reconcile(&c, mark, None, None, &desired, &rest, 7);
+        assert!(
+            actions.iter().all(|a| matches!(a, Action::Hold { .. })),
+            "{actions:?}"
+        );
+        assert_eq!(actions.len(), 2);
+        if let Action::Hold { age_cycles, .. } = &actions[0] {
+            assert_eq!(*age_cycles, 7);
+        }
+    }
+
+    // 9. Drift beyond refresh -> Cancel(mark_moved) + Place, cancel first.
+    #[test]
+    fn reconcile_requote_beyond_refresh() {
+        let c = cfg();
+        let mark = 100.05; // 5 bps > refresh 3
+        let desired = compute_desired_quotes(&c, mark, None, None, 0.0);
+        let rest = vec![resting(OrderSide::Buy, 0, 99.90, 100.0)];
+        let actions = reconcile(&c, mark, None, None, &desired, &rest, 1);
+        // Expect: cancel(buy, mark_moved), then places for buy+sell.
+        assert!(matches!(
+            actions[0],
+            Action::Cancel {
+                reason: CancelReason::MarkMovedBeyondRefresh,
+                ..
+            }
+        ));
+        let cancel_idx = 0;
+        let place_idx = actions
+            .iter()
+            .position(|a| matches!(a, Action::Place(_)))
+            .unwrap();
+        assert!(cancel_idx < place_idx);
+    }
+
+    // 10. Outside band takes precedence over refresh drift.
+    #[test]
+    fn reconcile_cancel_outside_band_precedence() {
+        let c = cfg();
+        // Mark gapped 30 bps: resting buy at 99.90 with ref 100.0 is now
+        // outside band [100.10, 100.50] around mark 100.30.
+        let mark = 100.30;
+        let desired = compute_desired_quotes(&c, mark, None, None, 0.0);
+        let rest = vec![resting(OrderSide::Buy, 0, 99.90, 100.0)];
+        let actions = reconcile(&c, mark, None, None, &desired, &rest, 1);
+        assert!(
+            matches!(
+                actions[0],
+                Action::Cancel {
+                    reason: CancelReason::OutsideBand,
+                    ..
+                }
+            ),
+            "{actions:?}"
+        );
+    }
+
+    // 11. Touch moved through a resting quote -> WouldCross.
+    #[test]
+    fn reconcile_cancel_would_cross() {
+        let c = cfg();
+        let mark = 100.01; // tiny drift, within refresh
+        let desired = compute_desired_quotes(&c, mark, Some(100.12), Some(100.14), 0.0);
+        // Resting sell at 100.10 now BELOW best bid 100.12 -> crossed.
+        let rest = vec![resting(OrderSide::Sell, 0, 100.10, 100.0)];
+        let actions = reconcile(&c, mark, Some(100.12), Some(100.14), &desired, &rest, 1);
+        assert!(
+            matches!(
+                actions[0],
+                Action::Cancel {
+                    reason: CancelReason::WouldCross,
+                    ..
+                }
+            ),
+            "{actions:?}"
+        );
+    }
+
+    // 12. Level removed from config -> Stale.
+    #[test]
+    fn reconcile_stale_level() {
+        let c = cfg(); // levels = 1 -> only level 0 desired
+        let mark = 100.0;
+        let desired = compute_desired_quotes(&c, mark, None, None, 0.0);
+        let rest = vec![
+            resting(OrderSide::Buy, 0, 99.90, 100.0),
+            resting(OrderSide::Buy, 1, 99.88, 100.0), // stale level
+        ];
+        let actions = reconcile(&c, mark, None, None, &desired, &rest, 1);
+        let stale: Vec<_> = actions
+            .iter()
+            .filter(|a| {
+                matches!(
+                    a,
+                    Action::Cancel {
+                        reason: CancelReason::Stale,
+                        level: 1,
+                        ..
+                    }
+                )
+            })
+            .collect();
+        assert_eq!(stale.len(), 1, "{actions:?}");
+    }
+
+    // 13. Multi-level ladder + duplicate collapse.
+    #[test]
+    fn multi_level_ladder() {
+        let mut c = cfg();
+        c.levels = 3;
+        let quotes = compute_desired_quotes(&c, 100.0, None, None, 0.0);
+        // Buys descending: 99.90, 99.88, 99.86; sells ascending mirrored.
+        assert_eq!(find(&quotes, OrderSide::Buy, 0).price, 99.90);
+        assert_eq!(find(&quotes, OrderSide::Buy, 1).price, 99.88);
+        assert_eq!(find(&quotes, OrderSide::Buy, 2).price, 99.86);
+        assert_eq!(find(&quotes, OrderSide::Sell, 2).price, 100.14);
+        assert_eq!(quotes.len(), 6);
+
+        // Ladder flattened by band: spread 18, step 2, band 20 -> levels 1+
+        // clamp to the band edge and duplicates collapse.
+        let mut c2 = cfg();
+        c2.levels = 3;
+        c2.spread_bps = 18.0;
+        let quotes = compute_desired_quotes(&c2, 100.0, None, None, 0.0);
+        let buys: Vec<_> = quotes.iter().filter(|q| q.side == OrderSide::Buy).collect();
+        assert_eq!(buys.len(), 2, "{buys:?}"); // 99.82, then 99.80 (L1) and L2 dup dropped
+        assert_eq!(buys[1].price, 99.80);
+    }
+
+    // 14. Helper edge cases.
+    #[test]
+    fn helper_edge_cases() {
+        assert_eq!(bps_diff(100.0, 0.0), 0.0);
+        assert!((bps_diff(100.05, 100.0) - 5.0).abs() < 1e-9); // ~5 bps
+        assert!((bps_diff(99.95, 100.0) - 5.0).abs() < 1e-9); // symmetric
+        assert_eq!(round_to_decimals(1.23456, 0), 1.0);
+        assert_eq!(round_to_decimals(-1.235, 2), -1.24);
+        assert_eq!(floor_to_decimals(99.90, 2), 99.90); // representation artifact guard
+        assert_eq!(ceil_to_decimals(100.10, 2), 100.10);
+        assert_eq!(format_decimals(99.9, 2), "99.90");
+        assert_eq!(format_decimals(0.0123, 4), "0.0123");
+    }
+}

--- a/crates/standx-sdk/src/models.rs
+++ b/crates/standx-sdk/src/models.rs
@@ -370,6 +370,7 @@ pub enum TimeInForce {
     Gtc, // Good Till Cancel
     Ioc, // Immediate or Cancel
     Fok, // Fill or Kill
+    Alo, // Add Liquidity Only (post-only: rejected instead of taking)
 }
 
 /// Order status


### PR DESCRIPTION
## What

Add `standx maker run <SYMBOL>` (alias `mk`) — a two-sided market-maker loop optimized for [SIP-5A Community Maker Yield](https://docs.standx.com/sip/sip-5a-community-maker-yield).

> ⚠️ **Stacked on #177** (workspace split). Review/merge that first; this PR targets `refactor/workspace-sdk-split` and its diff will collapse once #177 lands.

## The core idea: anti-flicker

SIP-5A rewards **uptime** (orders resting inside an eligibility band around mark price) and **excludes** flicker-cancels and short-lived quotes. So the bot does the opposite of a naive spread bot: quotes rest as long as they stay in-band, and re-quote *only* when mark drifts past `--refresh-bps` from the mark recorded at placement.

## Design

- **Pure core** in `standx_sdk::maker` (no I/O, 15 unit tests): spread/level ladder, band clamp, no-cross clamp, directional tick rounding, min-qty filter, max-position side suppression, and a 6-row reconcile decision table (suppressed → stale → outside-band → would-cross → mark-moved → **hold**).
- **Paper mode by default**: runs the full loop against live market data, prints intended actions, places **no** orders. Fills are not simulated (position stays 0).
- **`--live`** implements real quoting (post-only via `TIF=ALO`) but is **locked behind `STANDX_ENABLE_LIVE_MAKER=1`** pending supervised production testing.
- **Live safety rails**: startup cancel-all, exchange open-orders as the reconciliation source of truth (`create_order` only returns a request id — new orders are adopted by side/price/qty matching), cancel-all-with-retry + verification on every exit path, fail-safe stop after 3 consecutive API errors.
- **Output**: human per-cycle lines, JSON-lines for agents (`--output json`), quiet mode.
- Adds `TimeInForce::Alo` (backend enum is `gtc`/`alo`/`ioc`) and `order create --tif ALO`.

## Usage

```bash
# Paper (default) — safe, read-only, no credentials needed
standx maker run BTC-USD --size 0.001 --interval 3

standx maker run BTC-USD --spread-bps 5 --band-bps 20 --refresh-bps 3 --levels 2
```

## Verification

Paper-mode run against live BTC-USD exercised every decision path:
- initial two-sided place → HOLD lines with growing age through a calm market → `would_cross` cancel on **one side only** when the touch moved through it → `mark_moved` re-quote (cancel+place, cancel ordered first) past the 3bps threshold → clean Ctrl+C summary
- `--output json` emits valid JSON lines (one per action + a cycle_summary)
- `--dry-run maker run` shows the static financial-impact notice without entering the loop
- arg validation (band ≤ spread, size < min-qty, unknown symbol) and the `--live` lock all error as expected
- `cargo test` (56 CLI + SDK tests) / `clippy -- -D warnings` / `fmt --check` green

## Follow-ups (not blocking)

- Verify ALO rejection behavior (reject vs silent-adjust, error codes) before unlocking live
- API review of the SDK before any crates.io publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)