### PR TITLE
fix: redact maker webhook secrets from telemetry

### DIFF
--- a/crates/standx-cli/src/main.rs
+++ b/crates/standx-cli/src/main.rs
@@ -62,23 +62,26 @@ async fn main() {
     }
 
     // Track command start
-    let command_name = format!("{:?}", cli.command);
+    // Keep telemetry useful without serializing command fields. Several
+    // commands carry credentials or webhook URLs, so a Debug representation
+    // must never be written to the local telemetry log.
+    let command_name = command_name(&cli.command);
     let args: Vec<String> = std::env::args().collect();
-    telemetry.track_command_start(&command_name, &args);
+    telemetry.track_command_start(command_name, &args);
 
     // Handle dry run mode
     if cli.dry_run {
         let output = cli.output;
         match handle_dry_run(&cli.command, output).await {
             Ok(_) => {
-                telemetry.track_command_complete(&command_name, true, None);
+                telemetry.track_command_complete(command_name, true, None);
                 std::process::exit(0);
             }
             Err(e) => {
                 let boxed_error: Box<dyn std::error::Error> = Box::new(e);
                 print_error(&boxed_error, output);
                 telemetry.track_command_complete(
-                    &command_name,
+                    command_name,
                     false,
                     Some(&boxed_error.to_string()),
                 );
@@ -99,13 +102,32 @@ async fn main() {
     // Execute command and handle errors
     match execute_command(cli.command, output, cli.verbose).await {
         Ok(_) => {
-            telemetry.track_command_complete(&command_name, true, None);
+            telemetry.track_command_complete(command_name, true, None);
         }
         Err(e) => {
             print_error(&e, output);
-            telemetry.track_command_complete(&command_name, false, Some(&e.to_string()));
+            telemetry.track_command_complete(command_name, false, Some(&e.to_string()));
             std::process::exit(1);
         }
+    }
+}
+
+/// Stable, non-sensitive telemetry label for the top-level command.
+fn command_name(command: &Commands) -> &'static str {
+    match command {
+        Commands::Config { .. } => "config",
+        Commands::Auth { .. } => "auth",
+        Commands::Market { .. } => "market",
+        Commands::Account { .. } => "account",
+        Commands::Order { .. } => "order",
+        Commands::Trade { .. } => "trade",
+        Commands::Leverage { .. } => "leverage",
+        Commands::Margin { .. } => "margin",
+        Commands::Stream { .. } => "stream",
+        Commands::Dashboard { .. } => "dashboard",
+        Commands::Portfolio { .. } => "portfolio",
+        Commands::Block { .. } => "block",
+        Commands::Maker { .. } => "maker",
     }
 }
 

--- a/crates/standx-cli/src/telemetry.rs
+++ b/crates/standx-cli/src/telemetry.rs
@@ -123,22 +123,7 @@ impl Telemetry {
     /// Track command execution start
     pub fn track_command_start(&mut self, command: &str, args: &[String]) {
         self.command_start = Some(Instant::now());
-
-        // Sanitize args - remove sensitive data
-        let sanitized_args: Vec<String> = args
-            .iter()
-            .map(|arg| {
-                // Hide potential sensitive values after certain flags
-                if arg.starts_with("--private-key")
-                    || arg.starts_with("--token")
-                    || arg.starts_with("-p")
-                {
-                    format!("{}=***", arg.split('=').next().unwrap_or(arg))
-                } else {
-                    arg.clone()
-                }
-            })
-            .collect();
+        let sanitized_args = sanitize_args(args);
 
         self.track_event(
             EventType::CommandStarted,
@@ -227,6 +212,41 @@ impl Telemetry {
     }
 }
 
+/// Redact secrets from CLI argv while preserving the flag names needed for
+/// aggregate usage analysis. Handles both `--flag value` and `--flag=value`.
+fn sanitize_args(args: &[String]) -> Vec<String> {
+    const SENSITIVE_FLAGS: &[&str] = &["--private-key", "--token", "--alert-webhook", "-p"];
+
+    let mut sanitized = Vec::with_capacity(args.len());
+    let mut redact_next = false;
+
+    for arg in args {
+        if redact_next {
+            sanitized.push("***".to_string());
+            redact_next = false;
+            continue;
+        }
+
+        if SENSITIVE_FLAGS.contains(&arg.as_str()) {
+            sanitized.push(arg.clone());
+            redact_next = true;
+            continue;
+        }
+
+        if let Some(flag) = SENSITIVE_FLAGS
+            .iter()
+            .find(|flag| arg.starts_with(&format!("{}=", flag)))
+        {
+            sanitized.push(format!("{}=***", flag));
+            continue;
+        }
+
+        sanitized.push(arg.clone());
+    }
+
+    sanitized
+}
+
 impl Drop for Telemetry {
     fn drop(&mut self) {
         // Ensure any pending events are written
@@ -263,5 +283,50 @@ mod tests {
         let _telemetry = Telemetry::new();
         // Note: This might fail if user has env var set
         // In real tests, use a temp directory
+    }
+
+    #[test]
+    fn sanitize_args_redacts_separate_sensitive_values() {
+        let args = vec![
+            "standx".to_string(),
+            "maker".to_string(),
+            "run".to_string(),
+            "BTC-USD".to_string(),
+            "--alert-webhook".to_string(),
+            "https://api.telegram.org/bot-secret/sendMessage".to_string(),
+            "--token".to_string(),
+            "jwt-secret".to_string(),
+        ];
+
+        let sanitized = sanitize_args(&args);
+        assert_eq!(sanitized[4], "--alert-webhook");
+        assert_eq!(sanitized[5], "***");
+        assert_eq!(sanitized[6], "--token");
+        assert_eq!(sanitized[7], "***");
+        assert!(!sanitized.join(" ").contains("secret"));
+    }
+
+    #[test]
+    fn sanitize_args_redacts_equals_form_and_preserves_other_args() {
+        let args = vec![
+            "standx".to_string(),
+            "auth".to_string(),
+            "login".to_string(),
+            "--private-key=private-secret".to_string(),
+            "--alert-webhook=https://hooks.example/secret".to_string(),
+            "--output=json".to_string(),
+        ];
+
+        assert_eq!(
+            sanitize_args(&args),
+            vec![
+                "standx",
+                "auth",
+                "login",
+                "--private-key=***",
+                "--alert-webhook=***",
+                "--output=json",
+            ]
+        );
     }
 }


### PR DESCRIPTION
## What changed

- replace full Debug command serialization with stable top-level command labels
- redact sensitive CLI values in both `--flag value` and `--flag=value` forms
- treat `--alert-webhook` as sensitive so Telegram bot tokens and webhook credentials never reach local telemetry
- add regression tests for separate and equals-style arguments

## Why

Maker webhook URLs can contain credentials. The previous telemetry path recorded the full parsed command and did not redact the value following `--alert-webhook`, allowing tokens to be written to the local telemetry log.

## Impact

Telemetry retains useful command and flag names while removing credential values. Maker behavior and live gating are unchanged.

## Validation

- `cargo fmt --check`
- `cargo test -p standx-cli telemetry --offline`
- dry-run smoke test with a fake webhook secret; the telemetry file contained `"command":"maker"` and `"***"`, with no secret value
