### PR TITLE
Extract maker strategy into a standalone crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,6 +1861,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "standx-maker",
  "standx-sdk",
  "tabled",
  "tempfile",
@@ -1870,6 +1871,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "standx-maker"
+version = "0.1.0"
+dependencies = [
+ "standx-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/standx-sdk", "crates/standx-cli"]
+members = ["crates/standx-sdk", "crates/standx-maker", "crates/standx-cli"]
 
 [workspace.package]
 edition = "2021"

--- a/crates/standx-cli/Cargo.toml
+++ b/crates/standx-cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 standx-sdk = { path = "../standx-sdk", version = "0.1.0", features = ["tabled"] }
+standx-maker = { path = "../standx-maker", version = "0.1.0" }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "env", "cargo"] }

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -5,6 +5,7 @@ use super::{
 };
 use crate::cli::*;
 use anyhow::Result;
+use standx_maker::{self as maker, MakerConfig, MakerStats, RestingQuote, VolBreaker};
 use standx_sdk::client::order::CreateOrderParams;
 use standx_sdk::client::StandXClient;
 use standx_sdk::models::{OrderSide, OrderType, TimeInForce, Trade};
@@ -19,7 +20,7 @@ use std::time::Duration;
 pub(super) async fn maker_cycle(
     client: &StandXClient,
     symbol: &str,
-    cfg: &standx_sdk::maker::MakerConfig,
+    cfg: &MakerConfig,
     live: bool,
     cycle: u64,
     mark: f64,
@@ -28,7 +29,7 @@ pub(super) async fn maker_cycle(
     max_divergence_bps: f64,
     inventory_exit_pct: f64,
     inventory_exit_qty: f64,
-    resting: &mut Vec<standx_sdk::maker::RestingQuote>,
+    resting: &mut Vec<RestingQuote>,
     adopted: &mut HashMap<String, (u32, f64, u64)>,
     pending: &mut Vec<PendingPlace>,
     inventory_exit_pending: &mut bool,
@@ -36,12 +37,12 @@ pub(super) async fn maker_cycle(
     seen_fill_ids: &mut HashSet<u64>,
     session_started_at: i64,
     sim_position: &mut f64,
-    stats: &mut standx_sdk::maker::MakerStats,
-    breaker: &mut standx_sdk::maker::VolBreaker,
+    stats: &mut MakerStats,
+    breaker: &mut VolBreaker,
     output_format: OutputFormat,
     order_response_health: Option<&AtomicBool>,
 ) -> Result<(u64, u64, u64, u64)> {
-    use standx_sdk::maker::{
+    use maker::{
         cap_desired_exposure, compute_desired_quotes, format_decimals, mark_mid_divergence_bps,
         paper_quote_filled, reconcile, skew_center, Action, RestingQuote,
     };
@@ -248,7 +249,7 @@ pub(super) async fn maker_cycle(
     //    an empty desired set makes reconcile cancel every resting quote
     //    (pull all liquidity) and place none until volatility subsides.
     let raw_inventory_exit = if live {
-        standx_sdk::maker::inventory_exit_plan(
+        maker::inventory_exit_plan(
             position,
             cfg.max_position,
             inventory_exit_pct,

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -1,5 +1,8 @@
 use crate::cli::*;
 use anyhow::Result;
+use standx_maker::{
+    self as maker, Alert, AlertMonitor, MakerConfig, MakerStats, RestingQuote, VolBreaker,
+};
 use standx_sdk::auth::Credentials;
 use standx_sdk::client::StandXClient;
 use standx_sdk::error::Error as StandxError;
@@ -224,7 +227,7 @@ async fn notify_lifecycle(
 
 #[allow(clippy::too_many_arguments)]
 fn deliver_alert(
-    alert: &standx_sdk::maker::Alert,
+    alert: &Alert,
     symbol: &str,
     output_format: OutputFormat,
     http: Option<&reqwest::Client>,
@@ -353,7 +356,6 @@ struct MakerRunArgs {
 }
 
 async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputFormat) -> Result<()> {
-    use standx_sdk::maker::{self, MakerConfig, RestingQuote};
     use standx_sdk::order_response::OrderResponseStream;
 
     let order_session_id = args.live.then(|| uuid::Uuid::new_v4().to_string());
@@ -621,10 +623,10 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     let mut total_fills: u64 = 0;
     let mut total_halted: u64 = 0;
     let mut sim_position: f64 = 0.0; // paper-mode simulated inventory
-    let mut stats = maker::MakerStats::default();
-    let mut breaker = maker::VolBreaker::new(args.vol_window.max(1) as usize, args.vol_pause_bps);
+    let mut stats = MakerStats::default();
+    let mut breaker = VolBreaker::new(args.vol_window.max(1) as usize, args.vol_pause_bps);
     let mut alerts =
-        maker::AlertMonitor::new(args.alert_loss, args.alert_inventory_pct, args.alert_uptime);
+        AlertMonitor::new(args.alert_loss, args.alert_inventory_pct, args.alert_uptime);
     let mut last_mark: Option<f64> = None;
     let mut last_src: Option<&'static str> = None;
 

--- a/crates/standx-cli/src/commands/maker/output.rs
+++ b/crates/standx-cli/src/commands/maker/output.rs
@@ -1,4 +1,5 @@
 use super::*;
+use standx_maker::{self as maker, Action, MakerConfig, MakerStats};
 use standx_sdk::models::OrderSide;
 
 /// Per-cycle output: one human line + indented actions, or JSON lines.
@@ -12,15 +13,15 @@ pub(super) fn emit_maker_cycle(
     best_bid: Option<f64>,
     best_ask: Option<f64>,
     position: f64,
-    actions: &[standx_sdk::maker::Action],
+    actions: &[Action],
     // Paper-mode simulated fills this cycle: (side, price, qty). Empty in live.
     fills: &[(OrderSide, f64, f64)],
-    stats: &standx_sdk::maker::MakerStats,
+    stats: &MakerStats,
     // Some(vol_bps) when the volatility breaker halted quoting this cycle.
     halt_vol_bps: Option<f64>,
-    cfg: &standx_sdk::maker::MakerConfig,
+    cfg: &MakerConfig,
 ) {
-    use standx_sdk::maker::{format_decimals, Action};
+    use maker::format_decimals;
 
     let pnl = stats.pnl(position, mark);
 
@@ -241,7 +242,7 @@ pub(super) fn log_maker_event(
     price_decimals: u32,
     detail: &str,
 ) {
-    use standx_sdk::maker::format_decimals;
+    use maker::format_decimals;
     match output_format {
         OutputFormat::Json => {
             println!(

--- a/crates/standx-maker/Cargo.toml
+++ b/crates/standx-maker/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "standx-maker"
+version = "0.1.0"
+description = "Deterministic market-making strategy and risk engine for StandX"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+standx-sdk = { path = "../standx-sdk", version = "0.1.0" }

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -15,7 +15,7 @@
 //! ad-hoc f64 math on the API's string values); if symbols with more than ~8
 //! price decimals ever list, revisit with a decimal type.
 
-use crate::models::OrderSide;
+use standx_sdk::models::OrderSide;
 
 /// Static per-run configuration (CLI args + symbol metadata).
 #[derive(Debug, Clone)]

--- a/crates/standx-sdk/src/lib.rs
+++ b/crates/standx-sdk/src/lib.rs
@@ -40,7 +40,6 @@
 pub mod auth;
 pub mod client;
 pub mod error;
-pub mod maker;
 pub mod models;
 pub mod order_response;
 pub mod websocket;


### PR DESCRIPTION
## Summary
- Move the market-making strategy, risk controls, and alert types out of `standx-sdk` into a new `standx-maker` crate.
- Update the CLI to depend on the new crate directly and import maker-specific types from there.
- Remove the maker module from the SDK public surface and update the workspace membership accordingly.

## Testing
- Not run (not requested)