### PR TITLE
fix: align maker order API contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Utilities
 dirs = "6.0"
+uuid = { version = "1.7", features = ["v4"] }
 
 # Output formatting
 tabled = "0.18"

--- a/crates/standx-cli/Cargo.toml
+++ b/crates/standx-cli/Cargo.toml
@@ -50,7 +50,7 @@ chrono.workspace = true
 dirs.workspace = true
 rpassword = "7.3"
 regex = "1.10"
-uuid = { version = "1.7", features = ["v4"] }
+uuid.workspace = true
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -240,6 +240,7 @@ pub(super) async fn maker_cycle(
                     match client
                         .create_order(CreateOrderParams {
                             symbol: symbol.to_string(),
+                            cl_ord_id: None,
                             side: q.side,
                             order_type: OrderType::Limit,
                             quantity: format_decimals(q.qty, cfg.qty_decimals),

--- a/crates/standx-cli/src/commands/order.rs
+++ b/crates/standx-cli/src/commands/order.rs
@@ -45,6 +45,7 @@ pub async fn handle_order(command: OrderCommands) -> Result<()> {
 
             let params = CreateOrderParams {
                 symbol,
+                cl_ord_id: None,
                 side,
                 order_type,
                 quantity: qty,

--- a/crates/standx-sdk/Cargo.toml
+++ b/crates/standx-sdk/Cargo.toml
@@ -44,6 +44,7 @@ chrono.workspace = true
 
 # Utilities
 dirs.workspace = true
+uuid.workspace = true
 hex = "0.4"
 base64 = "0.22"
 

--- a/crates/standx-sdk/src/auth/mod.rs
+++ b/crates/standx-sdk/src/auth/mod.rs
@@ -12,7 +12,6 @@ pub use credentials::Credentials;
 pub struct StandXSigner {
     signing_key: SigningKey,
     verifying_key: VerifyingKey,
-    request_id: String,
 }
 
 /// Request signature headers
@@ -41,18 +40,11 @@ impl StandXSigner {
         })?);
 
         let verifying_key = signing_key.verifying_key();
-        let request_id = hex::encode(verifying_key.as_bytes());
 
         Ok(Self {
             signing_key,
             verifying_key,
-            request_id,
         })
-    }
-
-    /// Get the request ID (hex-encoded public key)
-    pub fn request_id(&self) -> &str {
-        &self.request_id
     }
 
     /// Get the public key in hex format
@@ -60,20 +52,34 @@ impl StandXSigner {
         hex::encode(self.verifying_key.as_bytes())
     }
 
-    /// Sign a request
-    pub fn sign_request(&self, timestamp: u64, payload: &str) -> RequestSignature {
+    /// Sign a request with a caller-provided request ID.
+    ///
+    /// This is useful for deterministic tests and for protocols that need to
+    /// correlate an externally-created UUID with an asynchronous response.
+    pub fn sign_request_with_id(
+        &self,
+        request_id: &str,
+        timestamp: u64,
+        payload: &str,
+    ) -> RequestSignature {
         let version = "v1";
-        let message = format!("{},{},{},{}", version, self.request_id, timestamp, payload);
+        let message = format!("{version},{request_id},{timestamp},{payload}");
 
         let signature = self.signing_key.sign(message.as_bytes());
 
         RequestSignature {
             version: version.to_string(),
-            request_id: self.request_id.clone(),
+            request_id: request_id.to_string(),
             timestamp,
             signature: STANDARD.encode(signature.to_bytes()),
             pubkey: self.pubkey_hex(),
         }
+    }
+
+    /// Sign a request with a fresh UUID request ID.
+    pub fn sign_request(&self, timestamp: u64, payload: &str) -> RequestSignature {
+        let request_id = uuid::Uuid::new_v4().to_string();
+        self.sign_request_with_id(&request_id, timestamp, payload)
     }
 
     /// Sign a request with the current timestamp
@@ -96,7 +102,6 @@ mod tests {
 
         let signer = StandXSigner::from_base58(&private_key_base58).unwrap();
 
-        assert!(!signer.request_id().is_empty());
         assert!(!signer.pubkey_hex().is_empty());
     }
 
@@ -115,7 +120,7 @@ mod tests {
         assert_eq!(sig.timestamp, 1700000000000);
         assert!(!sig.signature.is_empty());
         assert!(!sig.pubkey.is_empty());
-        assert_eq!(sig.request_id, signer.request_id());
+        assert!(uuid::Uuid::parse_str(&sig.request_id).is_ok());
     }
 
     #[test]
@@ -181,9 +186,10 @@ mod tests {
         let payload = r#"{"symbol":"BTC-USD","side":"buy"}"#;
         let timestamp = 1700000000000u64;
 
-        // Sign same payload twice
-        let sig1 = signer.sign_request(timestamp, payload);
-        let sig2 = signer.sign_request(timestamp, payload);
+        // Sign the same request twice with a fixed correlation ID.
+        let request_id = "6f071beb-1b81-4c68-a8bf-66f1589c2146";
+        let sig1 = signer.sign_request_with_id(request_id, timestamp, payload);
+        let sig2 = signer.sign_request_with_id(request_id, timestamp, payload);
 
         // Same signer should produce same request_id and pubkey
         assert_eq!(sig1.request_id, sig2.request_id);
@@ -191,5 +197,19 @@ mod tests {
 
         // Ed25519 is deterministic, so signatures should be identical
         assert_eq!(sig1.signature, sig2.signature);
+    }
+
+    #[test]
+    fn test_sign_request_uses_unique_uuid() {
+        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let private_key_base58 = bs58::encode(signing_key.to_bytes()).into_string();
+        let signer = StandXSigner::from_base58(&private_key_base58).unwrap();
+
+        let sig1 = signer.sign_request(1700000000000, "{}");
+        let sig2 = signer.sign_request(1700000000000, "{}");
+
+        assert_ne!(sig1.request_id, sig2.request_id);
+        assert!(uuid::Uuid::parse_str(&sig1.request_id).is_ok());
+        assert!(uuid::Uuid::parse_str(&sig2.request_id).is_ok());
     }
 }

--- a/crates/standx-sdk/src/client/order.rs
+++ b/crates/standx-sdk/src/client/order.rs
@@ -9,6 +9,8 @@ use serde_json::json;
 #[derive(Debug, Clone)]
 pub struct CreateOrderParams {
     pub symbol: String,
+    /// Client-generated idempotency/correlation ID.
+    pub cl_ord_id: Option<String>,
     pub side: OrderSide,
     pub order_type: OrderType,
     pub quantity: String,
@@ -24,6 +26,7 @@ impl Default for CreateOrderParams {
     fn default() -> Self {
         Self {
             symbol: String::new(),
+            cl_ord_id: None,
             side: OrderSide::Buy,
             order_type: OrderType::Limit,
             quantity: String::new(),
@@ -43,49 +46,7 @@ impl StandXClient {
     pub async fn create_order(&self, params: CreateOrderParams) -> Result<Order> {
         let url = format!("{}/api/new_order", self.base_url);
 
-        // Build request body
-        let order_type = match params.order_type {
-            OrderType::Market => "market",
-            OrderType::Limit => "limit",
-        };
-
-        let side = match params.side {
-            OrderSide::Buy => "buy",
-            OrderSide::Sell => "sell",
-        };
-
-        let tif = params
-            .time_in_force
-            .map(|t| match t {
-                TimeInForce::Gtc => "gtc",
-                TimeInForce::Ioc => "ioc",
-                TimeInForce::Fok => "fok",
-                TimeInForce::Alo => "alo",
-            })
-            .unwrap_or("gtc");
-
-        let mut body = json!({
-            "symbol": params.symbol,
-            "side": side,
-            "order_type": order_type,
-            "qty": params.quantity,
-            "time_in_force": tif,
-            "reduce_only": params.reduce_only,
-        });
-
-        // Add optional fields
-        if let Some(ref price) = params.price {
-            body["price"] = json!(price);
-        }
-        if let Some(stop_price) = params.stop_price {
-            body["stop_price"] = json!(stop_price);
-        }
-        if let Some(sl_price) = params.sl_price {
-            body["sl_price"] = json!(sl_price);
-        }
-        if let Some(tp_price) = params.tp_price {
-            body["tp_price"] = json!(tp_price);
-        }
+        let body = create_order_body(&params);
 
         let body_str = body.to_string();
         let headers = self.build_auth_headers(Some(&body_str)).await?;
@@ -98,34 +59,7 @@ impl StandXClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response.text().await.unwrap_or_default();
-            return Err(Error::Api {
-                code: status.as_u16(),
-                message: text,
-                endpoint: Some("/api/new_order".to_string()),
-                retryable: status.as_u16() >= 500,
-            });
-        }
-
-        let result: serde_json::Value = response.json().await?;
-
-        // Check for API error
-        if let Some(code) = result.get("code").and_then(|c| c.as_i64()) {
-            if code != 0 {
-                let message = result
-                    .get("message")
-                    .and_then(|m| m.as_str())
-                    .unwrap_or("Order rejected");
-                return Err(Error::Api {
-                    code: code as u16,
-                    message: message.to_string(),
-                    endpoint: Some("/api/new_order".to_string()),
-                    retryable: false,
-                });
-            }
-        }
+        let result = parse_order_response(response, "/api/new_order").await?;
 
         // Build order from response
         let now = chrono::Utc::now().to_rfc3339();
@@ -135,6 +69,7 @@ impl StandXClient {
                 .and_then(|r| r.as_str())
                 .unwrap_or("")
                 .to_string(),
+            cl_ord_id: params.cl_ord_id,
             symbol: params.symbol,
             side: params.side,
             order_type: params.order_type,
@@ -150,13 +85,14 @@ impl StandXClient {
     }
 
     /// Cancel an order by ID
-    pub async fn cancel_order(&self, symbol: &str, order_id: &str) -> Result<()> {
+    pub async fn cancel_order(&self, _symbol: &str, order_id: &str) -> Result<()> {
         let url = format!("{}/api/cancel_order", self.base_url);
+        let order_id = order_id.parse::<i64>().map_err(|_| Error::Validation {
+            field: "order_id".to_string(),
+            message: format!("expected an integer order ID, got '{order_id}'"),
+        })?;
 
-        let body = json!({
-            "symbol": symbol,
-            "order_id": order_id.parse::<i64>().unwrap_or(0),
-        });
+        let body = cancel_order_body(order_id);
 
         let body_str = body.to_string();
         let headers = self.build_auth_headers(Some(&body_str)).await?;
@@ -169,27 +105,19 @@ impl StandXClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response.text().await.unwrap_or_default();
-            return Err(Error::Api {
-                code: status.as_u16(),
-                message: text,
-                endpoint: Some("/api/cancel_order".to_string()),
-                retryable: status.as_u16() >= 500,
-            });
-        }
+        parse_order_response(response, "/api/cancel_order").await?;
 
         Ok(())
     }
 
-    /// Cancel all orders for a symbol
-    pub async fn cancel_all_orders(&self, symbol: &str) -> Result<()> {
+    /// Submit one asynchronous batch cancellation by exchange order IDs.
+    pub async fn cancel_orders(&self, order_ids: &[i64]) -> Result<()> {
+        if order_ids.is_empty() {
+            return Ok(());
+        }
+
         let url = format!("{}/api/cancel_orders", self.base_url);
-
-        let body = json!({
-            "symbol": symbol,
-        });
+        let body = cancel_orders_body(order_ids);
 
         let body_str = body.to_string();
         let headers = self.build_auth_headers(Some(&body_str)).await?;
@@ -202,19 +130,124 @@ impl StandXClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response.text().await.unwrap_or_default();
-            return Err(Error::Api {
-                code: status.as_u16(),
-                message: text,
-                endpoint: Some("/api/cancel_orders".to_string()),
-                retryable: status.as_u16() >= 500,
-            });
-        }
+        parse_order_response(response, "/api/cancel_orders").await?;
 
         Ok(())
     }
+
+    /// Cancel every currently-open order for a symbol using the documented
+    /// ID-list batch API. The accepted response is asynchronous; callers that
+    /// require a clean book must still confirm through order events or polling.
+    pub async fn cancel_all_orders(&self, symbol: &str) -> Result<()> {
+        let orders = self.get_open_orders(Some(symbol)).await?;
+        let order_ids = orders
+            .iter()
+            .map(|order| {
+                order.id.parse::<i64>().map_err(|_| Error::Validation {
+                    field: "order_id".to_string(),
+                    message: format!("exchange returned non-integer order ID '{}'", order.id),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        self.cancel_orders(&order_ids).await
+    }
+}
+
+fn create_order_body(params: &CreateOrderParams) -> serde_json::Value {
+    let order_type = match params.order_type {
+        OrderType::Market => "market",
+        OrderType::Limit => "limit",
+    };
+    let side = match params.side {
+        OrderSide::Buy => "buy",
+        OrderSide::Sell => "sell",
+    };
+    let tif = params
+        .time_in_force
+        .map(|t| match t {
+            TimeInForce::Gtc => "gtc",
+            TimeInForce::Ioc => "ioc",
+            TimeInForce::Fok => "fok",
+            TimeInForce::Alo => "alo",
+        })
+        .unwrap_or("gtc");
+
+    let mut body = json!({
+        "symbol": params.symbol,
+        "side": side,
+        "order_type": order_type,
+        "qty": params.quantity,
+        "time_in_force": tif,
+        "reduce_only": params.reduce_only,
+    });
+    if let Some(value) = &params.cl_ord_id {
+        body["cl_ord_id"] = json!(value);
+    }
+    if let Some(value) = &params.price {
+        body["price"] = json!(value);
+    }
+    if let Some(value) = &params.stop_price {
+        body["stop_price"] = json!(value);
+    }
+    if let Some(value) = &params.sl_price {
+        body["sl_price"] = json!(value);
+    }
+    if let Some(value) = &params.tp_price {
+        body["tp_price"] = json!(value);
+    }
+    body
+}
+
+fn cancel_order_body(order_id: i64) -> serde_json::Value {
+    json!({ "order_id": order_id })
+}
+
+fn cancel_orders_body(order_ids: &[i64]) -> serde_json::Value {
+    json!({ "order_id_list": order_ids })
+}
+
+async fn parse_order_response(
+    response: reqwest::Response,
+    endpoint: &str,
+) -> Result<serde_json::Value> {
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(Error::Api {
+            code: status.as_u16(),
+            message: text,
+            endpoint: Some(endpoint.to_string()),
+            retryable: response_code_is_retryable(status.as_u16()),
+        });
+    }
+
+    let result = response.json::<serde_json::Value>().await?;
+    ensure_order_response_success(&result, endpoint)?;
+    Ok(result)
+}
+
+fn ensure_order_response_success(result: &serde_json::Value, endpoint: &str) -> Result<()> {
+    if let Some(code) = result.get("code").and_then(|value| value.as_i64()) {
+        if code != 0 {
+            let code = u16::try_from(code).unwrap_or(u16::MAX);
+            let message = result
+                .get("message")
+                .and_then(|value| value.as_str())
+                .unwrap_or("Order request rejected");
+            return Err(Error::Api {
+                code,
+                message: message.to_string(),
+                endpoint: Some(endpoint.to_string()),
+                retryable: response_code_is_retryable(code),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn response_code_is_retryable(code: u16) -> bool {
+    code == 429 || code >= 500
 }
 
 #[cfg(test)]
@@ -245,5 +278,57 @@ mod tests {
         // Should fail because no credentials
         let result = client.create_order(params).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn create_body_includes_client_order_id() {
+        let params = CreateOrderParams {
+            symbol: "BTC-USD".to_string(),
+            cl_ord_id: Some("maker-buy-0-42".to_string()),
+            side: OrderSide::Buy,
+            order_type: OrderType::Limit,
+            quantity: "0.01".to_string(),
+            price: Some("65000".to_string()),
+            time_in_force: Some(TimeInForce::Alo),
+            ..Default::default()
+        };
+
+        let body = create_order_body(&params);
+        assert_eq!(body["cl_ord_id"], "maker-buy-0-42");
+        assert_eq!(body["time_in_force"], "alo");
+        assert_eq!(body["reduce_only"], false);
+    }
+
+    #[test]
+    fn response_codes_classify_rate_limit_as_retryable() {
+        assert!(!response_code_is_retryable(400));
+        assert!(!response_code_is_retryable(401));
+        assert!(response_code_is_retryable(429));
+        assert!(response_code_is_retryable(500));
+    }
+
+    #[test]
+    fn cancellation_bodies_use_documented_order_id_fields() {
+        assert_eq!(cancel_order_body(42), serde_json::json!({ "order_id": 42 }));
+        assert_eq!(
+            cancel_orders_body(&[42, 43]),
+            serde_json::json!({ "order_id_list": [42, 43] })
+        );
+    }
+
+    #[test]
+    fn response_body_errors_are_not_treated_as_success() {
+        let error = ensure_order_response_success(
+            &serde_json::json!({ "code": 429, "message": "rate limited" }),
+            "/api/cancel_orders",
+        )
+        .unwrap_err();
+        assert!(error.is_retryable());
+
+        assert!(ensure_order_response_success(
+            &serde_json::json!({ "code": 0, "message": "accepted" }),
+            "/api/cancel_orders",
+        )
+        .is_ok());
     }
 }

--- a/crates/standx-sdk/src/models.rs
+++ b/crates/standx-sdk/src/models.rs
@@ -425,6 +425,8 @@ pub struct OrderRequest {
 pub struct Order {
     #[serde(deserialize_with = "string_or_number_to_string")]
     pub id: String,
+    #[serde(default)]
+    pub cl_ord_id: Option<String>,
     pub symbol: String,
     #[serde(deserialize_with = "deserialize_order_side")]
     pub side: OrderSide,


### PR DESCRIPTION
## What changed

- generate a fresh UUID for every signed API request while retaining deterministic signing with an explicit request ID for tests and future async correlation
- expose `cl_ord_id` on order requests and responses
- validate integer exchange order IDs instead of silently converting malformed IDs to zero
- send documented `order_id` and `order_id_list` cancellation payloads
- implement cancel-all as query-open-orders followed by ID-list cancellation
- parse JSON `code` values for new/cancel requests instead of treating every HTTP 2xx response as accepted
- classify 429 and 5xx order responses as retryable

## Why

The previous SDK reused the signing public key as every `x-request-id`, sent `{symbol}` to the batch cancellation endpoint, and ignored application-level errors on cancellation. Those behaviors do not match the documented asynchronous order API contract and can hide failed cleanup requests.

## Impact

Order submission and cancellation requests now use the documented payload shape and correlation primitives. HTTP acceptance is still asynchronous; confirmed order lifecycle handling remains intentionally deferred to the follow-up maker order-state PR. The live maker gate remains locked.

## Validation

- `cargo fmt --check`
- `cargo test -p standx-sdk --offline` (79 unit tests + 1 doc test passed)
- `cargo test -p standx-cli --lib --offline` (30 passed)
- `cargo clippy --workspace --all-targets --offline -- -D warnings`
