### PR TITLE
feat(maker): inventory skew to lean against accumulated position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Paper mode by default** (full loop, prints intended actions, no orders); `--live` implements real post-only quoting but is locked behind `STANDX_ENABLE_LIVE_MAKER=1` pending supervised production testing
   - Live safety rails: startup cancel-all, exchange open-orders as reconciliation truth, cancel-all-with-retry + verification on exit, fail-safe stop after 3 consecutive API errors
   - JSON-lines output for agents (`--output json` / `--openclaw`)
-  - Pure quoting/reconcile core in `standx_sdk::maker` with 16 unit tests
+  - Pure quoting/reconcile core in `standx_sdk::maker` with 23 unit tests
+  - Inventory skew (`--skew-bps`, default 0/off): shifts the quote center by current position so the reducing side quotes nearer mark and the growing side further, turning `--max-position` from a hard brake into gradual mean reversion. The anti-flicker anchor generalizes from "mark at placement" to "quote center at placement," so the same re-quote rule reacts to both mark drift and inventory skew. Live-only (paper holds no position)
   - WebSocket market feed (price + depth on one connection) with automatic REST fallback when the feed is warming up or stale; `--no-ws` forces REST polling
   - Early re-quote: wakes before the interval elapses when the cached mark has already drifted past `--refresh-bps` (only fires when a re-quote would happen anyway — no added flicker; 1s min gap)
   - mark/mid divergence guard (`--max-divergence-bps`, default 25): skips the cycle without touching resting quotes when mark price and book mid disagree

--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ standx maker run BTC-USD \
   --refresh-bps 3     # anti-flicker: re-quote only after this much drift
   --levels 2          # quote levels per side
   --max-position 0.05 # suppress the side that would exceed this
