### PR TITLE
fix: notify before reporting maker cleanup failure

### DIFF
--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -778,9 +778,15 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     if let Some(handle) = order_response_handle {
         handle.abort();
     }
-    if args.live {
-        cancel_maker_orders_with_retry(&client, &symbol, 3).await?;
-    }
+    // Do not return early on cleanup failure: operators need the stopped
+    // lifecycle alert most when residual maker orders may still be live.
+    let cleanup_error = if args.live {
+        cancel_maker_orders_with_retry(&client, &symbol, 3)
+            .await
+            .err()
+    } else {
+        None
+    };
 
     // Notify stop on every exit path. Await delivery so the message lands
     // before the process exits.
@@ -791,16 +797,20 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     let pnl_str = last_mark
         .map(|m| format!("{:+.2}", stats.mark_to_market(m)))
         .unwrap_or_else(|| "n/a".to_string());
+    let cleanup_note = cleanup_error.as_ref().map_or_else(String::new, |error| {
+        format!(" | ⚠️ cleanup failed: {error}")
+    });
     notify_lifecycle(
         "stopped",
         &format!(
-            "🔴 maker stopped ({}) — {} | {} cycles, {} fills, uptime {:.0}%, PnL {}",
+            "🔴 maker stopped ({}) — {} | {} cycles, {} fills, uptime {:.0}%, PnL {}{}",
             reason,
             symbol,
             cycle,
             total_fills,
             stats.uptime_pct(),
-            pnl_str
+            pnl_str,
+            cleanup_note,
         ),
         &symbol,
         output_format,
@@ -810,6 +820,13 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
         true,
     )
     .await;
+
+    if let Some(error) = cleanup_error {
+        return Err(anyhow::anyhow!(
+            "maker stopped but maker-owned order cleanup failed: {}",
+            error
+        ));
+    }
 
     match exit {
         MakerExit::CtrlC => Ok(()),


### PR DESCRIPTION
## What changed

- records maker-owned order cleanup failure instead of returning before lifecycle reporting
- always emits the stopped notification, including an explicit cleanup-failure warning
- returns a non-zero error after notification so automation still sees an unsafe residual-order condition

## Why

The previous cleanup used `?` before the stopped lifecycle notification. If cancellation or verification failed, the most important operator signal was skipped precisely when residual orders needed immediate attention.

## Scope and follow-ups

This is stacked on #196. Exact fill/PnL accounting, inventory exits, replay, and canary approval remain separate PRs. Live trading remains locked behind `STANDX_ENABLE_LIVE_MAKER=1`.

## Validation

- `cargo test -p standx-cli --lib --offline` (35 tests)
- `cargo test -p standx-sdk --offline` (88 unit + 1 doc test)
- `cargo clippy --workspace --all-targets --offline -- -D warnings`
