### PR TITLE
feat(maker): WebSocket feed, divergence guard, and live resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - WebSocket market feed (price + depth on one connection) with automatic REST fallback when the feed is warming up or stale; `--no-ws` forces REST polling
   - Early re-quote: wakes before the interval elapses when the cached mark has already drifted past `--refresh-bps` (only fires when a re-quote would happen anyway — no added flicker; 1s min gap)
   - mark/mid divergence guard (`--max-divergence-bps`, default 25): skips the cycle without touching resting quotes when mark price and book mid disagree
+  - Error classification: post-only (ALO) would-cross rejections and cancels of already-gone orders are treated as normal events (logged, re-quoted next cycle) instead of counting toward the 3-consecutive-error fail-safe — only transient failures (network, 5xx) trip it
+  - Partial-fill tolerance: a partially-filled resting order keeps its identity (adopted by side + price, qty ≤ placed) and holds its remainder instead of being cancelled as an unknown order
 - `TimeInForce::Alo` (post-only / add-liquidity-only), matching the backend enum; `standx order create --tif ALO` now supported
 - Block trade commands: `standx block list` / `standx block watch`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Paper mode by default** (full loop, prints intended actions, no orders); `--live` implements real post-only quoting but is locked behind `STANDX_ENABLE_LIVE_MAKER=1` pending supervised production testing
   - Live safety rails: startup cancel-all, exchange open-orders as reconciliation truth, cancel-all-with-retry + verification on exit, fail-safe stop after 3 consecutive API errors
   - JSON-lines output for agents (`--output json` / `--openclaw`)
-  - Pure quoting/reconcile core in `standx_sdk::maker` with 15 unit tests
+  - Pure quoting/reconcile core in `standx_sdk::maker` with 16 unit tests
+  - WebSocket market feed (price + depth on one connection) with automatic REST fallback when the feed is warming up or stale; `--no-ws` forces REST polling
+  - Early re-quote: wakes before the interval elapses when the cached mark has already drifted past `--refresh-bps` (only fires when a re-quote would happen anyway — no added flicker; 1s min gap)
+  - mark/mid divergence guard (`--max-divergence-bps`, default 25): skips the cycle without touching resting quotes when mark price and book mid disagree
 - `TimeInForce::Alo` (post-only / add-liquidity-only), matching the backend enum; `standx order create --tif ALO` now supported
 - Block trade commands: `standx block list` / `standx block watch`
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,12 @@ standx maker run BTC-USD \
   --levels 2          # quote levels per side
   --max-position 0.05 # suppress the side that would exceed this
 
