### PR TITLE
docs: correct & complete API documentation + fix Homebrew test

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -37,6 +37,14 @@ Where `payload` is the request body (or empty string for GET requests).
 
 ## Public Endpoints
 
+### Health Check
+
+```http
+GET /api/health
+```
+
+Liveness probe; returns 200 when the API is up.
+
 ### Get Symbol Info
 
 ```http
@@ -88,6 +96,26 @@ Returns market data including funding rate.
 }
 ```
 
+### Get Symbol Price
+
+```http
+GET /api/query_symbol_price?symbol=BTC-USD
+```
+
+Returns the lightweight price ticker (mark / index / last). Used by the
+maker bot and `standx market ticker`.
+
+**Response:**
+```json
+{
+  "symbol": "BTC-USD",
+  "mark_price": "63127.37",
+  "index_price": "63126.67",
+  "last_price": "63115.80",
+  "time": "2026-02-24T08:06:48.645735Z"
+}
+```
+
 ### Get Order Book Depth
 
 ```http
@@ -135,14 +163,14 @@ Returns recent trades.
 ### Get Kline History
 
 ```http
-GET /api/kline/history?symbol=BTC-USD&resolution=1h&from=1704067200&to=1706659200
+GET /api/kline/history?symbol=BTC-USD&resolution=60&from=1704067200&to=1706659200
 ```
 
 Returns historical kline/candlestick data.
 
 **Parameters:**
 - `symbol`: Trading pair symbol
-- `resolution`: Time resolution (1m, 5m, 15m, 1h, 4h, 1d)
+- `resolution`: Minutes (`1`, `5`, `15`, `30`, `60`, `240`, `720`) or `1D` / `1W` / `1M`
 - `from`: Start timestamp (Unix seconds)
 - `to`: End timestamp (Unix seconds)
 
@@ -339,6 +367,109 @@ x-request-signature: <SIGNATURE>
 
 Cancels multiple orders.
 
+### Get Order History
+
+```http
+GET /api/query_orders?status=filled&symbol=BTC-USD&limit=50
+Authorization: Bearer <JWT>
+```
+
+Returns historical (filled) orders. Wrapped in `{ "result": [...] }`.
+
+**Response:**
+```json
+{
+  "result": [
+    {
+      "id": "12345",
+      "symbol": "BTC-USD",
+      "side": "Buy",
+      "type": "Limit",
+      "quantity": "0.1",
+      "filled_quantity": "0.1",
+      "price": "62000",
+      "status": "Filled",
+      "created_at": "2026-02-24T08:00:00Z",
+      "updated_at": "2026-02-24T08:01:00Z"
+    }
+  ]
+}
+```
+
+### Get User Trades
+
+```http
+GET /api/query_trades?symbol=BTC-USD&from=1704067200&to=1706659200&limit=100
+Authorization: Bearer <JWT>
+```
+
+Returns the caller's own trade (fill) history. Wrapped in `{ "result": [...] }`.
+
+### Get Position Config
+
+```http
+GET /api/query_position_config?symbol=BTC-USD
+Authorization: Bearer <JWT>
+```
+
+Returns per-symbol leverage and margin configuration.
+
+**Response:**
+```json
+{
+  "symbol": "BTC-USD",
+  "leverage": "10",
+  "max_leverage": "40",
+  "def_leverage": "10",
+  "margin_mode": "cross"
+}
+```
+
+### Change Leverage
+
+```http
+POST /api/change_leverage
+Authorization: Bearer <JWT>
+Content-Type: application/json
+
+{
+  "symbol": "BTC-USD",
+  "leverage": 20
+}
+```
+
+### Change Margin Mode
+
+```http
+POST /api/change_margin_mode
+Authorization: Bearer <JWT>
+Content-Type: application/json
+
+{
+  "symbol": "BTC-USD",
+  "margin_mode": "cross"
+}
+```
+
+### Transfer Margin
+
+```http
+POST /api/transfer_margin
+Authorization: Bearer <JWT>
+Content-Type: application/json
+
+{
+  "symbol": "BTC-USD",
+  "amount_in": "100.0"
+}
+```
+
+Adjusts isolated-position margin. `amount_in` is positive to add margin,
+negative to withdraw.
+
+> All authenticated `POST` endpoints require the full signing headers
+> (`x-request-*`) shown under [Create Order](#create-order).
+
 ## WebSocket API
 
 ### Connection
@@ -347,19 +478,25 @@ Connect to `wss://perps.standx.com/ws-stream/v1`
 
 ### Authentication
 
