### PR TITLE
fix: harden maker market data guards

### DIFF
--- a/crates/standx-cli/src/commands/maker/feed.rs
+++ b/crates/standx-cli/src/commands/maker/feed.rs
@@ -102,7 +102,9 @@ pub(super) async fn market_snapshot(
             |at: Option<std::time::Instant>| at.is_some_and(|t| t.elapsed() < WS_STALE_AFTER);
         if fresh(s.mark_at) && fresh(s.book_at) {
             if let Some(mark) = s.mark {
-                return Ok((mark, s.best_bid, s.best_ask, "ws"));
+                if let Ok(snapshot) = validated_snapshot(mark, s.best_bid, s.best_ask, "ws") {
+                    return Ok(snapshot);
+                }
             }
         }
     }
@@ -119,5 +121,49 @@ pub(super) async fn market_snapshot(
         .map_err(|_| anyhow::anyhow!("unparseable mark price: {}", price.mark_price))?;
     let best_bid: Option<f64> = depth.best_bid().and_then(|s| s.parse().ok());
     let best_ask: Option<f64> = depth.best_ask().and_then(|s| s.parse().ok());
-    Ok((mark, best_bid, best_ask, "rest"))
+    validated_snapshot(mark, best_bid, best_ask, "rest")
+}
+
+fn validated_snapshot(
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    source: &'static str,
+) -> Result<(f64, Option<f64>, Option<f64>, &'static str)> {
+    if !mark.is_finite() || mark <= 0.0 {
+        return Err(anyhow::anyhow!("invalid mark price from {source}: {mark}"));
+    }
+    if best_bid.is_some_and(|price| !price.is_finite() || price <= 0.0) {
+        return Err(anyhow::anyhow!("invalid best bid from {source}"));
+    }
+    if best_ask.is_some_and(|price| !price.is_finite() || price <= 0.0) {
+        return Err(anyhow::anyhow!("invalid best ask from {source}"));
+    }
+    if let (Some(bid), Some(ask)) = (best_bid, best_ask) {
+        if bid >= ask {
+            return Err(anyhow::anyhow!(
+                "crossed order book from {source}: bid {bid} >= ask {ask}"
+            ));
+        }
+    }
+
+    Ok((mark, best_bid, best_ask, source))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_validation_accepts_valid_and_one_sided_books() {
+        assert!(validated_snapshot(100.0, Some(99.9), Some(100.1), "test").is_ok());
+        assert!(validated_snapshot(100.0, Some(99.9), None, "test").is_ok());
+    }
+
+    #[test]
+    fn snapshot_validation_rejects_non_finite_and_crossed_books() {
+        assert!(validated_snapshot(f64::NAN, Some(99.9), Some(100.1), "test").is_err());
+        assert!(validated_snapshot(100.0, Some(f64::INFINITY), Some(100.1), "test").is_err());
+        assert!(validated_snapshot(100.0, Some(100.1), Some(100.1), "test").is_err());
+    }
 }

