### PR TITLE
feat: ledger exact maker fills from trade history

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,12 +413,14 @@ standx maker run BTC-USD --output json
 standx maker run BTC-USD --live
 ```
 
-In live mode the bot manages **all** orders on the quoted symbol (it starts
-with a cancel-all and cancels unknown orders as stale), cancels everything on
-exit (with retries and verification), and stops quoting after 3 consecutive
-API errors (fail-safe). Paper mode simulates fills when the touch crosses a
-quote, so position, inventory skew, and PnL telemetry are observable without
-going live.
+In live mode the bot manages only orders tagged with its `sxmk-` client-order
+ID prefix: manual/API orders are preserved. It cleans up maker-owned orders on
+exit (with retries and verification), stops quoting after 3 consecutive API
+errors, and fails closed if the asynchronous order-response stream disconnects.
+Live fill telemetry is sourced from authenticated, maker-order-correlated trade
+history rather than inferred from position changes. Paper mode simulates fills
+when the touch crosses a quote, so position, inventory skew, and PnL telemetry
+are observable without going live.
 
 See **[docs/13-maker.md](docs/13-maker.md)** for the full guide — every flag,
 the anti-flicker decision table, inventory skew, telemetry, and live safety

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -7,8 +7,8 @@ use crate::cli::*;
 use anyhow::Result;
 use standx_sdk::client::order::CreateOrderParams;
 use standx_sdk::client::StandXClient;
-use standx_sdk::models::{OrderSide, OrderType, TimeInForce};
-use std::collections::HashMap;
+use standx_sdk::models::{OrderSide, OrderType, TimeInForce, Trade};
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -29,6 +29,9 @@ pub(super) async fn maker_cycle(
     resting: &mut Vec<standx_sdk::maker::RestingQuote>,
     adopted: &mut HashMap<String, (u32, f64, u64)>,
     pending: &mut Vec<PendingPlace>,
+    maker_order_ids: &mut HashSet<u64>,
+    seen_fill_ids: &mut HashSet<u64>,
+    session_started_at: i64,
     sim_position: &mut f64,
     stats: &mut standx_sdk::maker::MakerStats,
     breaker: &mut standx_sdk::maker::VolBreaker,
@@ -89,12 +92,52 @@ pub(super) async fn maker_cycle(
     let position: f64;
     let mut fills: Vec<(OrderSide, f64, f64)> = Vec::new(); // paper sim only
     if live {
-        let (orders, positions) = tokio::join!(
+        let now = chrono::Utc::now().timestamp();
+        let (orders, positions, filled_orders, trades) = tokio::join!(
             client.get_open_orders(Some(symbol)),
-            client.get_positions(Some(symbol))
+            client.get_positions(Some(symbol)),
+            client.get_order_history(Some(symbol), Some(100)),
+            client.get_user_trades(symbol, session_started_at, now, Some(500)),
         );
         let orders = orders?;
         let positions = positions?;
+        let filled_orders = filled_orders?;
+        let trades = trades?;
+
+        // Open maker orders identify partial fills; historical maker orders
+        // identify a quote that fully filled between two polling cycles.
+        for order in orders.iter().chain(filled_orders.iter()) {
+            if is_maker_order(order) {
+                let order_id = order.id.parse::<u64>().map_err(|_| {
+                    anyhow::anyhow!(
+                        "maker-owned order has non-integer exchange ID '{}'",
+                        order.id
+                    )
+                })?;
+                maker_order_ids.insert(order_id);
+            }
+        }
+
+        for trade in trades {
+            let Some(order_id) = trade.order_id else {
+                continue;
+            };
+            if !maker_order_ids.contains(&order_id) {
+                continue;
+            }
+            if trade.id == 0 {
+                return Err(anyhow::anyhow!(
+                    "maker fill for order {} has no stable trade ID",
+                    order_id
+                ));
+            }
+            if !seen_fill_ids.insert(trade.id) {
+                continue;
+            }
+            let (side, price, qty) = maker_trade_fill(&trade)?;
+            stats.record_fill(side, price, qty, mark);
+            fills.push((side, price, qty));
+        }
 
         position = positions
             .iter()
@@ -358,7 +401,7 @@ pub(super) async fn maker_cycle(
     //    fill from any position delta; paper already recorded exact fills).
     let two_sided = resting.iter().any(|r| r.side == OrderSide::Buy)
         && resting.iter().any(|r| r.side == OrderSide::Sell);
-    stats.end_cycle(position, mark, two_sided, live);
+    stats.end_cycle(position, two_sided);
 
     // 6. Emit.
     emit_maker_cycle(
@@ -378,6 +421,39 @@ pub(super) async fn maker_cycle(
     );
 
     Ok((places, cancels, holds, fills.len() as u64))
+}
+
+/// Decode a venue fill strictly enough for accounting. A maker fill with
+/// missing side, price, or quantity is not silently guessed from position.
+fn maker_trade_fill(trade: &Trade) -> Result<(OrderSide, f64, f64)> {
+    let side = match trade.side.as_deref() {
+        Some(side) if side.eq_ignore_ascii_case("buy") => OrderSide::Buy,
+        Some(side) if side.eq_ignore_ascii_case("sell") => OrderSide::Sell,
+        _ => {
+            return Err(anyhow::anyhow!(
+                "maker trade {} is missing a valid side",
+                trade.id
+            ));
+        }
+    };
+    let price = trade.price.parse::<f64>().map_err(|_| {
+        anyhow::anyhow!(
+            "maker trade {} has invalid price '{}'",
+            trade.id,
+            trade.price
+        )
+    })?;
+    let qty = trade
+        .qty
+        .parse::<f64>()
+        .map_err(|_| anyhow::anyhow!("maker trade {} has invalid qty '{}'", trade.id, trade.qty))?;
+    if !price.is_finite() || price <= 0.0 || !qty.is_finite() || qty <= 0.0 {
+        return Err(anyhow::anyhow!(
+            "maker trade {} has non-positive price/qty",
+            trade.id
+        ));
+    }
+    Ok((side, price, qty))
 }
 
 /// Cancel maker-owned orders with retries, preserving manual/API orders.
@@ -455,5 +531,43 @@ pub(super) async fn cancel_maker_orders_with_retry(
                 e
             )),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trade(side: Option<&str>, price: &str, qty: &str) -> Trade {
+        Trade {
+            id: 42,
+            time: "2026-07-10T00:00:00Z".to_string(),
+            price: price.to_string(),
+            qty: qty.to_string(),
+            side: side.map(str::to_string),
+            is_buyer_taker: false,
+            fee_asset: None,
+            fee_qty: None,
+            pnl: None,
+            order_id: Some(7),
+            symbol: Some("BTC-USD".to_string()),
+            value: None,
+        }
+    }
+
+    #[test]
+    fn maker_trade_fill_requires_complete_venue_fields() {
+        assert_eq!(
+            maker_trade_fill(&trade(Some("buy"), "99.5", "0.02")).unwrap(),
+            (OrderSide::Buy, 99.5, 0.02)
+        );
+        assert!(maker_trade_fill(&trade(None, "99.5", "0.02"))
+            .unwrap_err()
+            .to_string()
+            .contains("valid side"));
+        assert!(maker_trade_fill(&trade(Some("sell"), "bad", "0.02"))
+            .unwrap_err()
+            .to_string()
+            .contains("invalid price"));
     }
 }

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -5,7 +5,7 @@ use standx_sdk::client::StandXClient;
 use standx_sdk::error::Error as StandxError;
 use standx_sdk::models::{Order, OrderSide};
 use standx_sdk::order_response::OrderResponse;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::signal;
@@ -588,6 +588,9 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     let mut resting: Vec<RestingQuote> = Vec::new(); // paper-mode book
     let mut adopted: HashMap<String, (u32, f64, u64)> = HashMap::new(); // id -> (level, ref_mark, cycle)
     let mut pending: Vec<PendingPlace> = Vec::new();
+    let mut maker_order_ids: HashSet<u64> = HashSet::new();
+    let mut seen_fill_ids: HashSet<u64> = HashSet::new();
+    let session_started_at = chrono::Utc::now().timestamp();
     let mut consecutive_errors: u32 = 0;
     let mut total_places: u64 = 0;
     let mut total_cancels: u64 = 0;
@@ -643,6 +646,9 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
                 &mut resting,
                 &mut adopted,
                 &mut pending,
+                &mut maker_order_ids,
+                &mut seen_fill_ids,
+                session_started_at,
                 &mut sim_position,
                 &mut stats,
                 &mut breaker,

--- a/crates/standx-sdk/src/maker.rs
+++ b/crates/standx-sdk/src/maker.rs
@@ -233,7 +233,7 @@ pub struct MakerStats {
     spread_bps_sum: f64,
     spread_bps_n: u64,
     pub max_abs_position: f64,
-    /// Last observed position, for inferring live fills from position deltas.
+    /// Last observed position, used for mark-to-market and inventory telemetry.
     last_position: f64,
 }
 
@@ -263,22 +263,9 @@ impl MakerStats {
         }
     }
 
-    /// Close out a cycle: infer a live fill from any position delta (priced at
-    /// mark, since the exact fill price isn't known without the fills channel),
-    /// then update uptime and inventory extent. `two_sided` is whether both a
-    /// bid and an ask were resting this cycle.
-    pub fn end_cycle(&mut self, position: f64, mark: f64, two_sided: bool, live: bool) {
-        if live {
-            let delta = position - self.last_position;
-            if delta.abs() > f64::EPSILON {
-                let side = if delta > 0.0 {
-                    OrderSide::Buy
-                } else {
-                    OrderSide::Sell
-                };
-                self.record_fill(side, mark, delta.abs(), mark);
-            }
-        }
+    /// Close out a cycle after the caller has recorded exact venue fills.
+    /// `two_sided` is whether both a bid and an ask were resting this cycle.
+    pub fn end_cycle(&mut self, position: f64, two_sided: bool) {
         self.last_position = position;
         self.max_abs_position = self.max_abs_position.max(position.abs());
         self.cycles += 1;
@@ -1155,15 +1142,16 @@ mod tests {
     #[test]
     fn stats_uptime_and_live_inference() {
         let mut s = MakerStats::default();
-        s.end_cycle(0.0, 100.0, true, false); // two-sided
-        s.end_cycle(0.0, 100.0, false, false); // one-sided
+        s.end_cycle(0.0, true); // two-sided
+        s.end_cycle(0.0, false); // one-sided
         assert_eq!(s.cycles, 2);
         assert!((s.uptime_pct() - 50.0).abs() < 1e-9);
-        // Live: a position jump 0 -> 0.01 infers one buy fill at mark.
+        // Position movement alone must not fabricate a live fill: exact
+        // maker fills are supplied by the venue ledger.
         let mut l = MakerStats::default();
-        l.end_cycle(0.01, 100.0, true, true);
-        assert_eq!(l.fills(), 1);
-        assert_eq!(l.buy_fills, 1);
+        l.end_cycle(0.01, true);
+        assert_eq!(l.fills(), 0);
+        assert_eq!(l.buy_fills, 0);
         assert!((l.max_abs_position - 0.01).abs() < 1e-9);
     }
 
@@ -1422,7 +1410,7 @@ mod tests {
         let mut m = AlertMonitor::new(0.0, 0.0, 50.0); // floor 50%
         let mut s = MakerStats::default();
         // One one-sided cycle -> uptime 0%, but before warmup: no alert.
-        s.end_cycle(0.0, 100.0, false, false);
+        s.end_cycle(0.0, false);
         assert!(m.evaluate(&s, 0.0, 100.0, 0.05, 5).is_empty());
         // After warmup, still 0% < 50% -> fire.
         let a = m.evaluate(&s, 0.0, 100.0, 0.05, 25);

--- a/docs/13-maker.md
+++ b/docs/13-maker.md
@@ -151,7 +151,7 @@ center = mark × (1 − skew_bps × clamp(position / max_position, ±1) / 1e4)
 | uptime % | 同时挂着买卖单的周期占比 —— SIP-5A 真正奖励的东西 |
 | fills / max pos | 成交笔数、会话内最大绝对持仓 |
 
-> paper 用精确模拟成交计算；live 从周期间仓位差推断成交（按 mark 计价，是捕获的保守下界，直到接入 fills 频道）。**调参在 paper 里做**：观察 avg capture 与 PnL 的关系来调 `--spread-bps` / `--refresh-bps` / `--skew-bps`。
+> paper 用精确模拟成交计算；live 从认证成交历史读取本次会话内、已关联到 `sxmk-` maker 订单的成交，并按成交 ID 去重。不会把手工/API 订单或单纯仓位变化当作 maker 成交。当前 mark-to-market 仍基于成交现金流与仓位估值；费用币种和交易所已实现盈亏会单列核对。**调参在 paper 里做**：观察 avg capture 与 PnL 的关系来调 `--spread-bps` / `--refresh-bps` / `--skew-bps`。
 
 ### 风险告警
 


### PR DESCRIPTION
## What changed

- fetches authenticated trade history and filled-order history for every live maker cycle
- identifies only orders tagged with the maker `sxmk-` client-order prefix
- records exact price, side, and quantity by stable trade ID, with duplicate suppression
- fails closed on malformed maker-fill records rather than inventing a fill from a position delta
- removes position-delta fill inference from `MakerStats`
- updates the maker guide and README to describe exact fill provenance and order ownership

## Why

A net position change cannot distinguish maker fills from manual/API activity or give an execution price. It made live fill counts, capture, and mark-to-market PnL an approximation. The ledger now uses venue trade IDs and order correlation.

## Scope and follow-ups

This is stacked on #197. Current mark-to-market uses exact maker fill cash flows and current position, but fee-currency handling and exchange-reported realized PnL reconciliation are intentionally separate follow-ups. Inventory exits, replay, and canary approval remain pending. Live trading remains locked behind `STANDX_ENABLE_LIVE_MAKER=1`.

## Validation

- `cargo test -p standx-sdk --offline` (88 unit + 1 doc test)
- `cargo test -p standx-cli --lib --offline` (36 tests)
- `cargo clippy --workspace --all-targets --offline -- -D warnings`