-Send authentication message immediately after connection:
+Send an authentication message immediately after connection. Public
+channels (`price`, `depth_book`, `public_trade`, `kline`) can be subscribed
+without auth; user channels (`order`, `position`, `balance`) require the
+token. The SDK lists the intended streams in the auth frame:
 
 ```json
 {
   "auth": {
-    "token": "eyJ..."
+    "token": "eyJ...",
+    "streams": [
+      { "channel": "price", "symbol": "BTC-USD" }
+    ]
   }
 }
 ```
 
 ### Subscription
 
-Subscribe to channels after successful authentication:
+Send a subscribe frame per channel (public channels need no prior auth):
 
 ```json
 {

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -287,7 +287,7 @@ Creates a new order.
 - `order_type`: `limit` or `market`
 - `qty`: Order quantity
 - `price`: Order price (required for limit orders)
-- `time_in_force`: `GTC`, `IOC`, or `FOK`
+- `time_in_force`: `GTC`, `ALO`, or `IOC` (`ALO` = add-liquidity-only / post-only)
 - `reduce_only`: Close position only
 - `sl_price`: Stop-loss price (optional)
 - `tp_price`: Take-profit price (optional)
@@ -487,8 +487,8 @@ Order updates (authenticated).
 
 ### Time in Force
 - `GTC` - Good Till Cancel
+- `ALO` - Add Liquidity Only (post-only; rejects if it would cross)
 - `IOC` - Immediate or Cancel
-- `FOK` - Fill or Kill
 
 ### Order Status
 - `New` - New order

--- a/HOMEBREW.md
+++ b/HOMEBREW.md
@@ -80,7 +80,7 @@ class StandxCli < Formula
 
   test do
     assert_match "standx #{version}", shell_output("#{bin}/standx --version")
-    assert_match "A CLI tool for StandX perpetual DEX", shell_output("#{bin}/standx --help")
+    assert_match "Usage: standx", shell_output("#{bin}/standx --help")
   end
 end
 ```

--- a/homebrew/standx-cli.rb
+++ b/homebrew/standx-cli.rb
@@ -14,6 +14,7 @@ class StandxCli < Formula
 
   test do
     assert_match "standx #{version}", shell_output("#{bin}/standx --version")
-    assert_match "A CLI tool for StandX perpetual DEX", shell_output("#{bin}/standx --help")
+    # Stable across branding changes: clap always prints the usage line.
+    assert_match "Usage: standx", shell_output("#{bin}/standx --help")
   end
 end


### PR DESCRIPTION
A correctness + completeness pass over `API_DOCUMENTATION.md`, plus a real Homebrew formula bug. All changes verified against the SDK client (the source of truth).

## Homebrew: `brew test` would fail (real bug)

`homebrew/standx-cli.rb` (and the example in `HOMEBREW.md`) asserted the `--help` output contains **"A CLI tool for StandX perpetual DEX"**, but the actual clap `about` is **"OpenClaw-first AI Agent trading toolkit"** — so the formula's test block would fail. Changed to assert **`"Usage: standx"`** (clap always prints it; won't drift with branding). The `--version` assertion was already correct.

## API doc: Time-in-Force was wrong

Listed `GTC / IOC / FOK`; the backend enum is **GTC / ALO / IOC** — FOK is unsupported and **ALO** (post-only) is what the maker bot uses. Fixed the request-field note and the Data Types list.

## API doc: missing endpoints added

The doc predated the leverage/margin/history commands and the maker bot. Added, with real request/response shapes:

- **Public**: `health`, `query_symbol_price` (mark/index/last — used by the maker + `market ticker`)
- **Authenticated**: `query_orders` (order history), `query_trades` (user trade history), `query_position_config`, `change_leverage`, `change_margin_mode`, `transfer_margin` — including the `{ "result": [...] }` list wrapper where the client uses it

## API doc: other fixes

- Kline `resolution` format corrected (`1/5/15/30/60/240/720` minutes + `1D/1W/1M`, not `1h/4h/1d`) and the example URL.
- WebSocket auth frame corrected to include the `streams` array the SDK actually sends; noted which channels require auth.

Verification: `comm` between the client's `/api/` endpoints and the doc now shows **full coverage**, and no `FOK` residue remains. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)