--- a/crates/standx-sdk/src/maker.rs
+++ b/crates/standx-sdk/src/maker.rs
@@ -548,7 +548,11 @@ pub fn compute_desired_quotes(
     position: f64,
 ) -> Vec<DesiredQuote> {
     let mut out = Vec::new();
-    if mark <= 0.0 {
+    if !mark.is_finite()
+        || mark <= 0.0
+        || best_bid.is_some_and(|price| !price.is_finite() || price <= 0.0)
+        || best_ask.is_some_and(|price| !price.is_finite() || price <= 0.0)
+    {
         return out;
     }
 
@@ -576,29 +580,34 @@ pub fn compute_desired_quotes(
         let mut last_price: Option<f64> = None;
         for level in 0..cfg.levels {
             let offset_bps = cfg.spread_bps + level as f64 * cfg.level_step_bps;
-            let mut price = match side {
+            let raw_price = match side {
                 OrderSide::Buy => center * (1.0 - offset_bps / 1e4),
                 OrderSide::Sell => center * (1.0 + offset_bps / 1e4),
             };
 
-            // Band clamp: quoting outside the band earns nothing, so clamp
-            // back to the edge (still eligible).
-            price = price.clamp(band_lo, band_hi);
-
-            // No-cross clamp: without relying solely on ALO rejection, never
-            // price through the touch. One tick of safety margin.
-            match side {
-                OrderSide::Buy => {
-                    if let Some(ask) = best_ask {
-                        price = price.min(ask - tick);
-                    }
-                }
-                OrderSide::Sell => {
-                    if let Some(bid) = best_bid {
-                        price = price.max(bid + tick);
-                    }
-                }
+            // Intersect the eligibility band with the post-only no-cross
+            // interval. If no tick can satisfy both, omit this side instead of
+            // emitting a quote outside the band or relying on ALO rejection.
+            let (price_lo, price_hi) = match side {
+                OrderSide::Buy => (
+                    band_lo,
+                    best_ask.map_or(band_hi, |ask| band_hi.min(ask - tick)),
+                ),
+                OrderSide::Sell => (
+                    best_bid.map_or(band_lo, |bid| band_lo.max(bid + tick)),
+                    band_hi,
+                ),
+            };
+            let price_tolerance = tick * 1e-6;
+            if !raw_price.is_finite()
+                || !price_lo.is_finite()
+                || !price_hi.is_finite()
+                || price_lo > price_hi + price_tolerance
+            {
+                continue;
             }
+
+            let mut price = raw_price.clamp(price_lo, price_hi);
 
             // Directional tick rounding: away from mark, so rounding never
             // pushes us through the touch.
@@ -607,15 +616,22 @@ pub fn compute_desired_quotes(
                 OrderSide::Sell => ceil_to_decimals(price, cfg.price_decimals),
             };
 
-            // Rounding may have pushed the price just outside the band —
-            // nudge one tick back toward mark.
-            if price < band_lo {
-                price = floor_to_decimals(price + tick, cfg.price_decimals);
-            } else if price > band_hi {
-                price = ceil_to_decimals(price - tick, cfg.price_decimals);
+            // Directional rounding can leave the feasible interval when the
+            // band boundary is not tick-aligned. Snap back to the nearest
+            // valid tick, then re-check every constraint.
+            if price < price_lo {
+                price = ceil_to_decimals(price_lo, cfg.price_decimals);
+            } else if price > price_hi {
+                price = floor_to_decimals(price_hi, cfg.price_decimals);
             }
 
-            if price <= 0.0 {
+            if !price.is_finite()
+                || price <= 0.0
+                || price < price_lo - price_tolerance
+                || price > price_hi + price_tolerance
+                || best_ask.is_some_and(|ask| side == OrderSide::Buy && price >= ask)
+                || best_bid.is_some_and(|bid| side == OrderSide::Sell && price <= bid)
+            {
                 continue;
             }
 
@@ -832,6 +848,7 @@ mod tests {
         // Best ask (99.85) sits BELOW our raw buy (99.90): buy must clamp
         // down to ask - tick.
         let quotes = compute_desired_quotes(&cfg(), 100.0, Some(99.83), Some(99.85), 0.0);
+        assert_eq!(quotes.len(), 2, "{quotes:?}");
         let buy = find(&quotes, OrderSide::Buy, 0);
         let sell = find(&quotes, OrderSide::Sell, 0);
         // buy clamped to ask - tick = 99.84
@@ -843,6 +860,22 @@ mod tests {
         let quotes = compute_desired_quotes(&cfg(), 100.0, Some(100.15), Some(100.20), 0.0);
         let sell = find(&quotes, OrderSide::Sell, 0);
         assert_eq!(sell.price, 100.16);
+    }
+
+    #[test]
+    fn drops_side_when_band_and_no_cross_have_no_feasible_tick() {
+        let quotes = compute_desired_quotes(&cfg(), 100.0, Some(99.78), Some(99.79), 0.0);
+        assert!(quotes.iter().all(|quote| quote.side == OrderSide::Sell));
+
+        let quotes = compute_desired_quotes(&cfg(), 100.0, Some(100.21), Some(100.22), 0.0);
+        assert!(quotes.iter().all(|quote| quote.side == OrderSide::Buy));
+    }
+
+    #[test]
+    fn invalid_market_values_produce_no_quotes() {
+        assert!(compute_desired_quotes(&cfg(), f64::NAN, None, None, 0.0).is_empty());
+        assert!(compute_desired_quotes(&cfg(), 100.0, Some(f64::INFINITY), None, 0.0).is_empty());
+        assert!(compute_desired_quotes(&cfg(), 100.0, None, Some(0.0), 0.0).is_empty());
     }
 
     // 6. Size below min_order_qty -> no quotes at all.
@@ -1200,6 +1233,7 @@ mod tests {
         // full long: buy suppressed; sell pulled down hard but held above the
         // band floor and one tick above the bid.
         let q = compute_desired_quotes(&c, 100.0, Some(bid), Some(ask), 0.05);
+        assert_eq!(q.len(), 1, "{q:?}");
         let sell = find(&q, OrderSide::Sell, 0).price;
         assert!(sell >= 99.80 - 1e-9, "sell {sell} below band floor");
         assert!(sell > bid, "sell {sell} crosses bid {bid}");

--- a/crates/standx-sdk/src/models.rs
+++ b/crates/standx-sdk/src/models.rs
@@ -176,12 +176,26 @@ pub struct OrderBook {
 impl OrderBook {
     /// Get best bid price
     pub fn best_bid(&self) -> Option<&str> {
-        self.bids.first().map(|b| b[0].as_str())
+        self.bids
+            .iter()
+            .filter_map(|level| {
+                let price = level[0].parse::<f64>().ok()?;
+                (price.is_finite() && price > 0.0).then_some((price, level[0].as_str()))
+            })
+            .max_by(|(left, _), (right, _)| left.total_cmp(right))
+            .map(|(_, price)| price)
     }
 
     /// Get best ask price
     pub fn best_ask(&self) -> Option<&str> {
-        self.asks.first().map(|a| a[0].as_str())
+        self.asks
+            .iter()
+            .filter_map(|level| {
+                let price = level[0].parse::<f64>().ok()?;
+                (price.is_finite() && price > 0.0).then_some((price, level[0].as_str()))
+            })
+            .min_by(|(left, _), (right, _)| left.total_cmp(right))
+            .map(|(_, price)| price)
     }
 
     /// Get spread between best bid and ask
@@ -919,22 +933,23 @@ mod tests {
     #[test]
     fn test_order_book_sorting() {
         // Server might return unsorted data
-        let _book = OrderBook {
+        let book = OrderBook {
             symbol: "BTC-USD".to_string(),
             bids: vec![
                 ["67900".to_string(), "2.0".to_string()],
+                ["not-a-price".to_string(), "9.0".to_string()],
                 ["68000".to_string(), "1.0".to_string()],
             ],
             asks: vec![
                 ["68200".to_string(), "1.0".to_string()],
+                ["NaN".to_string(), "9.0".to_string()],
                 ["68100".to_string(), "0.5".to_string()],
             ],
             timestamp: "2026-01-01T00:00:00Z".to_string(),
         };
 
-        // Client should sort: bids descending, asks ascending
-        // Note: This test documents expected behavior
-        // In actual implementation, sorting would happen in the client
+        assert_eq!(book.best_bid(), Some("68000"));
+        assert_eq!(book.best_ask(), Some("68100"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- derive best bid and ask from unsorted depth arrays instead of trusting the first level
- ignore non-finite, non-positive, and malformed depth prices
- validate mark/touch snapshots and fall back from invalid WebSocket cache entries to REST
- reject crossed books and invalid market values
- intersect the eligibility band with the post-only no-cross range before tick rounding
- omit a quote when no price tick can satisfy both constraints

## Why

The StandX depth API does not guarantee level ordering. Taking the first level can select the wrong touch, which weakens no-cross protection, divergence checks, and paper fill behavior. The previous band/no-cross sequence could also move a quote outside the band when the two constraints had no feasible overlap.

## Impact

Market snapshots fail closed on invalid values, and maker quotes are only emitted when they satisfy both band and post-only constraints. Order execution, inventory accounting, and the live gate are unchanged.

## Validation

- `cargo fmt --check`
- `cargo test -p standx-sdk maker::tests --offline` (36 passed)
- `cargo test -p standx-sdk models::tests::test_order_book --offline` (2 passed)
- `cargo test -p standx-cli commands::maker --offline` (5 passed)
