### PR TITLE
fix: fail closed when maker order stream disconnects

### DIFF
--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -9,6 +9,7 @@ use standx_sdk::client::order::CreateOrderParams;
 use standx_sdk::client::StandXClient;
 use standx_sdk::models::{OrderSide, OrderType, TimeInForce};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 /// One reconcile cycle over an already-acquired market snapshot.
@@ -32,6 +33,7 @@ pub(super) async fn maker_cycle(
     stats: &mut standx_sdk::maker::MakerStats,
     breaker: &mut standx_sdk::maker::VolBreaker,
     output_format: OutputFormat,
+    order_response_health: Option<&AtomicBool>,
 ) -> Result<(u64, u64, u64, u64)> {
     use standx_sdk::maker::{
         cap_desired_exposure, compute_desired_quotes, format_decimals, mark_mid_divergence_bps,
@@ -281,6 +283,11 @@ pub(super) async fn maker_cycle(
             }
             Action::Place(q) => {
                 if live {
+                    if !order_response_health.is_some_and(|health| health.load(Ordering::Acquire)) {
+                        return Err(anyhow::anyhow!(
+                            "order-response stream is unhealthy; refusing live placement"
+                        ));
+                    }
                     let cl_ord_id = format!("{}{}", MAKER_CL_ORD_ID_PREFIX, uuid::Uuid::new_v4());
                     match client
                         .create_order(CreateOrderParams {

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -34,8 +34,8 @@ pub(super) async fn maker_cycle(
     output_format: OutputFormat,
 ) -> Result<(u64, u64, u64, u64)> {
     use standx_sdk::maker::{
-        compute_desired_quotes, format_decimals, mark_mid_divergence_bps, paper_quote_filled,
-        reconcile, skew_center, Action, RestingQuote,
+        cap_desired_exposure, compute_desired_quotes, format_decimals, mark_mid_divergence_bps,
+        paper_quote_filled, reconcile, skew_center, Action, RestingQuote,
     };
 
     // 0. Feed the volatility breaker every cycle (even when a later guard
@@ -192,7 +192,12 @@ pub(super) async fn maker_cycle(
     let desired = if halted {
         Vec::new()
     } else {
-        compute_desired_quotes(cfg, mark, best_bid, best_ask, position)
+        let raw = compute_desired_quotes(cfg, mark, best_bid, best_ask, position);
+        let pending_slots = pending
+            .iter()
+            .map(|place| (place.side, place.level))
+            .collect::<Vec<_>>();
+        cap_desired_exposure(cfg, position, &raw, &pending_slots)
     };
     let actions = reconcile(
         cfg, mark, position, best_bid, best_ask, &desired, resting, cycle,

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -6,6 +6,7 @@ use standx_sdk::error::Error as StandxError;
 use standx_sdk::models::{Order, OrderSide};
 use standx_sdk::order_response::OrderResponse;
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::signal;
 
@@ -73,8 +74,17 @@ fn apply_order_responses(
     symbol: &str,
     cycle: u64,
     price_decimals: u32,
-) {
-    while let Ok(response) = receiver.try_recv() {
+) -> Result<()> {
+    loop {
+        let response = match receiver.try_recv() {
+            Ok(response) => response,
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => return Ok(()),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                return Err(anyhow::anyhow!(
+                    "order-response stream disconnected; refusing further live orders"
+                ));
+            }
+        };
         let Some(request_id) = response.request_id.as_deref() else {
             continue;
         };
@@ -424,6 +434,7 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
 
     // ---- Live gating & clean start ----
     let mut order_responses = None;
+    let mut order_response_health = None;
     let mut order_response_handle = None;
     if args.live {
         if std::env::var(LIVE_MAKER_ENV).ok().as_deref() != Some("1") {
@@ -464,8 +475,9 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
                 .as_deref()
                 .expect("live maker must have an order session"),
         )?;
-        let (responses, handle) = stream.connect().await?;
+        let (responses, health, handle) = stream.connect().await?;
         order_responses = Some(responses);
+        order_response_health = Some(health);
         order_response_handle = Some(handle);
     }
 
@@ -591,15 +603,26 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     let mut last_src: Option<&'static str> = None;
 
     let exit = 'main: loop {
+        if args.live
+            && !order_response_health
+                .as_ref()
+                .is_some_and(|health| health.load(Ordering::Acquire))
+        {
+            break MakerExit::FailSafe(
+                "order-response stream is unhealthy; refusing further live orders".to_string(),
+            );
+        }
         if let Some(receiver) = order_responses.as_mut() {
-            apply_order_responses(
+            if let Err(error) = apply_order_responses(
                 receiver,
                 &mut pending,
                 output_format,
                 &symbol,
                 cycle,
                 cfg.price_decimals,
-            );
+            ) {
+                break MakerExit::FailSafe(error.to_string());
+            }
         }
 
         // Work phase raced against Ctrl+C so a slow API call can be
@@ -624,6 +647,7 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
                 &mut stats,
                 &mut breaker,
                 output_format,
+                order_response_health.as_deref(),
             )
             .await?;
             Ok::<_, anyhow::Error>((places, cancels, holds, fills, mark, src, breaker.halted()))
@@ -936,7 +960,8 @@ mod tests {
             "BTC-USD",
             2,
             2,
-        );
+        )
+        .unwrap();
 
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].request_id, "request-2");
@@ -970,8 +995,28 @@ mod tests {
             "BTC-USD",
             2,
             2,
-        );
+        )
+        .unwrap();
 
         assert_eq!(pending.len(), 1);
+    }
+
+    #[test]
+    fn disconnected_order_response_stream_is_fail_closed() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        drop(sender);
+        let mut pending = Vec::new();
+
+        let error = apply_order_responses(
+            &mut receiver,
+            &mut pending,
+            OutputFormat::Quiet,
+            "BTC-USD",
+            1,
+            2,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("disconnected"));
     }
 }

--- a/crates/standx-sdk/src/maker.rs
+++ b/crates/standx-sdk/src/maker.rs
@@ -637,6 +637,48 @@ pub fn compute_desired_quotes(
     out
 }
 
+/// Limit a desired ladder so that all quotes on either side filling cannot
+/// push the account beyond `max_position`.
+///
+/// Position-only suppression is insufficient for a multi-level ladder: while
+/// the current position may be inside the cap, several resting bids (or asks)
+/// can all fill before the next reconciliation cycle. This guard budgets each
+/// directional ladder independently. `reserved_slots` are considered first;
+/// callers use them for submitted-but-not-yet-visible orders, so transport
+/// delay cannot make a later level lose its exposure reservation.
+pub fn cap_desired_exposure(
+    cfg: &MakerConfig,
+    position: f64,
+    desired: &[DesiredQuote],
+    reserved_slots: &[(OrderSide, u32)],
+) -> Vec<DesiredQuote> {
+    let mut buy_budget = (cfg.max_position - position).max(0.0);
+    let mut sell_budget = (cfg.max_position + position).max(0.0);
+    let mut candidates = desired.to_vec();
+    // Stable ordering keeps the configured inner-to-outer ladder order while
+    // moving only submitted-but-not-yet-visible slots to the front.
+    candidates.sort_by_key(|quote| !reserved_slots.contains(&(quote.side, quote.level)));
+
+    candidates
+        .into_iter()
+        .filter(|quote| {
+            let budget = match quote.side {
+                OrderSide::Buy => &mut buy_budget,
+                OrderSide::Sell => &mut sell_budget,
+            };
+            // Retain only full, tick-aligned orders. Shrinking a level would
+            // create a quantity not represented by the strategy's config and
+            // could fall below the venue's minimum order size.
+            if quote.qty <= *budget + f64::EPSILON {
+                *budget = (*budget - quote.qty).max(0.0);
+                true
+            } else {
+                false
+            }
+        })
+        .collect()
+}
+
 /// Diff desired vs resting quotes, applying the anti-flicker hold rule.
 ///
 /// Decision table per resting quote (checked in order):
@@ -1176,6 +1218,59 @@ mod tests {
         let base = compute_desired_quotes(&c, 100.0, None, None, 0.0);
         let with_pos = compute_desired_quotes(&c, 100.0, None, None, 0.025);
         assert_eq!(base, with_pos);
+    }
+
+    #[test]
+    fn exposure_cap_limits_all_same_side_fills() {
+        let mut c = cfg();
+        c.levels = 3;
+        c.size = 0.02;
+        c.max_position = 0.05;
+        let raw = compute_desired_quotes(&c, 100.0, None, None, 0.03);
+        let capped = cap_desired_exposure(&c, 0.03, &raw, &[]);
+
+        // At +0.03, only one additional 0.02 buy can be exposed. All three
+        // sells remain safe: even if they all fill, the position is -0.03.
+        assert_eq!(
+            capped
+                .iter()
+                .filter(|quote| quote.side == OrderSide::Buy)
+                .count(),
+            1
+        );
+        assert_eq!(
+            capped
+                .iter()
+                .filter(|quote| quote.side == OrderSide::Sell)
+                .count(),
+            3
+        );
+        let buy_qty: f64 = capped
+            .iter()
+            .filter(|quote| quote.side == OrderSide::Buy)
+            .map(|quote| quote.qty)
+            .sum();
+        assert!(0.03 + buy_qty <= c.max_position + 1e-9);
+    }
+
+    #[test]
+    fn exposure_cap_reserves_pending_slot_before_new_levels() {
+        let mut c = cfg();
+        c.levels = 3;
+        c.size = 0.02;
+        c.max_position = 0.05;
+        let raw = compute_desired_quotes(&c, 100.0, None, None, 0.03);
+        let capped = cap_desired_exposure(&c, 0.03, &raw, &[(OrderSide::Buy, 2)]);
+
+        // The in-flight outer bid gets the only 0.02 buy budget. A later
+        // reconcile cannot place level 0 in addition while level 2 is still
+        // awaiting exchange visibility.
+        assert!(capped
+            .iter()
+            .any(|quote| quote.side == OrderSide::Buy && quote.level == 2));
+        assert!(!capped
+            .iter()
+            .any(|quote| quote.side == OrderSide::Buy && quote.level == 0));
     }
 
     // 20. Inventory ratio saturates at ±1 past max_position.

--- a/crates/standx-sdk/src/order_response.rs
+++ b/crates/standx-sdk/src/order_response.rs
@@ -4,6 +4,11 @@ use crate::auth::Credentials;
 use crate::error::{Error, Result};
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
@@ -31,6 +36,9 @@ pub struct OrderResponseStream {
     token: String,
     session_id: String,
 }
+
+/// Shared liveness flag for an authenticated order-response connection.
+pub type OrderResponseHealth = Arc<AtomicBool>;
 
 impl OrderResponseStream {
     /// Construct a production stream from the currently-loaded credentials.
@@ -68,16 +76,63 @@ impl OrderResponseStream {
         &self.session_id
     }
 
-    /// Connect, authenticate, and return parsed asynchronous order responses.
+    /// Connect, wait for a successful authentication acknowledgement, and
+    /// return parsed asynchronous order responses plus a shared liveness flag.
     pub async fn connect(
         &self,
-    ) -> Result<(mpsc::Receiver<OrderResponse>, tokio::task::JoinHandle<()>)> {
+    ) -> Result<(
+        mpsc::Receiver<OrderResponse>,
+        OrderResponseHealth,
+        tokio::task::JoinHandle<()>,
+    )> {
         let (stream, _) = connect_async(&self.url).await?;
         let (mut write, mut read) = stream.split();
-        let auth = auth_request(&self.session_id, &self.token);
+        let auth_request_id = uuid::Uuid::new_v4().to_string();
+        let auth = auth_request(&self.session_id, &self.token, &auth_request_id);
         write.send(Message::Text(auth.to_string().into())).await?;
 
+        let auth_response = loop {
+            let message = tokio::time::timeout(Duration::from_secs(10), read.next())
+                .await
+                .map_err(|_| Error::WebSocket {
+                    message: "timed out waiting for order-response authentication".to_string(),
+                })?
+                .ok_or_else(|| Error::WebSocket {
+                    message: "order-response stream closed before authentication".to_string(),
+                })??;
+            match message {
+                Message::Text(text) => {
+                    let response = serde_json::from_str::<OrderResponse>(&text)?;
+                    if response.request_id.as_deref() != Some(auth_request_id.as_str()) {
+                        return Err(Error::WebSocket {
+                            message: "received an unexpected response before authentication"
+                                .to_string(),
+                        });
+                    }
+                    break response;
+                }
+                Message::Ping(payload) => write.send(Message::Pong(payload)).await?,
+                Message::Close(_) => {
+                    return Err(Error::WebSocket {
+                        message: "order-response stream closed before authentication".to_string(),
+                    });
+                }
+                _ => {}
+            }
+        };
+        if !auth_response.accepted() {
+            return Err(Error::AuthRequired {
+                message: format!(
+                    "order-response authentication rejected: {}",
+                    auth_response.message
+                ),
+                resolution: "Run 'standx auth login' and retry".to_string(),
+            });
+        }
+
         let (tx, rx) = mpsc::channel(256);
+        let healthy = Arc::new(AtomicBool::new(true));
+        let task_health = Arc::clone(&healthy);
         let handle = tokio::spawn(async move {
             while let Some(message) = read.next().await {
                 match message {
@@ -97,16 +152,17 @@ impl OrderResponseStream {
                     _ => {}
                 }
             }
+            task_health.store(false, Ordering::Release);
         });
 
-        Ok((rx, handle))
+        Ok((rx, healthy, handle))
     }
 }
 
-fn auth_request(session_id: &str, token: &str) -> serde_json::Value {
+fn auth_request(session_id: &str, token: &str, request_id: &str) -> serde_json::Value {
     serde_json::json!({
         "session_id": session_id,
-        "request_id": uuid::Uuid::new_v4().to_string(),
+        "request_id": request_id,
         "method": "auth:login",
         "params": serde_json::json!({ "token": token }).to_string(),
     })
@@ -115,14 +171,16 @@ fn auth_request(session_id: &str, token: &str) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio_tungstenite::accept_async;
 
     #[test]
     fn auth_request_uses_stable_session_and_unique_request() {
-        let first = auth_request("maker-session", "jwt");
-        let second = auth_request("maker-session", "jwt");
+        let first = auth_request("maker-session", "jwt", "request-1");
+        let second = auth_request("maker-session", "jwt", "request-2");
 
         assert_eq!(first["session_id"], "maker-session");
         assert_eq!(first["method"], "auth:login");
+        assert_eq!(first["request_id"], "request-1");
         assert_ne!(first["request_id"], second["request_id"]);
         assert!(first["params"].as_str().unwrap().contains("jwt"));
     }
@@ -154,5 +212,85 @@ mod tests {
             "maker-session",
         );
         assert_eq!(stream.session_id(), "maker-session");
+    }
+
+    #[tokio::test]
+    async fn authenticated_connection_becomes_unhealthy_after_server_close() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(socket).await.unwrap();
+            let auth = websocket
+                .next()
+                .await
+                .unwrap()
+                .unwrap()
+                .into_text()
+                .unwrap();
+            let auth: serde_json::Value = serde_json::from_str(&auth).unwrap();
+            websocket
+                .send(Message::Text(
+                    serde_json::json!({
+                        "code": 0,
+                        "message": "authenticated",
+                        "request_id": auth["request_id"],
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+            // Drop the socket: the client must flip the liveness flag rather
+            // than continuing to place orders on a dead response stream.
+        });
+
+        let stream = OrderResponseStream::with_url_and_token(url, "jwt", "maker-session");
+        let (_responses, health, handle) = stream.connect().await.unwrap();
+        assert!(health.load(Ordering::Acquire));
+        server.await.unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while health.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("connection close should mark the response stream unhealthy");
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn authentication_rejection_prevents_connection_start() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(socket).await.unwrap();
+            let auth = websocket
+                .next()
+                .await
+                .unwrap()
+                .unwrap()
+                .into_text()
+                .unwrap();
+            let auth: serde_json::Value = serde_json::from_str(&auth).unwrap();
+            websocket
+                .send(Message::Text(
+                    serde_json::json!({
+                        "code": 401,
+                        "message": "invalid token",
+                        "request_id": auth["request_id"],
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        });
+
+        let stream = OrderResponseStream::with_url_and_token(url, "bad-jwt", "maker-session");
+        let error = stream.connect().await.unwrap_err();
+        assert!(matches!(error, Error::AuthRequired { .. }));
+        server.await.unwrap();
     }
 }


### PR DESCRIPTION
## What changed

- waits for a correlated, successful order-response authentication acknowledgement before live maker startup
- exposes shared order-response stream liveness to the maker loop
- exits fail-safe and cancels maker-owned orders when the stream closes, reads fail, or the receiver disconnects
- checks liveness again immediately before every live placement
- adds local WebSocket tests for authentication rejection and post-authentication disconnects

## Why

HTTP order submission is asynchronous. Continuing to place orders after losing the response stream leaves the strategy unable to distinguish venue acceptance from rejection, so the safe behavior is to stop and clean up.

## Scope and follow-ups

This is stacked on #195. Reconnection with proven session recovery, exact fill/PnL accounting, inventory exits, replay, and canary approval remain follow-up PRs. Live trading remains locked behind `STANDX_ENABLE_LIVE_MAKER=1`.

## Validation

- `cargo test -p standx-sdk --offline` (88 unit + 1 doc test)
- `cargo test -p standx-cli --lib --offline` (35 tests)
- `cargo clippy --workspace --all-targets --offline -- -D warnings`