+  --skew-bps 5        # inventory skew: at full inventory, shift the quote
+                      # center this many bps toward the reducing side
+                      # (0 = off; live only, paper holds no position)
 
 # Market data comes from a WebSocket feed (REST fallback when stale);
 # the loop also wakes early when mark has already drifted past

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -411,6 +411,12 @@ pub enum MakerCommands {
         /// Max absolute position; suppress the side that would exceed it
         #[arg(long, default_value = "0.05")]
         max_position: f64,
+        /// Inventory skew: at full inventory, shift the quote center this many
+        /// bps away from mark to favor the reducing side (0 disables). Only
+        /// takes effect in live mode; paper holds no position. Suggested
+        /// starting point: roughly your --spread-bps
+        #[arg(long, default_value = "0")]
+        skew_bps: f64,
         /// Sanity guard: skip the cycle (no places/cancels) when mark price
         /// and book mid diverge by more than this (bps) — the data sources
         /// disagree and acting on them would be unsafe

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -27,8 +27,8 @@ pub(super) async fn maker_cycle(
     output_format: OutputFormat,
 ) -> Result<(u64, u64, u64)> {
     use standx_sdk::maker::{
-        compute_desired_quotes, format_decimals, mark_mid_divergence_bps, reconcile, Action,
-        RestingQuote,
+        compute_desired_quotes, format_decimals, mark_mid_divergence_bps, reconcile, skew_center,
+        Action, RestingQuote,
     };
 
     // 1. Sanity guard: when mark and the book mid disagree, at least one
@@ -99,7 +99,7 @@ pub(super) async fn maker_cycle(
             .map(|o| {
                 let price: f64 = o.price.parse().unwrap_or(0.0);
                 let qty: f64 = o.qty.parse().unwrap_or(0.0);
-                let (level, ref_mark, placed_at_cycle) = match adopted.get(&o.id) {
+                let (level, ref_center, placed_at_cycle) = match adopted.get(&o.id) {
                     Some(&meta) => meta,
                     None => {
                         // Try to adopt from a recent place by side + price,
@@ -113,7 +113,7 @@ pub(super) async fn maker_cycle(
                         let meta = match matched {
                             Some(idx) => {
                                 let p = pending.remove(idx);
-                                (p.level, p.ref_mark, p.cycle)
+                                (p.level, p.ref_center, p.cycle)
                             }
                             // Unknown order (manual or unmatched): sentinel
                             // level so reconcile cancels it as stale — the
@@ -130,7 +130,7 @@ pub(super) async fn maker_cycle(
                     level,
                     price,
                     qty,
-                    ref_mark,
+                    ref_center,
                     placed_at_cycle,
                 }
             })
@@ -145,7 +145,13 @@ pub(super) async fn maker_cycle(
 
     // 3. Decide.
     let desired = compute_desired_quotes(cfg, mark, best_bid, best_ask, position);
-    let actions = reconcile(cfg, mark, best_bid, best_ask, &desired, resting, cycle);
+    let actions = reconcile(
+        cfg, mark, position, best_bid, best_ask, &desired, resting, cycle,
+    );
+
+    // The quote center these places are built around — the anti-flicker
+    // anchor stored on each placed quote (equals mark when skew is off).
+    let ref_center = skew_center(cfg, mark, position);
 
     // 4. Execute. Business rejections (post-only would-cross, order already
     //    gone) are expected and logged inline; only transient failures
@@ -220,7 +226,7 @@ pub(super) async fn maker_cycle(
                                 price: q.price,
                                 qty: q.qty,
                                 level: q.level,
-                                ref_mark: mark,
+                                ref_center,
                                 cycle,
                             });
                             places += 1;
@@ -249,7 +255,7 @@ pub(super) async fn maker_cycle(
                         level: q.level,
                         price: q.price,
                         qty: q.qty,
-                        ref_mark: mark,
+                        ref_center,
                         placed_at_cycle: cycle,
                     });
                     places += 1;

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -38,7 +38,7 @@ struct PendingPlace {
     price: f64,
     qty: f64,
     level: u32,
-    ref_mark: f64,
+    ref_center: f64,
     cycle: u64,
 }
 
@@ -84,6 +84,7 @@ pub async fn handle_maker(
             refresh_bps,
             interval,
             max_position,
+            skew_bps,
             max_divergence_bps,
             no_ws,
             live,
@@ -99,6 +100,7 @@ pub async fn handle_maker(
                     refresh_bps,
                     interval,
                     max_position,
+                    skew_bps,
                     max_divergence_bps,
                     no_ws,
                     live,
@@ -120,6 +122,7 @@ struct MakerRunArgs {
     refresh_bps: f64,
     interval: u64,
     max_position: f64,
+    skew_bps: f64,
     max_divergence_bps: f64,
     no_ws: bool,
     live: bool,
@@ -165,6 +168,7 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
         levels: args.levels.max(1),
         size: args.size,
         max_position: args.max_position,
+        skew_bps: args.skew_bps,
         price_decimals: info.price_tick_decimals,
         qty_decimals: info.qty_tick_decimals,
         min_order_qty,
@@ -172,6 +176,9 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
 
     if cfg.spread_bps <= 0.0 {
         return Err(anyhow::anyhow!("--spread-bps must be > 0"));
+    }
+    if cfg.skew_bps < 0.0 {
+        return Err(anyhow::anyhow!("--skew-bps must be >= 0"));
     }
     if cfg.band_bps <= cfg.spread_bps {
         return Err(anyhow::anyhow!(
@@ -240,6 +247,12 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
             "│ size {} | max-position {} | interval {}s",
             cfg.size, cfg.max_position, args.interval
         );
+        if cfg.skew_bps > 0.0 {
+            println!(
+                "│ inventory skew {}bps (live only; paper holds no position)",
+                cfg.skew_bps
+            );
+        }
         println!(
             "│ ticks: price {}dp, qty {}dp | min qty {}",
             cfg.price_decimals, cfg.qty_decimals, cfg.min_order_qty

--- a/crates/standx-sdk/src/maker.rs
+++ b/crates/standx-sdk/src/maker.rs
@@ -36,6 +36,10 @@ pub struct MakerConfig {
     /// Max absolute position; the side that would grow it further is
     /// suppressed once exceeded.
     pub max_position: f64,
+    /// Inventory skew: at full inventory (`|position| == max_position`), the
+    /// quote center is shifted this many bps away from mark to favor the
+    /// reducing side. 0 disables skew (quotes stay centered on mark).
+    pub skew_bps: f64,
     /// Price precision (decimal places) from `SymbolInfo.price_tick_decimals`.
     pub price_decimals: u32,
     /// Quantity precision (decimal places) from `SymbolInfo.qty_tick_decimals`.
@@ -70,15 +74,18 @@ pub struct RestingQuote {
     pub level: u32,
     pub price: f64,
     pub qty: f64,
-    /// Mark price when this quote was placed — the anti-flicker anchor.
-    pub ref_mark: f64,
+    /// The quote center (`skew_center(mark, position)`) when this quote was
+    /// placed — the anti-flicker anchor. Equals the mark at placement when
+    /// skew is off; re-quoting keys off drift of the current center from this.
+    pub ref_center: f64,
     pub placed_at_cycle: u64,
 }
 
 /// Why a resting quote is being cancelled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CancelReason {
-    /// Mark drifted more than `refresh_bps` from the quote's `ref_mark`.
+    /// The quote center drifted more than `refresh_bps` from the quote's
+    /// `ref_center` — driven by mark movement and/or inventory skew.
     MarkMovedBeyondRefresh,
     /// The resting price left the eligibility band (earns nothing there).
     OutsideBand,
@@ -119,7 +126,8 @@ pub enum Action {
         level: u32,
         price: f64,
         age_cycles: u64,
-        /// Current drift from the quote's ref_mark, in bps (for display).
+        /// Current drift of the quote center from the quote's ref_center, in
+        /// bps (for display).
         drift_bps: f64,
     },
 }
@@ -167,13 +175,31 @@ pub fn mark_mid_divergence_bps(mark: f64, best_bid: f64, best_ask: f64) -> f64 {
     bps_diff((best_bid + best_ask) / 2.0, mark)
 }
 
+/// Inventory-skewed quote center.
+///
+/// The quote ladder is built around this instead of mark. Holding a long
+/// position (`position > 0`) shifts the center DOWN, which moves the reducing
+/// side (sell) nearer the true mark (more likely to fill) and the growing side
+/// (buy) further away (less likely to fill) — turning `max_position` from a
+/// hard brake into gradual mean reversion. Short positions shift it up. The
+/// shift scales linearly with inventory and saturates at `skew_bps` when
+/// `|position| >= max_position`. Returns mark unchanged when skew is off or
+/// `max_position` is non-positive.
+pub fn skew_center(cfg: &MakerConfig, mark: f64, position: f64) -> f64 {
+    if cfg.max_position <= 0.0 {
+        return mark;
+    }
+    let inv_ratio = (position / cfg.max_position).clamp(-1.0, 1.0);
+    mark * (1.0 - cfg.skew_bps * inv_ratio / 1e4)
+}
+
 /// Compute the desired quote set for the current market snapshot.
 ///
-/// Applies, in order: the spread/level ladder, the band clamp, the no-cross
-/// clamp, directional tick rounding (with band re-entry), the min-qty filter,
-/// and max-position side suppression. Quotes that fail a guard are dropped;
-/// duplicate prices after clamping/rounding are collapsed (outer level wins
-/// nothing — the inner level is kept).
+/// Applies, in order: the inventory-skewed spread/level ladder, the band clamp,
+/// the no-cross clamp, directional tick rounding (with band re-entry), the
+/// min-qty filter, and max-position side suppression. Quotes that fail a guard
+/// are dropped; duplicate prices after clamping/rounding are collapsed (outer
+/// level wins nothing — the inner level is kept).
 pub fn compute_desired_quotes(
     cfg: &MakerConfig,
     mark: f64,
@@ -192,8 +218,13 @@ pub fn compute_desired_quotes(
     }
 
     let tick = cfg.price_tick();
+    // Band eligibility is defined around the TRUE mark, not the skewed center.
     let band_lo = mark * (1.0 - cfg.band_bps / 1e4);
     let band_hi = mark * (1.0 + cfg.band_bps / 1e4);
+
+    // Ladder is centered on the inventory-skewed price; the band/no-cross
+    // guards below still reference the true mark and touch.
+    let center = skew_center(cfg, mark, position);
 
     let suppress_buy = position >= cfg.max_position;
     let suppress_sell = position <= -cfg.max_position;
@@ -206,8 +237,8 @@ pub fn compute_desired_quotes(
         for level in 0..cfg.levels {
             let offset_bps = cfg.spread_bps + level as f64 * cfg.level_step_bps;
             let mut price = match side {
-                OrderSide::Buy => mark * (1.0 - offset_bps / 1e4),
-                OrderSide::Sell => mark * (1.0 + offset_bps / 1e4),
+                OrderSide::Buy => center * (1.0 - offset_bps / 1e4),
+                OrderSide::Sell => center * (1.0 + offset_bps / 1e4),
             };
 
             // Band clamp: quoting outside the band earns nothing, so clamp
@@ -276,23 +307,31 @@ pub fn compute_desired_quotes(
 /// | 2 | no desired quote at (side, level)                | Cancel (Stale)                |
 /// | 3 | price outside current band                       | Cancel (OutsideBand)          |
 /// | 4 | price crosses current touch                      | Cancel (WouldCross)           |
-/// | 5 | mark drifted > refresh_bps from ref_mark         | Cancel (MarkMovedBeyondRefresh) |
+/// | 5 | quote center drifted > refresh_bps from ref_center | Cancel (MarkMovedBeyondRefresh) |
 /// | 6 | otherwise                                        | Hold (anti-flicker)           |
 ///
-/// Every desired quote without a surviving resting counterpart yields a
-/// `Place`. The returned Vec orders all Cancels before all Places so the
-/// executor frees margin before re-placing; Holds come last.
+/// The center (row 5) is `skew_center(mark, position)`, so this single rule
+/// re-quotes on both mark movement and inventory skew; with skew off it is the
+/// bare mark, identical to prior behavior. Every desired quote without a
+/// surviving resting counterpart yields a `Place`. The returned Vec orders all
+/// Cancels before all Places so the executor frees margin before re-placing;
+/// Holds come last.
+#[allow(clippy::too_many_arguments)]
 pub fn reconcile(
     cfg: &MakerConfig,
     mark: f64,
+    position: f64,
     best_bid: Option<f64>,
     best_ask: Option<f64>,
     desired: &[DesiredQuote],
     resting: &[RestingQuote],
     cycle: u64,
 ) -> Vec<Action> {
+    // Band/no-cross reference the true mark and touch; the anti-flicker anchor
+    // uses the inventory-skewed center.
     let band_lo = mark * (1.0 - cfg.band_bps / 1e4);
     let band_hi = mark * (1.0 + cfg.band_bps / 1e4);
+    let center = skew_center(cfg, mark, position);
 
     let desired_has = |side: OrderSide, level: u32| -> bool {
         desired.iter().any(|d| d.side == side && d.level == level)
@@ -318,7 +357,7 @@ pub fn reconcile(
             OrderSide::Sell => best_bid.map(|b| r.price <= b).unwrap_or(false),
         } {
             Some(CancelReason::WouldCross)
-        } else if bps_diff(mark, r.ref_mark) > cfg.refresh_bps {
+        } else if bps_diff(center, r.ref_center) > cfg.refresh_bps {
             Some(CancelReason::MarkMovedBeyondRefresh)
         } else {
             None
@@ -339,7 +378,7 @@ pub fn reconcile(
                     level: r.level,
                     price: r.price,
                     age_cycles: cycle.saturating_sub(r.placed_at_cycle),
-                    drift_bps: bps_diff(mark, r.ref_mark),
+                    drift_bps: bps_diff(center, r.ref_center),
                 });
             }
         }
@@ -372,20 +411,21 @@ mod tests {
             levels: 1,
             size: 0.01,
             max_position: 0.05,
+            skew_bps: 0.0,
             price_decimals: 2,
             qty_decimals: 4,
             min_order_qty: 0.001,
         }
     }
 
-    fn resting(side: OrderSide, level: u32, price: f64, ref_mark: f64) -> RestingQuote {
+    fn resting(side: OrderSide, level: u32, price: f64, ref_center: f64) -> RestingQuote {
         RestingQuote {
             order_id: Some("1".into()),
             side,
             level,
             price,
             qty: 0.01,
-            ref_mark,
+            ref_center,
             placed_at_cycle: 0,
         }
     }
@@ -499,7 +539,7 @@ mod tests {
             resting(OrderSide::Buy, 0, 99.90, 100.0),
             resting(OrderSide::Sell, 0, 100.10, 100.0),
         ];
-        let actions = reconcile(&c, mark, None, None, &desired, &rest, 7);
+        let actions = reconcile(&c, mark, 0.0, None, None, &desired, &rest, 7);
         assert!(
             actions.iter().all(|a| matches!(a, Action::Hold { .. })),
             "{actions:?}"
@@ -517,7 +557,7 @@ mod tests {
         let mark = 100.05; // 5 bps > refresh 3
         let desired = compute_desired_quotes(&c, mark, None, None, 0.0);
         let rest = vec![resting(OrderSide::Buy, 0, 99.90, 100.0)];
-        let actions = reconcile(&c, mark, None, None, &desired, &rest, 1);
+        let actions = reconcile(&c, mark, 0.0, None, None, &desired, &rest, 1);
         // Expect: cancel(buy, mark_moved), then places for buy+sell.
         assert!(matches!(
             actions[0],
@@ -543,7 +583,7 @@ mod tests {
         let mark = 100.30;
         let desired = compute_desired_quotes(&c, mark, None, None, 0.0);
         let rest = vec![resting(OrderSide::Buy, 0, 99.90, 100.0)];
-        let actions = reconcile(&c, mark, None, None, &desired, &rest, 1);
+        let actions = reconcile(&c, mark, 0.0, None, None, &desired, &rest, 1);
         assert!(
             matches!(
                 actions[0],
@@ -564,7 +604,16 @@ mod tests {
         let desired = compute_desired_quotes(&c, mark, Some(100.12), Some(100.14), 0.0);
         // Resting sell at 100.10 now BELOW best bid 100.12 -> crossed.
         let rest = vec![resting(OrderSide::Sell, 0, 100.10, 100.0)];
-        let actions = reconcile(&c, mark, Some(100.12), Some(100.14), &desired, &rest, 1);
+        let actions = reconcile(
+            &c,
+            mark,
+            0.0,
+            Some(100.12),
+            Some(100.14),
+            &desired,
+            &rest,
+            1,
+        );
         assert!(
             matches!(
                 actions[0],
@@ -587,7 +636,7 @@ mod tests {
             resting(OrderSide::Buy, 0, 99.90, 100.0),
             resting(OrderSide::Buy, 1, 99.88, 100.0), // stale level
         ];
-        let actions = reconcile(&c, mark, None, None, &desired, &rest, 1);
+        let actions = reconcile(&c, mark, 0.0, None, None, &desired, &rest, 1);
         let stale: Vec<_> = actions
             .iter()
             .filter(|a| {
@@ -653,5 +702,115 @@ mod tests {
         assert!((mark_mid_divergence_bps(100.0, 99.7, 99.8) - 25.0).abs() < 1e-9);
         // degenerate mark = 0 -> 0.0, no blowup
         assert_eq!(mark_mid_divergence_bps(0.0, 99.9, 100.1), 0.0);
+    }
+
+    // 16. skew_center helper: directional, zero cases.
+    #[test]
+    fn skew_center_directional() {
+        let mut c = cfg();
+        c.skew_bps = 10.0;
+        // flat position -> center = mark
+        assert_eq!(skew_center(&c, 100.0, 0.0), 100.0);
+        // long (ratio +0.5) -> center down 99.95
+        assert!((skew_center(&c, 100.0, 0.025) - 99.95).abs() < 1e-9);
+        // short (ratio -0.5) -> center up 100.05
+        assert!((skew_center(&c, 100.0, -0.025) - 100.05).abs() < 1e-9);
+        // skew off -> center = mark regardless of position
+        let c0 = cfg();
+        assert_eq!(skew_center(&c0, 100.0, 0.05), 100.0);
+    }
+
+    // 17. Long inventory shifts the whole ladder down; reducing side (sell)
+    // moves nearer mark, growing side (buy) further.
+    #[test]
+    fn skew_long_shifts_center_down() {
+        let mut c = cfg();
+        c.skew_bps = 10.0;
+        // half-max long -> center 99.95; buy = 99.85, sell = 100.05
+        let q = compute_desired_quotes(&c, 100.0, None, None, 0.025);
+        assert_eq!(find(&q, OrderSide::Buy, 0).price, 99.85);
+        assert_eq!(find(&q, OrderSide::Sell, 0).price, 100.05);
+        // both below the no-skew baseline (99.90 / 100.10)
+        assert!(find(&q, OrderSide::Buy, 0).price < 99.90);
+        assert!(find(&q, OrderSide::Sell, 0).price < 100.10);
+    }
+
+    // 18. Short inventory shifts up; reducing side (buy) nearer mark.
+    #[test]
+    fn skew_short_shifts_center_up() {
+        let mut c = cfg();
+        c.skew_bps = 10.0;
+        // half-max short -> center 100.05; buy = 99.94, sell = 100.16
+        let q = compute_desired_quotes(&c, 100.0, None, None, -0.025);
+        assert_eq!(find(&q, OrderSide::Buy, 0).price, 99.94);
+        assert_eq!(find(&q, OrderSide::Sell, 0).price, 100.16);
+        // buy moved nearer mark than the no-skew baseline 99.90
+        assert!(find(&q, OrderSide::Buy, 0).price > 99.90);
+    }
+
+    // 19. skew_bps = 0 is a no-op regardless of position.
+    #[test]
+    fn skew_zero_is_noop() {
+        let c = cfg(); // skew_bps = 0
+        let base = compute_desired_quotes(&c, 100.0, None, None, 0.0);
+        let with_pos = compute_desired_quotes(&c, 100.0, None, None, 0.025);
+        assert_eq!(base, with_pos);
+    }
+
+    // 20. Inventory ratio saturates at ±1 past max_position.
+    #[test]
+    fn skew_clamps_at_full_inventory() {
+        let mut c = cfg();
+        c.skew_bps = 10.0;
+        // 2x max short: growing side (sell) suppressed, only buy remains;
+        // ratio clamps to -1 -> center 100.10 -> buy 99.99 (NOT the ratio=-2
+        // value 100.09).
+        let q = compute_desired_quotes(&c, 100.0, None, None, -0.10);
+        assert!(q.iter().all(|d| d.side == OrderSide::Buy));
+        assert_eq!(find(&q, OrderSide::Buy, 0).price, 99.99);
+    }
+
+    // 21. Large skew still respects the band and no-cross guards.
+    #[test]
+    fn skew_still_respects_band_and_no_cross() {
+        let mut c = cfg();
+        c.skew_bps = 100.0; // would push the sell far below mark
+        let (bid, ask) = (99.90, 100.00);
+        // full long: buy suppressed; sell pulled down hard but held above the
+        // band floor and one tick above the bid.
+        let q = compute_desired_quotes(&c, 100.0, Some(bid), Some(ask), 0.05);
+        let sell = find(&q, OrderSide::Sell, 0).price;
+        assert!(sell >= 99.80 - 1e-9, "sell {sell} below band floor");
+        assert!(sell > bid, "sell {sell} crosses bid {bid}");
+    }
+
+    // 22. Inventory skew alone (mark unchanged) triggers a re-quote once the
+    // center drifts past refresh_bps; stays held within it.
+    #[test]
+    fn reconcile_skew_requote() {
+        let mut c = cfg();
+        c.skew_bps = 10.0;
+        let mark = 100.0;
+        // Resting sell placed when flat (ref_center = 100.0).
+        // Long 0.025 -> center 99.95, drift 5bps > refresh 3 -> re-quote.
+        let pos = 0.025;
+        let desired = compute_desired_quotes(&c, mark, None, None, pos);
+        let rest = vec![resting(OrderSide::Sell, 0, 100.10, 100.0)];
+        let actions = reconcile(&c, mark, pos, None, None, &desired, &rest, 1);
+        assert!(actions.iter().any(|a| matches!(
+            a,
+            Action::Cancel {
+                reason: CancelReason::MarkMovedBeyondRefresh,
+                ..
+            }
+        )));
+
+        // Smaller long 0.01 -> center 99.98, drift 2bps < refresh -> hold.
+        let pos2 = 0.01;
+        let desired2 = compute_desired_quotes(&c, mark, None, None, pos2);
+        let rest2 = vec![resting(OrderSide::Sell, 0, 100.10, 100.0)];
+        let actions2 = reconcile(&c, mark, pos2, None, None, &desired2, &rest2, 1);
+        assert!(actions2.iter().any(|a| matches!(a, Action::Hold { .. })));
+        assert!(!actions2.iter().any(|a| matches!(a, Action::Cancel { .. })));
     }
 }


### PR DESCRIPTION
## What

Adds **inventory skew** to the maker bot (#4 on the roadmap): the quote center shifts with current position so the side that reduces inventory quotes more aggressively.

Passive market making has adverse selection built in — buys fill on the way down, sells on the way up, so inventory drifts toward the losing side. The only defense so far was the `--max-position` hard brake (all-or-nothing side suppression). Skew turns that cliff into a gradual mean-reversion force.

## How it works

Holding **long** moves the quote center DOWN, so the reducing side (sell) sits nearer the true mark (more likely to fill) and the growing side (buy) further away (less likely). Short is symmetric. The shift scales linearly with inventory and saturates at `--skew-bps` when `|position| == max_position`, handing off to the existing hard suppression at the limit.

```
center = mark · (1 − skew_bps · clamp(position/max_position, ±1) / 1e4)
```

**Anti-flicker anchor generalized.** The core tension: `reconcile` matched resting↔desired by `(side, level)` and re-quoted only on `mark` drift — so a skewed target price would never actually be quoted in a calm market (old quotes just stay HELD). Fix: the anchor generalizes from *"mark at placement"* (`ref_mark`) to *"quote center at placement"* (`ref_center = skew_center(mark, position)`). One re-quote rule now reacts to **both** mark drift and inventory skew. With `--skew-bps 0` (default) the center is the bare mark, so behavior is byte-for-byte unchanged.

**Guards unaffected.** Band eligibility and the no-cross clamp still key off the true mark and touch — skew moves quotes *within* the band, never outside it.

## Changes

- `standx_sdk::maker`: new pure `skew_center()` helper; `MakerConfig.skew_bps`; `compute_desired_quotes` centers the ladder on it; `RestingQuote.ref_mark` → `ref_center`; `reconcile` gains a `position` arg and compares current center vs `ref_center`.
- CLI: `--skew-bps` flag (default `0`), validation (`>= 0`), banner line, wired through `commands/maker/{mod,cycle}.rs`.
- 7 new unit tests (directional shift, zero-is-noop, full-inventory clamp, band/no-cross still enforced, skew-driven re-quote). **140 tests total**, `clippy --workspace --all-targets` clean, `fmt` clean.

## Verification

- `cargo test` (140, +7), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` — all green
- Paper smoke: default run unchanged (no skew banner line); `--skew-bps 5` shows the banner line; `--skew-bps=-1` rejected

## Known limitation

Skew only activates with a nonzero position, which **paper mode never holds** (fills aren't simulated) — so it's observable only via unit tests or live. **Paper fill simulation** is the natural next step and would make skew (and inventory PnL telemetry, #5) visible without going live. Live order paths remain locked behind `STANDX_ENABLE_LIVE_MAKER=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)