+# Market data comes from a WebSocket feed (REST fallback when stale);
+# the loop also wakes early when mark has already drifted past
+# --refresh-bps, shrinking the reaction window without adding flicker.
+# --no-ws forces plain REST polling; --max-divergence-bps (default 25)
+# skips a cycle when mark price and the book mid disagree.
+
 # Machine-readable JSON lines (one object per action)
 standx maker run BTC-USD --output json
 

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -411,6 +411,14 @@ pub enum MakerCommands {
         /// Max absolute position; suppress the side that would exceed it
         #[arg(long, default_value = "0.05")]
         max_position: f64,
+        /// Sanity guard: skip the cycle (no places/cancels) when mark price
+        /// and book mid diverge by more than this (bps) — the data sources
+        /// disagree and acting on them would be unsafe
+        #[arg(long, default_value = "25")]
+        max_divergence_bps: f64,
+        /// Disable the WebSocket market feed and poll REST every cycle
+        #[arg(long)]
+        no_ws: bool,
         /// Place real orders (without this flag the bot runs in paper mode:
         /// full loop, prints intended actions, no orders placed)
         #[arg(long)]

--- a/crates/standx-cli/src/commands.rs
+++ b/crates/standx-cli/src/commands.rs
@@ -1517,7 +1517,7 @@ struct PendingPlace {
 pub async fn handle_maker(
     command: MakerCommands,
     output_format: OutputFormat,
-    _verbose: bool,
+    verbose: bool,
 ) -> Result<()> {
     match command {
         MakerCommands::Run {
@@ -1530,6 +1530,8 @@ pub async fn handle_maker(
             refresh_bps,
             interval,
             max_position,
+            max_divergence_bps,
+            no_ws,
             live,
         } => {
             run_maker(
@@ -1543,7 +1545,10 @@ pub async fn handle_maker(
                     refresh_bps,
                     interval,
                     max_position,
+                    max_divergence_bps,
+                    no_ws,
                     live,
+                    verbose,
                 },
                 output_format,
             )
@@ -1561,7 +1566,127 @@ struct MakerRunArgs {
     refresh_bps: f64,
     interval: u64,
     max_position: f64,
+    max_divergence_bps: f64,
+    no_ws: bool,
     live: bool,
+    verbose: bool,
+}
+
+/// Latest market data from the WebSocket feed. Values are pre-parsed on
+/// receipt so cycle reads are lock-and-go.
+#[derive(Default)]
+struct FeedState {
+    mark: Option<f64>,
+    mark_at: Option<std::time::Instant>,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    book_at: Option<std::time::Instant>,
+}
+
+/// WS cache entries older than this fall back to REST for the cycle. REST
+/// polling refreshed data once per interval, so 5s keeps freshness at least
+/// as good as the old behavior while tolerating slow feed ticks.
+const WS_STALE_AFTER: Duration = Duration::from_secs(5);
+
+/// Spawn the resident market-feed task: one public WS connection carrying
+/// `price` + `depth_book`, written into a shared cache. The outer loop wraps
+/// the SDK's internal 5-attempt reconnect — when the stream ends (attempts
+/// exhausted or clean close), it rebuilds the connection from scratch, since
+/// subscriptions only take effect when registered before `connect()`.
+fn spawn_market_feed(
+    symbol: String,
+    verbose: bool,
+) -> (
+    Arc<RwLock<FeedState>>,
+    watch::Receiver<u64>,
+    tokio::task::JoinHandle<()>,
+) {
+    let state = Arc::new(RwLock::new(FeedState::default()));
+    let (tx, rx) = watch::channel(0u64);
+    let state_task = state.clone();
+
+    let handle = tokio::spawn(async move {
+        let mut seq = 0u64;
+        loop {
+            let ws = match StandXWebSocket::without_auth_with_verbose(verbose) {
+                Ok(ws) => ws,
+                Err(e) => {
+                    eprintln!("⚠️  market feed setup failed: {e}; retrying in 10s");
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    continue;
+                }
+            };
+            let _ = ws.subscribe("price", Some(&symbol)).await;
+            let _ = ws.subscribe("depth_book", Some(&symbol)).await;
+            let mut events = match ws.connect().await {
+                Ok(rx) => rx,
+                Err(e) => {
+                    eprintln!("⚠️  market feed connect failed: {e}; retrying in 10s");
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    continue;
+                }
+            };
+            while let Some(msg) = events.recv().await {
+                let now = std::time::Instant::now();
+                match msg {
+                    WsMessage::Price(p) if p.symbol.eq_ignore_ascii_case(&symbol) => {
+                        if let Ok(mark) = p.mark_price.parse::<f64>() {
+                            let mut s = state_task.write().await;
+                            s.mark = Some(mark);
+                            s.mark_at = Some(now);
+                        }
+                    }
+                    WsMessage::Depth(d) if d.symbol.eq_ignore_ascii_case(&symbol) => {
+                        let mut s = state_task.write().await;
+                        s.best_bid = d.best_bid().and_then(|v| v.parse().ok());
+                        s.best_ask = d.best_ask().and_then(|v| v.parse().ok());
+                        s.book_at = Some(now);
+                    }
+                    _ => continue,
+                }
+                seq += 1;
+                let _ = tx.send(seq);
+            }
+            // Stream ended: SDK reconnects exhausted or server closed.
+            eprintln!("⚠️  market feed stream ended; rebuilding connection in 10s");
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        }
+    });
+
+    (state, rx, handle)
+}
+
+/// One market snapshot: WS cache when fresh, REST fallback otherwise
+/// (startup warm-up, feed outage, or --no-ws).
+async fn market_snapshot(
+    client: &StandXClient,
+    symbol: &str,
+    feed: Option<&Arc<RwLock<FeedState>>>,
+) -> Result<(f64, Option<f64>, Option<f64>, &'static str)> {
+    if let Some(feed) = feed {
+        let s = feed.read().await;
+        let fresh =
+            |at: Option<std::time::Instant>| at.is_some_and(|t| t.elapsed() < WS_STALE_AFTER);
+        if fresh(s.mark_at) && fresh(s.book_at) {
+            if let Some(mark) = s.mark {
+                return Ok((mark, s.best_bid, s.best_ask, "ws"));
+            }
+        }
+    }
+
+    let (price, depth) = tokio::join!(
+        client.get_symbol_price(symbol),
+        client.get_depth(symbol, Some(5))
+    );
+    let price = price?;
+    let depth = depth?;
+    let mark: f64 = price
+        .mark_price
+        .parse()
+        .map_err(|_| anyhow::anyhow!("unparseable mark price: {}", price.mark_price))?;
+    let best_bid: Option<f64> = depth.best_bid().and_then(|s| s.parse().ok());
+    let best_ask: Option<f64> = depth.best_ask().and_then(|s| s.parse().ok());
+    Ok((mark, best_bid, best_ask, "rest"))
 }
 
 async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputFormat) -> Result<()> {
@@ -1692,9 +1817,25 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
             );
             println!("│ orders on this symbol will be cancelled as stale.");
         }
+        if args.no_ws {
+            println!("│ feed: REST polling (--no-ws)");
+        } else {
+            println!(
+                "│ feed: websocket (REST fallback) | divergence guard {}bps",
+                args.max_divergence_bps
+            );
+        }
         println!("│ Ctrl+C to stop (cancels all resting orders on exit)");
         println!("└──────────────────────────────────────────────────────────┘");
     }
+
+    // ---- Market feed (WS primary, REST fallback) ----
+    let (feed, mut updates, feed_handle) = if args.no_ws {
+        (None, None, None)
+    } else {
+        let (state, rx, handle) = spawn_market_feed(symbol.clone(), args.verbose);
+        (Some(state), Some(rx), Some(handle))
+    };
 
     // ---- Loop state ----
     let mut cycle: u64 = 0;
@@ -1705,32 +1846,54 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     let mut total_places: u64 = 0;
     let mut total_cancels: u64 = 0;
     let mut total_holds: u64 = 0;
+    let mut last_mark: Option<f64> = None;
+    let mut last_src: Option<&'static str> = None;
 
-    let exit = loop {
+    let exit = 'main: loop {
         // Work phase raced against Ctrl+C so a slow API call can be
         // interrupted (mirrors run_watch_loop).
-        let work = maker_cycle(
-            &client,
-            &symbol,
-            &cfg,
-            args.live,
-            cycle,
-            &mut resting,
-            &mut adopted,
-            &mut pending,
-            output_format,
-        );
+        let work = async {
+            let (mark, best_bid, best_ask, src) =
+                market_snapshot(&client, &symbol, feed.as_ref()).await?;
+            let (places, cancels, holds) = maker_cycle(
+                &client,
+                &symbol,
+                &cfg,
+                args.live,
+                cycle,
+                mark,
+                best_bid,
+                best_ask,
+                args.max_divergence_bps,
+                &mut resting,
+                &mut adopted,
+                &mut pending,
+                output_format,
+            )
+            .await?;
+            Ok::<_, anyhow::Error>((places, cancels, holds, mark, src))
+        };
         let cycle_result = tokio::select! {
             _ = signal::ctrl_c() => break MakerExit::CtrlC,
             result = work => result,
         };
 
         match cycle_result {
-            Ok((places, cancels, holds)) => {
+            Ok((places, cancels, holds, mark, src)) => {
                 consecutive_errors = 0;
                 total_places += places;
                 total_cancels += cancels;
                 total_holds += holds;
+                last_mark = Some(mark);
+                if !args.no_ws && last_src != Some(src) {
+                    match src {
+                        "ws" => eprintln!("✅ market feed: websocket live"),
+                        _ => eprintln!(
+                            "⚠️  market feed: REST fallback (websocket warming up or stale)"
+                        ),
+                    }
+                    last_src = Some(src);
+                }
             }
             Err(e) => {
                 consecutive_errors += 1;
@@ -1743,13 +1906,51 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
 
         cycle += 1;
 
-        tokio::select! {
-            _ = signal::ctrl_c() => break MakerExit::CtrlC,
-            _ = tokio::time::sleep(Duration::from_secs(args.interval)) => {}
+        // Sleep until the next cycle, but wake early when the cached mark
+        // has already drifted beyond refresh_bps — the quotes would be
+        // re-quoted anyway, so reacting now shrinks the pick-off window
+        // without adding flicker. min-gap of 1s bounds the API rate.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(args.interval);
+        let min_gap = tokio::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            let update = async {
+                match updates.as_mut() {
+                    Some(rx) => rx.changed().await.is_ok(),
+                    None => std::future::pending().await,
+                }
+            };
+            tokio::select! {
+                _ = signal::ctrl_c() => break 'main MakerExit::CtrlC,
+                _ = tokio::time::sleep_until(deadline) => break,
+                ok = update => {
+                    if !ok {
+                        // Feed task gone: fall back to plain interval waits.
+                        updates = None;
+                        continue;
+                    }
+                    if tokio::time::Instant::now() < min_gap {
+                        continue;
+                    }
+                    let (Some(feed), Some(prev)) = (feed.as_ref(), last_mark) else {
+                        continue;
+                    };
+                    let drifted = {
+                        let s = feed.read().await;
+                        s.mark
+                            .is_some_and(|m| maker::bps_diff(m, prev) > cfg.refresh_bps)
+                    };
+                    if drifted {
+                        break; // early re-quote cycle
+                    }
+                }
+            }
         }
     };
 
     // ---- Cleanup on ALL exit paths ----
+    if let Some(handle) = feed_handle {
+        handle.abort();
+    }
     if output_format == OutputFormat::Table {
         println!(
             "\n👋 Stopping maker (ran {} cycles: {} places, {} cancels, {} holds)",
@@ -1769,7 +1970,8 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     }
 }
 
-/// One reconcile cycle. Returns (places, cancels, holds) counts.
+/// One reconcile cycle over an already-acquired market snapshot.
+/// Returns (places, cancels, holds) counts.
 #[allow(clippy::too_many_arguments)]
 async fn maker_cycle(
     client: &StandXClient,
@@ -1777,28 +1979,52 @@ async fn maker_cycle(
     cfg: &standx_sdk::maker::MakerConfig,
     live: bool,
     cycle: u64,
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    max_divergence_bps: f64,
     resting: &mut Vec<standx_sdk::maker::RestingQuote>,
     adopted: &mut HashMap<String, (u32, f64, u64)>,
     pending: &mut Vec<PendingPlace>,
     output_format: OutputFormat,
 ) -> Result<(u64, u64, u64)> {
     use standx_sdk::maker::{
-        compute_desired_quotes, format_decimals, reconcile, Action, RestingQuote,
+        compute_desired_quotes, format_decimals, mark_mid_divergence_bps, reconcile, Action,
+        RestingQuote,
     };
 
-    // 1. Market snapshot.
-    let (price, depth) = tokio::join!(
-        client.get_symbol_price(symbol),
-        client.get_depth(symbol, Some(5))
-    );
-    let price = price?;
-    let depth = depth?;
-    let mark: f64 = price
-        .mark_price
-        .parse()
-        .map_err(|_| anyhow::anyhow!("unparseable mark price: {}", price.mark_price))?;
-    let best_bid: Option<f64> = depth.best_bid().and_then(|s| s.parse().ok());
-    let best_ask: Option<f64> = depth.best_ask().and_then(|s| s.parse().ok());
+    // 1. Sanity guard: when mark and the book mid disagree, at least one
+    //    data source is wrong (stale feed, bad print, dislocated book).
+    //    Acting on it is unsafe in every direction, so do nothing this
+    //    cycle: resting quotes stay untouched. Not a fail-safe error.
+    if let (Some(bid), Some(ask)) = (best_bid, best_ask) {
+        let divergence = mark_mid_divergence_bps(mark, bid, ask);
+        if divergence > max_divergence_bps {
+            let live_str = if live { "live" } else { "paper" };
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                            "cycle": cycle, "mode": live_str, "symbol": symbol,
+                            "action": "skip", "reason": "mark_mid_divergence",
+                            "mark": format_decimals(mark, cfg.price_decimals),
+                            "divergence_bps": (divergence * 100.0).round() / 100.0,
+                            "max_divergence_bps": max_divergence_bps,
+                        })
+                    );
+                }
+                _ => {
+                    eprintln!(
+                        "⚠️  #{} mark/mid divergence {:.1}bps > {}bps — skipping cycle (no actions)",
+                        cycle, divergence, max_divergence_bps
+                    );
+                }
+            }
+            return Ok((0, 0, 0));
+        }
+    }
 
     if live && (best_bid.is_none() || best_ask.is_none()) {
         // Fail-safe: without a touch we cannot guarantee no-cross pricing.

--- a/crates/standx-cli/src/commands.rs
+++ b/crates/standx-cli/src/commands.rs
@@ -1513,6 +1513,31 @@ struct PendingPlace {
     cycle: u64,
 }
 
+/// A business rejection from the venue: the exchange responded with a
+/// definite "no" (post-only would-cross, order not found, insufficient
+/// margin, …). These are expected during normal quoting and must NOT trip
+/// the fail-safe — that is reserved for transient failures (network, 5xx,
+/// rate limit) that signal we can no longer talk to the exchange, which
+/// keep their `retryable` flag and propagate as cycle errors.
+fn is_order_rejection(e: &StandxError) -> bool {
+    matches!(
+        e,
+        StandxError::Api {
+            retryable: false,
+            ..
+        }
+    )
+}
+
+/// Whether an open order's remaining `open_qty` plausibly belongs to a place
+/// we made for `placed_qty`. A partial fill leaves a positive remainder no
+/// larger than what we placed; anything bigger is somebody else's order.
+/// Tolerating the shrink is what keeps a partially-filled order adopted
+/// (and thus HELD) instead of cancelled as an unknown order.
+fn open_qty_adopts(open_qty: f64, placed_qty: f64) -> bool {
+    open_qty > 0.0 && open_qty <= placed_qty * (1.0 + 1e-6)
+}
+
 /// Handle maker commands
 pub async fn handle_maker(
     command: MakerCommands,
@@ -2064,11 +2089,13 @@ async fn maker_cycle(
                 let (level, ref_mark, placed_at_cycle) = match adopted.get(&o.id) {
                     Some(&meta) => meta,
                     None => {
-                        // Try to adopt from a recent place by (side, price, qty).
+                        // Try to adopt from a recent place by side + price,
+                        // tolerating a shrunk qty from a partial fill (see
+                        // open_qty_adopts).
                         let matched = pending.iter().position(|p| {
                             p.side == o.side
                                 && (p.price - price).abs() < tick / 2.0
-                                && (p.qty - qty).abs() < f64::EPSILON.max(qty * 1e-6)
+                                && open_qty_adopts(qty, p.qty)
                         });
                         let meta = match matched {
                             Some(idx) => {
@@ -2096,7 +2123,7 @@ async fn maker_cycle(
             })
             .collect();
         // Places older than 2 cycles never showed up as open orders —
-        // likely rejected (e.g. ALO would-cross) or instantly filled.
+        // likely rejected (e.g. ALO would-cross) or fully filled on arrival.
         pending.retain(|p| cycle.saturating_sub(p.cycle) <= 2);
         adopted.retain(|id, _| resting.iter().any(|r| r.order_id.as_deref() == Some(id)));
     } else {
@@ -2107,7 +2134,9 @@ async fn maker_cycle(
     let desired = compute_desired_quotes(cfg, mark, best_bid, best_ask, position);
     let actions = reconcile(cfg, mark, best_bid, best_ask, &desired, resting, cycle);
 
-    // 4. Execute.
+    // 4. Execute. Business rejections (post-only would-cross, order already
+    //    gone) are expected and logged inline; only transient failures
+    //    propagate as cycle errors toward the fail-safe.
     let mut places: u64 = 0;
     let mut cancels: u64 = 0;
     let mut holds: u64 = 0;
@@ -2117,22 +2146,45 @@ async fn maker_cycle(
                 order_id,
                 side,
                 level,
+                price,
                 ..
             } => {
-                cancels += 1;
                 if live {
                     if let Some(id) = order_id {
-                        client.cancel_order(symbol, id).await?;
-                        adopted.remove(id);
+                        match client.cancel_order(symbol, id).await {
+                            Ok(()) => {
+                                adopted.remove(id);
+                                cancels += 1;
+                            }
+                            Err(e) if is_order_rejection(&e) => {
+                                // Order already gone (filled or cancelled
+                                // out from under us) — that IS the goal.
+                                adopted.remove(id);
+                                cancels += 1;
+                                log_maker_event(
+                                    output_format,
+                                    symbol,
+                                    cycle,
+                                    "cancel_noop",
+                                    *side,
+                                    *level,
+                                    *price,
+                                    cfg.price_decimals,
+                                    "order already gone",
+                                );
+                            }
+                            // Transient (network / 5xx) → fail-safe path.
+                            Err(e) => return Err(e.into()),
+                        }
                     }
                 } else {
                     resting.retain(|r| !(r.side == *side && r.level == *level));
+                    cancels += 1;
                 }
             }
             Action::Place(q) => {
-                places += 1;
                 if live {
-                    client
+                    match client
                         .create_order(CreateOrderParams {
                             symbol: symbol.to_string(),
                             side: q.side,
@@ -2147,15 +2199,36 @@ async fn maker_cycle(
                             sl_price: None,
                             tp_price: None,
                         })
-                        .await?;
-                    pending.push(PendingPlace {
-                        side: q.side,
-                        price: q.price,
-                        qty: q.qty,
-                        level: q.level,
-                        ref_mark: mark,
-                        cycle,
-                    });
+                        .await
+                    {
+                        Ok(_) => {
+                            pending.push(PendingPlace {
+                                side: q.side,
+                                price: q.price,
+                                qty: q.qty,
+                                level: q.level,
+                                ref_mark: mark,
+                                cycle,
+                            });
+                            places += 1;
+                        }
+                        Err(e) if is_order_rejection(&e) => {
+                            // Post-only would-cross etc. — expected in fast
+                            // markets. Re-quote next cycle, don't fail-safe.
+                            log_maker_event(
+                                output_format,
+                                symbol,
+                                cycle,
+                                "place_rejected",
+                                q.side,
+                                q.level,
+                                q.price,
+                                cfg.price_decimals,
+                                "post-only rejected",
+                            );
+                        }
+                        Err(e) => return Err(e.into()),
+                    }
                 } else {
                     resting.push(RestingQuote {
                         order_id: None,
@@ -2166,6 +2239,7 @@ async fn maker_cycle(
                         ref_mark: mark,
                         placed_at_cycle: cycle,
                     });
+                    places += 1;
                 }
             }
             Action::Hold { .. } => holds += 1,
@@ -2415,9 +2489,90 @@ fn side_str(side: OrderSide) -> &'static str {
     }
 }
 
+/// Emit a one-off maker event (order rejection, no-op cancel) inline,
+/// respecting the output format. Only reached in live mode.
+#[allow(clippy::too_many_arguments)]
+fn log_maker_event(
+    output_format: OutputFormat,
+    symbol: &str,
+    cycle: u64,
+    action: &str,
+    side: OrderSide,
+    level: u32,
+    price: f64,
+    price_decimals: u32,
+    detail: &str,
+) {
+    use standx_sdk::maker::format_decimals;
+    match output_format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                    "cycle": cycle, "mode": "live", "symbol": symbol,
+                    "action": action, "side": side, "level": level,
+                    "price": format_decimals(price, price_decimals),
+                    "detail": detail,
+                })
+            );
+        }
+        _ => {
+            eprintln!(
+                "    {} {} L{} @ {} — {}",
+                action,
+                side_str(side),
+                level,
+                format_decimals(price, price_decimals),
+                detail
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn business_rejection_not_fail_safe() {
+        // Post-only would-cross / order-not-found: exchange said no.
+        assert!(is_order_rejection(&StandxError::Api {
+            code: 400,
+            message: "post-only would cross".into(),
+            endpoint: None,
+            retryable: false,
+        }));
+        // 5xx from the venue: transient → counts toward fail-safe.
+        assert!(!is_order_rejection(&StandxError::Api {
+            code: 502,
+            message: "bad gateway".into(),
+            endpoint: None,
+            retryable: true,
+        }));
+        // Network layer: transient → counts toward fail-safe.
+        assert!(!is_order_rejection(&StandxError::Http {
+            code: 0,
+            message: "connection reset".into(),
+            retryable: Some(true),
+        }));
+    }
+
+    #[test]
+    fn partial_fill_stays_adopted() {
+        // Full remainder adopts.
+        assert!(open_qty_adopts(0.01, 0.01));
+        // Partial remainder (half filled) still adopts.
+        assert!(open_qty_adopts(0.005, 0.01));
+        // Tiny remainder adopts.
+        assert!(open_qty_adopts(0.0001, 0.01));
+        // Zero / fully filled does not adopt (no open order to match).
+        assert!(!open_qty_adopts(0.0, 0.01));
+        // Larger than placed is someone else's order.
+        assert!(!open_qty_adopts(0.02, 0.01));
+        // Float slop just under the placed qty is tolerated.
+        assert!(open_qty_adopts(0.01 + 1e-9, 0.01));
+    }
 
     #[test]
     fn test_parse_relative_time_hours() {

--- a/crates/standx-sdk/src/maker.rs
+++ b/crates/standx-sdk/src/maker.rs
@@ -158,6 +158,15 @@ pub fn bps_diff(a: f64, b: f64) -> f64 {
     ((a - b) / b).abs() * 10_000.0
 }
 
+/// Divergence between mark price and the book mid, in bps of mark.
+///
+/// A large value means the two data sources disagree (stale feed, bad print,
+/// or a dislocated book) — quotes anchored to mark would sit nonsensically
+/// relative to the book, so callers should skip acting on such a snapshot.
+pub fn mark_mid_divergence_bps(mark: f64, best_bid: f64, best_ask: f64) -> f64 {
+    bps_diff((best_bid + best_ask) / 2.0, mark)
+}
+
 /// Compute the desired quote set for the current market snapshot.
 ///
 /// Applies, in order: the spread/level ladder, the band clamp, the no-cross
@@ -631,5 +640,18 @@ mod tests {
         assert_eq!(ceil_to_decimals(100.10, 2), 100.10);
         assert_eq!(format_decimals(99.9, 2), "99.90");
         assert_eq!(format_decimals(0.0123, 4), "0.0123");
+    }
+
+    // 15. Mark/mid divergence guard helper.
+    #[test]
+    fn mark_mid_divergence() {
+        // mid = 100.0 == mark -> no divergence
+        assert_eq!(mark_mid_divergence_bps(100.0, 99.9, 100.1), 0.0);
+        // mid = 100.25 vs mark 100.0 -> 25 bps
+        assert!((mark_mid_divergence_bps(100.0, 100.2, 100.3) - 25.0).abs() < 1e-9);
+        // symmetric below
+        assert!((mark_mid_divergence_bps(100.0, 99.7, 99.8) - 25.0).abs() < 1e-9);
+        // degenerate mark = 0 -> 0.0, no blowup
+        assert_eq!(mark_mid_divergence_bps(0.0, 99.9, 100.1), 0.0);
     }
 }

--- a/crates/standx-sdk/src/maker.rs
+++ b/crates/standx-sdk/src/maker.rs
@@ -390,7 +390,7 @@ mod tests {
         }
     }
 
-    fn find<'a>(quotes: &'a [DesiredQuote], side: OrderSide, level: u32) -> &'a DesiredQuote {
+    fn find(quotes: &[DesiredQuote], side: OrderSide, level: u32) -> &DesiredQuote {
         quotes
             .iter()
             .find(|q| q.side == side && q.level == level)


### PR DESCRIPTION
## What

Everything for the maker bot that landed **after** the base command merged in #178: the WebSocket market feed (#3 on the roadmap) plus two live-path resilience fixes (#1, #2). #178 was squash-merged while it only carried the base quoting loop, so the WS-feed commit was orphaned — this PR carries it forward alongside the resilience work, rebased onto current `main`.

Everything except the fail-safe classifier's live branch is exercised by paper-mode runs and unit tests; paper mode's per-cycle output is unchanged except for the new feed/guard lines.

## 1. WebSocket market feed (replaces per-cycle REST polling)

REST polling showed mark price lagging the book by ~4bps in paper testing — quotes anchored to a stale mark are a pick-off invitation, and reaction time was capped at one full `--interval`.

- Resident feed task: one public WS connection carrying `price` + `depth_book`, pre-parsed into a shared cache; the outer loop rebuilds the connection when the SDK's internal 5-attempt reconnect is exhausted.
- **WS-primary, REST-fallback** snapshots: cache entries older than 5s fall back to the existing REST path (covers warm-up, outages, `--no-ws`); feed-source transitions logged to stderr.
- **Early re-quote**: the inter-cycle sleep is interruptible — when a feed update shows mark already drifted past `--refresh-bps`, the next cycle fires immediately (1s min gap). Only fires when a re-quote would happen anyway, so no added flicker. Verified with `--interval 30 --refresh-bps 1`: cycles fired 1–22s apart, each a real re-quote.
- **mark/mid divergence guard** (`--max-divergence-bps`, default 25): when mark and book mid disagree, skip the cycle without touching resting quotes — not counted toward fail-safe. New pure helper `mark_mid_divergence_bps` (+1 test).
- `--no-ws` forces plain REST polling.

## 2. Post-only rejections no longer trip the fail-safe

`create_order`/`cancel_order` errors were propagated as whole-cycle failures counting toward the 3-consecutive-error fail-safe. In a fast market, **post-only (ALO) would-cross rejections are an expected, high-frequency event** — three in a row would take the bot (and its SIP-5A uptime score) down exactly when it should keep quoting.

Errors are now classified: a **business rejection** (`Error::Api { retryable: false }` — would-cross, order-not-found) is logged and the loop continues; only **transient failures** (network / 5xx) propagate toward fail-safe. A cancel of an already-gone order is treated as success.

## 3. Partial fills keep their identity

Live adoption matched exchange open-orders to our places by exact `(side, price, qty)`. A partial fill shrinks the open qty → exact match fails → the remainder was cancelled as an *unknown* order, i.e. **cancelling our own resting liquidity at the moment it's being filled** (lost uptime + flicker penalty). Adoption now matches `side + price` with `qty <= placed` (`open_qty_adopts`), so a partial fill HOLDs its remainder.

## Tests

- New: `mark_mid_divergence`, `business_rejection_not_fail_safe`, `partial_fill_stays_adopted`
- Full suite green; `cargo clippy --workspace --all-targets -- -D warnings` clean (includes eliding one pre-existing needless lifetime in a maker test helper, newly caught by main's tightened CI); `fmt --check` clean
- Paper-mode verification for the feed, early-wake, divergence guard, `--no-ws`, and JSON-lines integrity

## Verification note

Live order-placement paths can't run here (locked behind `STANDX_ENABLE_LIVE_MAKER=1`). The classifier and adoption predicates are unit-tested; real ALO reject codes and partial-fill handling are part of the supervised-unlock checklist.

## Follow-ups (not in scope)

- Top-up of a partially-filled level back to full size
- Replace the `(side, price, qty)` adoption heuristic with a client order id if the backend supports one

🤖 Generated with [Claude Code](https://claude.com/claude-code)