### PR TITLE
feat: add safe reduce-only maker inventory exit

### DIFF
--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -417,6 +417,14 @@ pub enum MakerCommands {
         /// starting point: roughly your --spread-bps
         #[arg(long, default_value = "0")]
         skew_bps: f64,
+        /// Actively exit inventory once |position| reaches this percent of
+        /// --max-position. 0 disables; requires --inventory-exit-qty.
+        #[arg(long, default_value = "0")]
+        inventory_exit_pct: f64,
+        /// Maximum base quantity for one reduce-only inventory exit. 0
+        /// disables; requires --inventory-exit-pct.
+        #[arg(long, default_value = "0")]
+        inventory_exit_qty: f64,
         /// Sanity guard: skip the cycle (no places/cancels) when mark price
         /// and book mid diverge by more than this (bps) — the data sources
         /// disagree and acting on them would be unsafe

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -94,6 +94,7 @@ pub(super) async fn maker_cycle(
     //    simulated book (paper).
     let position: f64;
     let mut fills: Vec<(OrderSide, f64, f64)> = Vec::new(); // paper sim only
+    let mut exit_fill_observed = false;
     if live {
         let now = chrono::Utc::now().timestamp();
         let (orders, positions, filled_orders, trades) = tokio::join!(
@@ -109,6 +110,7 @@ pub(super) async fn maker_cycle(
 
         // Open maker orders identify partial fills; historical maker orders
         // identify a quote that fully filled between two polling cycles.
+        let mut exit_order_ids = HashSet::new();
         for order in orders.iter().chain(filled_orders.iter()) {
             if is_maker_order(order) {
                 let order_id = order.id.parse::<u64>().map_err(|_| {
@@ -118,6 +120,13 @@ pub(super) async fn maker_cycle(
                     )
                 })?;
                 maker_order_ids.insert(order_id);
+                if order
+                    .cl_ord_id
+                    .as_deref()
+                    .is_some_and(|id| id.starts_with("sxmk-exit-"))
+                {
+                    exit_order_ids.insert(order_id);
+                }
             }
         }
 
@@ -140,6 +149,7 @@ pub(super) async fn maker_cycle(
             let (side, price, qty) = maker_trade_fill(&trade)?;
             stats.record_fill(side, price, qty, mark);
             fills.push((side, price, qty));
+            exit_fill_observed |= exit_order_ids.contains(&order_id);
         }
 
         position = positions
@@ -237,7 +247,7 @@ pub(super) async fn maker_cycle(
     // 3. Decide. When the volatility breaker is tripped, quote nothing —
     //    an empty desired set makes reconcile cancel every resting quote
     //    (pull all liquidity) and place none until volatility subsides.
-    let inventory_exit = if live {
+    let raw_inventory_exit = if live {
         standx_sdk::maker::inventory_exit_plan(
             position,
             cfg.max_position,
@@ -247,14 +257,22 @@ pub(super) async fn maker_cycle(
     } else {
         None
     };
-    if inventory_exit.is_none() {
+    if exit_fill_observed {
         *inventory_exit_pending = false;
     }
-    if inventory_exit.is_some() && *inventory_exit_pending {
+    if raw_inventory_exit.is_none() {
+        *inventory_exit_pending = false;
+    }
+    if raw_inventory_exit.is_some() && *inventory_exit_pending {
         return Err(anyhow::anyhow!(
             "inventory exit is still awaiting venue confirmation; refusing to submit another"
         ));
     }
+
+    // Volatility halt pulls liquidity but deliberately does not send the
+    // opt-in market exit: de-risking at a taker price during the most
+    // dislocated interval requires a separate explicit emergency policy.
+    let inventory_exit = if halted { None } else { raw_inventory_exit };
 
     let desired = if halted || inventory_exit.is_some() {
         Vec::new()
@@ -460,8 +478,8 @@ pub(super) async fn maker_cycle(
         }
     }
 
-    // 5. Telemetry: fold this cycle into the running stats (live infers a
-    //    fill from any position delta; paper already recorded exact fills).
+    // 5. Telemetry uses exact ledger fills in live mode and simulated fills
+    // in paper mode; never infer a fill from a position delta.
     let two_sided = resting.iter().any(|r| r.side == OrderSide::Buy)
         && resting.iter().any(|r| r.side == OrderSide::Sell);
     stats.end_cycle(position, two_sided);

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -26,9 +26,12 @@ pub(super) async fn maker_cycle(
     best_bid: Option<f64>,
     best_ask: Option<f64>,
     max_divergence_bps: f64,
+    inventory_exit_pct: f64,
+    inventory_exit_qty: f64,
     resting: &mut Vec<standx_sdk::maker::RestingQuote>,
     adopted: &mut HashMap<String, (u32, f64, u64)>,
     pending: &mut Vec<PendingPlace>,
+    inventory_exit_pending: &mut bool,
     maker_order_ids: &mut HashSet<u64>,
     seen_fill_ids: &mut HashSet<u64>,
     session_started_at: i64,
@@ -234,7 +237,26 @@ pub(super) async fn maker_cycle(
     // 3. Decide. When the volatility breaker is tripped, quote nothing —
     //    an empty desired set makes reconcile cancel every resting quote
     //    (pull all liquidity) and place none until volatility subsides.
-    let desired = if halted {
+    let inventory_exit = if live {
+        standx_sdk::maker::inventory_exit_plan(
+            position,
+            cfg.max_position,
+            inventory_exit_pct,
+            inventory_exit_qty,
+        )
+    } else {
+        None
+    };
+    if inventory_exit.is_none() {
+        *inventory_exit_pending = false;
+    }
+    if inventory_exit.is_some() && *inventory_exit_pending {
+        return Err(anyhow::anyhow!(
+            "inventory exit is still awaiting venue confirmation; refusing to submit another"
+        ));
+    }
+
+    let desired = if halted || inventory_exit.is_some() {
         Vec::new()
     } else {
         let raw = compute_desired_quotes(cfg, mark, best_bid, best_ask, position);
@@ -394,6 +416,47 @@ pub(super) async fn maker_cycle(
                 }
             }
             Action::Hold { .. } => holds += 1,
+        }
+    }
+
+    if let Some(exit) = inventory_exit {
+        // Do not race a reduce-only market order against quote cancellations.
+        // The next cycle must observe an empty maker book before the single
+        // exit request can be submitted.
+        if resting.is_empty() && pending.is_empty() {
+            if !order_response_health.is_some_and(|health| health.load(Ordering::Acquire)) {
+                return Err(anyhow::anyhow!(
+                    "order-response stream is unhealthy; refusing inventory exit"
+                ));
+            }
+            let cl_ord_id = format!("{}exit-{}", MAKER_CL_ORD_ID_PREFIX, uuid::Uuid::new_v4());
+            client
+                .create_order(CreateOrderParams {
+                    symbol: symbol.to_string(),
+                    cl_ord_id: Some(cl_ord_id),
+                    side: exit.side,
+                    order_type: OrderType::Market,
+                    quantity: format_decimals(exit.qty, cfg.qty_decimals),
+                    price: None,
+                    time_in_force: None,
+                    reduce_only: true,
+                    stop_price: None,
+                    sl_price: None,
+                    tp_price: None,
+                })
+                .await?;
+            *inventory_exit_pending = true;
+            log_maker_event(
+                output_format,
+                symbol,
+                cycle,
+                "inventory_exit_submitted",
+                exit.side,
+                0,
+                mark,
+                cfg.price_decimals,
+                "reduce-only market order submitted after maker book cleared",
+            );
         }
     }
 

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -281,6 +281,8 @@ pub async fn handle_maker(
             interval,
             max_position,
             skew_bps,
+            inventory_exit_pct,
+            inventory_exit_qty,
             max_divergence_bps,
             vol_pause_bps,
             vol_window,
@@ -304,6 +306,8 @@ pub async fn handle_maker(
                     interval,
                     max_position,
                     skew_bps,
+                    inventory_exit_pct,
+                    inventory_exit_qty,
                     max_divergence_bps,
                     vol_pause_bps,
                     vol_window,
@@ -333,6 +337,8 @@ struct MakerRunArgs {
     interval: u64,
     max_position: f64,
     skew_bps: f64,
+    inventory_exit_pct: f64,
+    inventory_exit_qty: f64,
     max_divergence_bps: f64,
     vol_pause_bps: f64,
     vol_window: u32,
@@ -401,6 +407,16 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     }
     if cfg.skew_bps < 0.0 {
         return Err(anyhow::anyhow!("--skew-bps must be >= 0"));
+    }
+    if !(0.0..=100.0).contains(&args.inventory_exit_pct) || args.inventory_exit_qty < 0.0 {
+        return Err(anyhow::anyhow!(
+            "--inventory-exit-pct must be 0..=100 and --inventory-exit-qty must be >= 0"
+        ));
+    }
+    if (args.inventory_exit_pct > 0.0) != (args.inventory_exit_qty > 0.0) {
+        return Err(anyhow::anyhow!(
+            "active inventory exit requires both --inventory-exit-pct and --inventory-exit-qty"
+        ));
     }
     if cfg.band_bps <= cfg.spread_bps {
         return Err(anyhow::anyhow!(
@@ -499,6 +515,12 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
                 cfg.skew_bps
             );
         }
+        if args.inventory_exit_pct > 0.0 {
+            println!(
+                "│ active exit: {}% of max, reduce-only chunks of {} (live only)",
+                args.inventory_exit_pct, args.inventory_exit_qty
+            );
+        }
         println!(
             "│ ticks: price {}dp, qty {}dp | min qty {}",
             cfg.price_decimals, cfg.qty_decimals, cfg.min_order_qty
@@ -588,6 +610,7 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     let mut resting: Vec<RestingQuote> = Vec::new(); // paper-mode book
     let mut adopted: HashMap<String, (u32, f64, u64)> = HashMap::new(); // id -> (level, ref_mark, cycle)
     let mut pending: Vec<PendingPlace> = Vec::new();
+    let mut inventory_exit_pending = false;
     let mut maker_order_ids: HashSet<u64> = HashSet::new();
     let mut seen_fill_ids: HashSet<u64> = HashSet::new();
     let session_started_at = chrono::Utc::now().timestamp();
@@ -643,9 +666,12 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
                 best_bid,
                 best_ask,
                 args.max_divergence_bps,
+                args.inventory_exit_pct,
+                args.inventory_exit_qty,
                 &mut resting,
                 &mut adopted,
                 &mut pending,
+                &mut inventory_exit_pending,
                 &mut maker_order_ids,
                 &mut seen_fill_ids,
                 session_started_at,

--- a/docs/13-maker.md
+++ b/docs/13-maker.md
@@ -63,6 +63,8 @@ standx maker run <SYMBOL> [OPTIONS]
 | `-i, --interval` | `5` | 循环间隔（秒） |
 | `--max-position` | `0.05` | 最大绝对持仓；会把继续加仓的一侧压制掉 |
 | `--skew-bps` | `0` | 库存 skew：满仓时把报价中心向减仓侧偏移的最大幅度（bps），0 关闭。见 [13.3](#库存-skew) |
+| `--inventory-exit-pct` | `0` | 主动减仓触发线：仓位达到 `--max-position` 的此百分比时启动退出流程；需同时设置 `--inventory-exit-qty`，0 关闭 |
+| `--inventory-exit-qty` | `0` | 单次 reduce-only 主动退出的最大数量；先确认 maker 空簿再下市价单，提交后未确认会 fail-safe，0 关闭 |
 | `--max-divergence-bps` | `25` | 当 mark 价与盘口中价背离超过此值时跳过该轮（不动挂单） |
 | `--vol-pause-bps` | `0` | 波动率熔断：mark 在 `--vol-window` 轮内的极差达到此值（bps）即撤掉全部报价暂停，回落到一半以下才恢复。0 关闭。见 [13.3](#波动率熔断) |
 | `--vol-window` | `12` | 波动率熔断测量极差的窗口（最近 N 轮） |
@@ -74,7 +76,7 @@ standx maker run <SYMBOL> [OPTIONS]
 | `--no-ws` | 关 | 禁用 WebSocket 行情，改为每轮 REST 轮询 |
 | `--live` | 关 | 下真实单（不带此标志即 paper 模式） |
 
-启动时会做快速校验（fail fast）：交易对存在且在交易中、`spread-bps > 0`、`band-bps > spread-bps`、`size` 取整后 ≥ 最小下单量、`skew-bps ≥ 0`。
+启动时会做快速校验（fail fast）：交易对存在且在交易中、`spread-bps > 0`、`band-bps > spread-bps`、`size` 取整后 ≥ 最小下单量、`skew-bps ≥ 0`；主动退出必须同时设置百分比与数量。
 
 ---
 
@@ -106,6 +108,10 @@ center = mark × (1 − skew_bps × clamp(position / max_position, ±1) / 1e4)
 持多头时中心下移 → 减仓侧（卖）更贴近 mark（更易成交）、加仓侧（买）更远（更难成交）；持空头相反。这把 `max-position` 从"急刹车"变成"渐进回中"。anti-flicker 的锚点也是这个中心，所以同一条重报规则同时响应 mark 漂移与库存 skew。
 
 > **注意**：paper 模式下 skew 只有在模拟成交累积出仓位后才生效；`--skew-bps 0`（默认）时行为与不带 skew 完全一致。
+
+### 主动库存退出
+
+`--inventory-exit-pct 80 --inventory-exit-qty 0.01` 表示仓位达到上限的 80% 后，先撤销 maker 自有报价；在下一轮确认 maker 空簿且没有待确认下单时，再提交一笔最大 `0.01` 的 reduce-only 市价单。多头只卖出、空头只买入，数量不会超过当前仓位。该功能只在 live 模式生效，默认关闭；退出请求提交后若交易所状态未及时确认，策略会 fail-safe，而不会重复追单。
 
 ### 行情来源与守卫
 

--- a/docs/13-maker.md
+++ b/docs/13-maker.md
@@ -111,7 +111,7 @@ center = mark × (1 − skew_bps × clamp(position / max_position, ±1) / 1e4)
 
 ### 主动库存退出
 
-`--inventory-exit-pct 80 --inventory-exit-qty 0.01` 表示仓位达到上限的 80% 后，先撤销 maker 自有报价；在下一轮确认 maker 空簿且没有待确认下单时，再提交一笔最大 `0.01` 的 reduce-only 市价单。多头只卖出、空头只买入，数量不会超过当前仓位。该功能只在 live 模式生效，默认关闭；退出请求提交后若交易所状态未及时确认，策略会 fail-safe，而不会重复追单。
+`--inventory-exit-pct 80 --inventory-exit-qty 0.01` 表示仓位达到上限的 80% 后，先撤销 maker 自有报价；在下一轮确认 maker 空簿且没有待确认下单时，再提交一笔最大 `0.01` 的 reduce-only 市价单。多头只卖出、空头只买入，数量不会超过当前仓位。该功能只在 live 模式生效，默认关闭。波动熔断期间只撤单、不发送主动市价退出；每笔退出必须由 `sxmk-exit-` 关联成交进入账本后才能允许下一笔 chunk，未确认时策略 fail-safe，不会重复追单。
 
 ### 行情来源与守卫
 


### PR DESCRIPTION
## What changed

- adds opt-in `--inventory-exit-pct` and `--inventory-exit-qty` controls
- when triggered, stops quoting and cancels maker-owned orders first
- submits one reduce-only market exit only after a subsequent cycle observes an empty maker book and no pending placements
- refuses to resubmit an unconfirmed exit, entering fail-safe instead
- documents activation, ordering, and validation rules

## Why

Inventory skew and exposure caps cannot guarantee a timely unwind in a one-way market. A direct market exit is necessary, but it must never race resting maker quotes or repeat blindly after an uncertain venue response.

## Scope and follow-ups

This is stacked on #199. Exit fill confirmation currently relies on the same authenticated trade ledger used for maker fills; more detailed fee and realized-PnL reconciliation, replay simulation, adaptive quote controls, and canary approval remain follow-up work. Live trading remains locked behind `STANDX_ENABLE_LIVE_MAKER=1`.

## Validation

- `cargo test -p standx-sdk --offline` (89 unit + 1 doc test)
- `cargo test -p standx-cli --lib --offline` (36 tests)
- `cargo clippy --workspace --all-targets --offline -- -D warnings`
