### PR TITLE
fix: make `cargo clippy --workspace --all-targets` pass clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   # 多平台构建矩阵
   build-matrix:

--- a/crates/standx-cli/src/config.rs
+++ b/crates/standx-cli/src/config.rs
@@ -266,13 +266,13 @@ mod tests {
         config.save().unwrap();
 
         // 然后损坏文件
-        let mut file = std::fs::File::create(&config.config_file()).unwrap();
+        let mut file = std::fs::File::create(config.config_file()).unwrap();
         file.write_all(b"invalid toml [[[").unwrap();
         drop(file);
 
         // 尝试加载损坏的配置文件
         // 注意：Config::load() 使用默认路径，这里我们手动测试解析错误
-        let content = std::fs::read_to_string(&config.config_file()).unwrap();
+        let content = std::fs::read_to_string(config.config_file()).unwrap();
         let result: std::result::Result<Config, _> = toml::from_str(&content);
         assert!(result.is_err());
     }
@@ -309,7 +309,7 @@ mod tests {
         // Test environment variable priority: Env > File > Default
         // Create a config file with specific values
         let temp_dir = TempDir::new().unwrap();
-        let mut config = Config {
+        let config = Config {
             base_url: "https://file.standx.com".to_string(),
             output_format: "table".to_string(),
             default_symbol: "BTC-USD".to_string(),
@@ -356,7 +356,7 @@ mod tests {
     fn test_load_from_path_with_specific_directory() {
         let temp_dir = TempDir::new().unwrap();
 
-        let mut config = Config {
+        let config = Config {
             base_url: "https://specific.test.com".to_string(),
             output_format: "json".to_string(),
             default_symbol: "ETH-USD".to_string(),
@@ -379,7 +379,7 @@ mod tests {
     fn test_load_from_path_with_string() {
         let temp_dir = TempDir::new().unwrap();
 
-        let mut config = Config {
+        let config = Config {
             base_url: "https://string.test.com".to_string(),
             output_format: "csv".to_string(),
             default_symbol: "DOGE-USD".to_string(),
@@ -396,7 +396,7 @@ mod tests {
     fn test_load_from_path_with_pathbuf() {
         let temp_dir = TempDir::new().unwrap();
 
-        let mut config = Config {
+        let config = Config {
             base_url: "https://pathbuf.test.com".to_string(),
             output_format: "csv".to_string(),
             default_symbol: "DOGE-USD".to_string(),
@@ -419,7 +419,7 @@ mod tests {
     fn test_load_backward_compatibility() {
         let temp_dir = TempDir::new().unwrap();
 
-        let mut config = Config {
+        let config = Config {
             base_url: "https://backward.compat.com".to_string(),
             output_format: "table".to_string(),
             default_symbol: "BTC-USD".to_string(),

--- a/crates/standx-cli/src/output.rs
+++ b/crates/standx-cli/src/output.rs
@@ -68,33 +68,6 @@ pub fn format_order_book(book: &OrderBook, limit: usize) -> String {
     output
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_format_json() {
-        let symbol = SymbolInfo {
-            symbol: "BTC-USD".to_string(),
-            base_asset: "BTC".to_string(),
-            quote_asset: "DUSD".to_string(),
-            base_decimals: 9,
-            price_tick_decimals: 2,
-            qty_tick_decimals: 4,
-            min_order_qty: "0.0001".to_string(),
-            def_leverage: "10".to_string(),
-            max_leverage: "40".to_string(),
-            maker_fee: "0.0001".to_string(),
-            taker_fee: "0.0004".to_string(),
-            status: "trading".to_string(),
-        };
-
-        let json = format_json(&symbol).unwrap();
-        assert!(json.contains("BTC-USD"));
-        assert!(json.contains("\"symbol\""));
-    }
-}
-
 /// Format dashboard as MVP compact view (Issue #156)
 pub fn format_dashboard_mvp(snapshot: &DashboardSnapshot, compact: bool) -> String {
     let mut output = String::new();
@@ -552,4 +525,31 @@ pub fn render_dashboard(snapshot: &DashboardSnapshot, compact: bool) -> String {
     output.push_str(&format_dashboard_trades(&snapshot.trades, compact, width));
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_json() {
+        let symbol = SymbolInfo {
+            symbol: "BTC-USD".to_string(),
+            base_asset: "BTC".to_string(),
+            quote_asset: "DUSD".to_string(),
+            base_decimals: 9,
+            price_tick_decimals: 2,
+            qty_tick_decimals: 4,
+            min_order_qty: "0.0001".to_string(),
+            def_leverage: "10".to_string(),
+            max_leverage: "40".to_string(),
+            maker_fee: "0.0001".to_string(),
+            taker_fee: "0.0004".to_string(),
+            status: "trading".to_string(),
+        };
+
+        let json = format_json(&symbol).unwrap();
+        assert!(json.contains("BTC-USD"));
+        assert!(json.contains("\"symbol\""));
+    }
 }

--- a/crates/standx-cli/src/telemetry.rs
+++ b/crates/standx-cli/src/telemetry.rs
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn test_telemetry_enabled_by_default() {
         env::remove_var(TELEMETRY_ENV_VAR);
-        let telemetry = Telemetry::new();
+        let _telemetry = Telemetry::new();
         // Note: This might fail if user has env var set
         // In real tests, use a temp directory
     }

--- a/crates/standx-cli/tests/e2e/new_user_journey.rs
+++ b/crates/standx-cli/tests/e2e/new_user_journey.rs
@@ -1,7 +1,7 @@
 //! E2E Test: New User Journey
 //! Simulates a new user from installation to first trade
 
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use std::fs;
 use tempfile::TempDir;
 
@@ -16,22 +16,22 @@ fn test_new_user_journey() {
     fs::create_dir_all(&config_dir).unwrap();
 
     // Step 1: Check CLI version
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.arg("--version");
     cmd.assert().success();
 
     // Step 2: View help
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.arg("--help");
     cmd.assert().success();
 
     // Step 3: View market symbols (public API, no auth needed)
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "symbols"]);
     cmd.assert().success();
 
     // Step 4: View market ticker
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "ticker", "--symbol", "BTC-USD"]);
     cmd.assert().success();
 
@@ -45,7 +45,7 @@ fn test_cli_without_config() {
     // Ensure no config exists in temp environment
     let temp_dir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.env("HOME", temp_dir.path());
     cmd.args(["market", "symbols", "--output", "json"]);
     cmd.assert().success();

--- a/crates/standx-cli/tests/e2e/trader_workflow.rs
+++ b/crates/standx-cli/tests/e2e/trader_workflow.rs
@@ -1,7 +1,7 @@
 //! E2E Test: Trader Daily Workflow
 //! Simulates a trader's daily routine
 
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 
 /// Test: Daily trader workflow
 /// Steps: check positions → market analysis → place order → monitor
@@ -9,22 +9,22 @@ use assert_cmd::Command;
 #[ignore = "Requires TEST_TOKEN and TEST_PRIVATE_KEY environment variables"]
 fn test_trader_daily_workflow() {
     // Step 1: Check account balance
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["account", "balance"]);
     cmd.assert().success();
 
     // Step 2: Check positions
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["position", "list"]);
     cmd.assert().success();
 
     // Step 3: Market analysis - get order book
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "depth", "--symbol", "BTC-USD"]);
     cmd.assert().success();
 
     // Step 4: Check funding rates
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "funding", "--symbol", "BTC-USD"]);
     cmd.assert().success();
 
@@ -36,13 +36,13 @@ fn test_trader_daily_workflow() {
 #[test]
 fn test_market_analysis_workflow() {
     // Get all symbols
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "symbols"]);
     cmd.assert().success();
 
     // Get ticker for multiple symbols
     for symbol in ["BTC-USD", "ETH-USD"] {
-        let mut cmd = Command::cargo_bin("standx").unwrap();
+        let mut cmd = cargo_bin_cmd!("standx");
         cmd.args(["market", "ticker", symbol]);
         cmd.assert().success();
     }

--- a/crates/standx-cli/tests/integration/cli_commands.rs
+++ b/crates/standx-cli/tests/integration/cli_commands.rs
@@ -1,12 +1,12 @@
 //! CLI Command Integration Tests
 //! Tests CLI commands using assert_cmd
 
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 
 #[test]
 fn test_cli_version() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.arg("--version");
     cmd.assert()
         .success()
@@ -16,7 +16,7 @@ fn test_cli_version() {
 
 #[test]
 fn test_cli_help() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.arg("--help");
     cmd.assert()
         .success()
@@ -26,7 +26,7 @@ fn test_cli_help() {
 
 #[test]
 fn test_cli_market_help() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "--help"]);
     cmd.assert()
         .success()

--- a/crates/standx-cli/tests/integration/cli_market_commands.rs
+++ b/crates/standx-cli/tests/integration/cli_market_commands.rs
@@ -1,11 +1,11 @@
 //! CLI Market Commands Integration Tests
 
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 
 #[test]
 fn test_market_symbols_command() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "symbols"]);
     cmd.assert().success().stdout(
         predicate::str::contains("BTC")
@@ -16,7 +16,7 @@ fn test_market_symbols_command() {
 
 #[test]
 fn test_market_ticker_command() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "ticker", "BTC-USD"]);
     cmd.assert().success().stdout(
         predicate::str::contains("BTC-USD")
@@ -27,7 +27,7 @@ fn test_market_ticker_command() {
 
 #[test]
 fn test_market_depth_command() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "depth", "BTC-USD"]);
     cmd.assert().success().stdout(
         predicate::str::contains("Asks")
@@ -38,7 +38,7 @@ fn test_market_depth_command() {
 
 #[test]
 fn test_market_funding_command() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "funding", "BTC-USD"]);
     cmd.assert()
         .success()

--- a/crates/standx-cli/tests/integration/cli_output_formats.rs
+++ b/crates/standx-cli/tests/integration/cli_output_formats.rs
@@ -1,11 +1,11 @@
 //! CLI Output Format Integration Tests
 
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 
 #[test]
 fn test_market_symbols_json_output() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "symbols", "--output", "json"]);
     cmd.assert()
         .success()
@@ -19,7 +19,7 @@ fn test_market_symbols_json_output() {
 
 #[test]
 fn test_market_symbols_table_output() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "symbols", "--output", "table"]);
     cmd.assert()
         .success()
@@ -28,7 +28,7 @@ fn test_market_symbols_table_output() {
 
 #[test]
 fn test_market_symbols_csv_output() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "symbols", "--output", "csv"]);
     cmd.assert()
         .success()
@@ -37,7 +37,7 @@ fn test_market_symbols_csv_output() {
 
 #[test]
 fn test_output_format_quiet() {
-    let mut cmd = Command::cargo_bin("standx").unwrap();
+    let mut cmd = cargo_bin_cmd!("standx");
     cmd.args(["market", "symbols", "--quiet"]);
     cmd.assert()
         .success()

--- a/crates/standx-cli/tests/unit/utils/error_test.rs
+++ b/crates/standx-cli/tests/unit/utils/error_test.rs
@@ -79,7 +79,7 @@ fn test_api_error_json_serialization() {
 #[test]
 fn test_error_retryable() {
     // 5xx 错误应该可重试
-    let err = Error::Http {
+    let _err = Error::Http {
         code: 500,
         message: "Server Error".to_string(),
         retryable: Some(true),
@@ -87,7 +87,7 @@ fn test_error_retryable() {
     // retryable 字段已设置
 
     // 4xx 错误不应该重试
-    let err = Error::Http {
+    let _err = Error::Http {
         code: 400,
         message: "Bad Request".to_string(),
         retryable: Some(false),

--- a/crates/standx-cli/tests/unit/utils/time_parser_test.rs
+++ b/crates/standx-cli/tests/unit/utils/time_parser_test.rs
@@ -139,7 +139,7 @@ fn test_parse_time_edge_cases() {
 /// 测试大小写不敏感
 #[test]
 fn test_parse_time_case_insensitive() {
-    let now = chrono::Utc::now().timestamp();
+    let _now = chrono::Utc::now().timestamp();
 
     // 大写应该也支持
     let result_lower = parse_time_string("1d", false).unwrap();

--- a/crates/standx-sdk/src/auth/credentials.rs
+++ b/crates/standx-sdk/src/auth/credentials.rs
@@ -246,6 +246,7 @@ mod tests {
     }
 
     impl EnvGuard {
+        #[allow(dead_code)]
         fn set(key: &str, value: &str) -> Self {
             let original_value = std::env::var(key).ok();
             std::env::set_var(key, value);
@@ -267,7 +268,7 @@ mod tests {
 
     #[test]
     fn test_credentials_new() {
-        let mut creds = Credentials::new("test_token".to_string(), Some("test_key".to_string()));
+        let creds = Credentials::new("test_token".to_string(), Some("test_key".to_string()));
 
         assert_eq!(creds.token, "test_token");
         assert_eq!(creds.private_key, "test_key");

--- a/crates/standx-sdk/src/auth/mod.rs
+++ b/crates/standx-sdk/src/auth/mod.rs
@@ -87,9 +87,6 @@ impl StandXSigner {
 mod tests {
     use super::*;
 
-    // Test private key (Base58) - DO NOT USE IN PRODUCTION
-    const TEST_PRIVATE_KEY: &str = "HdsyJD7oWgT7tRZ7L8QJ9K3mP5nQ8rS2vX4wY6zA1bC3dE5fG7hI9jK0lM2nO4pQ6rS8tU0vW1xY2zA3bC4dE5fG6h";
-
     #[test]
     fn test_signer_from_base58() {
         // Generate a random key for testing

--- a/crates/standx-sdk/src/models.rs
+++ b/crates/standx-sdk/src/models.rs
@@ -918,7 +918,7 @@ mod tests {
     #[test]
     fn test_order_book_sorting() {
         // Server might return unsorted data
-        let book = OrderBook {
+        let _book = OrderBook {
             symbol: "BTC-USD".to_string(),
             bids: vec![
                 ["67900".to_string(), "2.0".to_string()],
@@ -1196,7 +1196,7 @@ mod tests {
     #[test]
     fn test_order_status_untriggered() {
         // Test new Untriggered status
-        let json = r#"{"status": "untriggered"}"#;
+        let _json = r#"{"status": "untriggered"}"#;
         // We need to test this via Order since OrderStatus is not directly deserializable
         let order_json = r#"{
             "id": "123",


### PR DESCRIPTION
## What & why

`cargo clippy --workspace --all-targets -- -D warnings` failed entirely, all on **pre-existing lints in test code**. This clears them so the stricter workspace gate is green, and upgrades CI to enforce it.

The existing CI command (`cargo clippy -- -D warnings`) already passed and still does — no regression.

## Changes

- **Deprecated `cargo_bin` (~22 sites)** — migrated `Command::cargo_bin("standx").unwrap()` → `cargo_bin_cmd!("standx")` macro across the 5 e2e/integration test files; import changed to `use assert_cmd::cargo::cargo_bin_cmd;`.
- **Unused variables** — underscore-prefixed the genuinely-unused bindings: `_telemetry`, `_now`, `_err`, `_book`, `_json`.
- **Needless `mut`** — removed from 5 `let mut config` in `config.rs` and `let mut creds` in `credentials.rs`.
- **Needless borrows** — dropped redundant `&` on `config.config_file()` args (`needless_borrows_for_generic_args`).
- **Items after test module** — `output.rs` had `format_dashboard_mvp` (and helpers) declared after `mod tests`; moved the test module to the end of the file.
- **Dead code** — removed the unused `TEST_PRIVATE_KEY` const in `auth/mod.rs`; added `#[allow(dead_code)]` to `EnvGuard::set` (its struct was already so annotated, so this keeps the helper consistent with the author's intent).
- **CI** — clippy step upgraded to `cargo clippy --workspace --all-targets -- -D warnings`.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo clippy -- -D warnings` (old CI command) → exit 0
- `cargo fmt --all -- --check` → clean
- `cargo test --workspace` → all pass

## Reviewer note

A few of the underscore-fixed tests (`test_error_retryable`, `test_order_book_sorting`, `test_order_status_untriggered`, the telemetry tests) only construct a value and never assert on it — they're effectively no-op tests. This PR only silences the lint without changing their semantics; adding real assertions is worthwhile follow-up but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)