### PR TITLE
Adopt live maker inventory and add position reconciliation

### DIFF
--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -1,7 +1,7 @@
 use super::output::{emit_maker_cycle, log_maker_event};
 use super::{
-    is_maker_order, is_order_rejection, open_qty_adopts, pending_covers_slot, PendingPlace,
-    MAKER_CL_ORD_ID_PREFIX,
+    is_current_run_order, is_maker_order, is_order_rejection, open_qty_adopts, pending_covers_slot,
+    position_for_symbol, MakerFill, PendingPlace,
 };
 use crate::cli::*;
 use anyhow::Result;
@@ -11,7 +11,114 @@ use standx_sdk::client::StandXClient;
 use standx_sdk::models::{Balance, OrderSide, OrderType, TimeInForce, Trade};
 use standx_sdk::order_response::OrderResponseHealth;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::time::Duration;
+
+#[derive(Debug)]
+pub(super) struct PositionReconciliationError {
+    pub(super) expected: f64,
+    pub(super) observed: f64,
+}
+
+impl fmt::Display for PositionReconciliationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "expected position {:+.8}, venue reported {:+.8}",
+            self.expected, self.observed
+        )
+    }
+}
+
+impl std::error::Error for PositionReconciliationError {}
+
+fn quote_client_order_id(
+    run_order_prefix: &str,
+    cycle: u64,
+    side: OrderSide,
+    level: u32,
+) -> String {
+    let side_code = match side {
+        OrderSide::Buy => 'b',
+        OrderSide::Sell => 's',
+    };
+    format!(
+        "{run_order_prefix}q{:08x}{side_code}{level:x}",
+        cycle as u32
+    )
+}
+
+fn exit_client_order_id(run_order_prefix: &str, cycle: u64) -> String {
+    format!("{run_order_prefix}x{:08x}", cycle as u32)
+}
+
+fn trade_is_in_session(trade: &Trade, session_started_at: i64, now: i64) -> Result<bool> {
+    let timestamp = chrono::DateTime::parse_from_rfc3339(&trade.time).map_err(|_| {
+        anyhow::anyhow!(
+            "maker trade {} has invalid RFC3339 timestamp '{}'",
+            trade.id,
+            trade.time
+        )
+    })?;
+    let timestamp = timestamp.timestamp();
+    Ok(timestamp >= session_started_at && timestamp <= now)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_current_run_fills(
+    trades: Vec<Trade>,
+    maker_order_ids: &HashSet<u64>,
+    exit_order_ids: &HashSet<u64>,
+    seen_fill_ids: &mut HashSet<u64>,
+    session_started_at: i64,
+    now: i64,
+    mark: f64,
+    stats: &mut MakerStats,
+    fills: &mut Vec<MakerFill>,
+    expected_position: &mut f64,
+) -> Result<bool> {
+    let mut exit_fill_observed = false;
+    for trade in trades {
+        let Some(order_id) = trade.order_id else {
+            continue;
+        };
+        if !maker_order_ids.contains(&order_id) {
+            continue;
+        }
+        if trade.id == 0 {
+            return Err(anyhow::anyhow!(
+                "maker fill for order {} has no stable trade ID",
+                order_id
+            ));
+        }
+        if !trade_is_in_session(&trade, session_started_at, now)? {
+            return Err(anyhow::anyhow!(
+                "current-run maker trade {} falls outside the session time boundary",
+                trade.id
+            ));
+        }
+        if !seen_fill_ids.insert(trade.id) {
+            continue;
+        }
+        let (side, price, qty) = maker_trade_fill(&trade)?;
+        stats.record_fill(side, price, qty, mark);
+        *expected_position += match side {
+            OrderSide::Buy => qty,
+            OrderSide::Sell => -qty,
+        };
+        fills.push(MakerFill {
+            side,
+            price,
+            qty,
+            trade_id: Some(trade.id),
+            order_id: Some(order_id),
+            trade_ts: Some(trade.time),
+            origin: "current_run",
+        });
+        exit_fill_observed |= exit_order_ids.contains(&order_id);
+    }
+    Ok(exit_fill_observed)
+}
 
 fn unhealthy_order_response(health: Option<&OrderResponseHealth>) -> Option<String> {
     match health {
@@ -46,6 +153,9 @@ pub(super) async fn maker_cycle(
     maker_order_ids: &mut HashSet<u64>,
     seen_fill_ids: &mut HashSet<u64>,
     session_started_at: i64,
+    run_order_prefix: &str,
+    starting_position: f64,
+    expected_position: &mut f64,
     sim_position: &mut f64,
     stats: &mut MakerStats,
     breaker: &mut VolBreaker,
@@ -103,19 +213,17 @@ pub(super) async fn maker_cycle(
     //    simulated book (paper).
     let position: f64;
     let mut account_balance: Option<Balance> = None;
-    let mut fills: Vec<(OrderSide, f64, f64)> = Vec::new(); // paper sim only
+    let mut fills: Vec<MakerFill> = Vec::new();
     let mut exit_fill_observed = false;
     if live {
         let now = chrono::Utc::now().timestamp();
-        let (orders, positions, filled_orders, trades, balance) = tokio::join!(
+        let (orders, filled_orders, trades, balance) = tokio::join!(
             client.get_open_orders(Some(symbol)),
-            client.get_positions(Some(symbol)),
             client.get_order_history(Some(symbol), Some(100)),
             client.get_user_trades(symbol, session_started_at, now, Some(500)),
             client.get_balance(),
         );
-        let orders = orders?;
-        let positions = positions?;
+        let mut orders = orders?;
         let filled_orders = filled_orders?;
         let trades = trades?;
         account_balance = Some(balance?);
@@ -124,10 +232,10 @@ pub(super) async fn maker_cycle(
         // identify a quote that fully filled between two polling cycles.
         let mut exit_order_ids = HashSet::new();
         for order in orders.iter().chain(filled_orders.iter()) {
-            if is_maker_order(order) {
+            if is_current_run_order(order, run_order_prefix) {
                 let order_id = order.id.parse::<u64>().map_err(|_| {
                     anyhow::anyhow!(
-                        "maker-owned order has non-integer exchange ID '{}'",
+                        "current-run maker order has non-integer exchange ID '{}'",
                         order.id
                     )
                 })?;
@@ -135,51 +243,104 @@ pub(super) async fn maker_cycle(
                 if order
                     .cl_ord_id
                     .as_deref()
-                    .is_some_and(|id| id.starts_with("sxmk-exit-"))
+                    .is_some_and(|id| id.starts_with(&format!("{run_order_prefix}x")))
                 {
                     exit_order_ids.insert(order_id);
                 }
             }
         }
 
-        for trade in trades {
-            let Some(order_id) = trade.order_id else {
-                continue;
-            };
-            if !maker_order_ids.contains(&order_id) {
-                continue;
-            }
-            if trade.id == 0 {
-                return Err(anyhow::anyhow!(
-                    "maker fill for order {} has no stable trade ID",
-                    order_id
-                ));
-            }
-            if !seen_fill_ids.insert(trade.id) {
-                continue;
-            }
-            let (side, price, qty) = maker_trade_fill(&trade)?;
-            stats.record_fill(side, price, qty, mark);
-            fills.push((side, price, qty));
-            exit_fill_observed |= exit_order_ids.contains(&order_id);
-        }
+        exit_fill_observed |= collect_current_run_fills(
+            trades,
+            maker_order_ids,
+            &exit_order_ids,
+            seen_fill_ids,
+            session_started_at,
+            now,
+            mark,
+            stats,
+            &mut fills,
+            expected_position,
+        )?;
 
-        position = positions
-            .iter()
-            .filter(|p| p.symbol.eq_ignore_ascii_case(symbol))
-            .map(|p| {
-                let qty: f64 = p.qty.parse().unwrap_or(0.0);
-                match p.side {
-                    Some(OrderSide::Sell) => -qty,
-                    _ => qty,
+        let positions = client.get_positions(Some(symbol)).await?;
+        let mut observed_position = position_for_symbol(&positions, symbol)?;
+        let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
+        if (observed_position - *expected_position).abs() > qty_tolerance {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let retry_now = chrono::Utc::now().timestamp();
+            let (retry_orders, retry_filled_orders, retry_trades) = tokio::join!(
+                client.get_open_orders(Some(symbol)),
+                client.get_order_history(Some(symbol), Some(100)),
+                client.get_user_trades(symbol, session_started_at, retry_now, Some(500)),
+            );
+            orders = retry_orders?;
+            let retry_filled_orders = retry_filled_orders?;
+            for order in orders.iter().chain(retry_filled_orders.iter()) {
+                if is_current_run_order(order, run_order_prefix) {
+                    let order_id = order.id.parse::<u64>().map_err(|_| {
+                        anyhow::anyhow!(
+                            "current-run maker order has non-integer exchange ID '{}'",
+                            order.id
+                        )
+                    })?;
+                    maker_order_ids.insert(order_id);
+                    if order
+                        .cl_ord_id
+                        .as_deref()
+                        .is_some_and(|id| id.starts_with(&format!("{run_order_prefix}x")))
+                    {
+                        exit_order_ids.insert(order_id);
+                    }
                 }
-            })
-            .sum();
+            }
+            exit_fill_observed |= collect_current_run_fills(
+                retry_trades?,
+                maker_order_ids,
+                &exit_order_ids,
+                seen_fill_ids,
+                session_started_at,
+                retry_now,
+                mark,
+                stats,
+                &mut fills,
+                expected_position,
+            )?;
+            let retry_positions = client.get_positions(Some(symbol)).await?;
+            observed_position = position_for_symbol(&retry_positions, symbol)?;
+            if (observed_position - *expected_position).abs() > qty_tolerance {
+                if output_format == OutputFormat::Json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                            "symbol": symbol,
+                            "cycle": cycle,
+                            "action": "position_reconciliation",
+                            "event": "failed",
+                            "expected_position": *expected_position,
+                            "observed_position": observed_position,
+                            "message": "venue position cannot be explained by current-run maker fills",
+                        })
+                    );
+                } else {
+                    eprintln!(
+                        "⚠️  position reconciliation failed: expected {:+.8}, observed {:+.8}",
+                        *expected_position, observed_position
+                    );
+                }
+                return Err(anyhow::Error::new(PositionReconciliationError {
+                    expected: *expected_position,
+                    observed: observed_position,
+                }));
+            }
+        }
+        position = observed_position;
 
         let tick = cfg.price_tick();
         *resting = orders
             .into_iter()
-            .filter(is_maker_order)
+            .filter(|order| is_current_run_order(order, run_order_prefix))
             .map(|o| {
                 let price: f64 = o.price.parse().unwrap_or(0.0);
                 let qty: f64 = o.qty.parse().unwrap_or(0.0);
@@ -248,7 +409,15 @@ pub(super) async fn maker_cycle(
                     OrderSide::Sell => -q.qty,
                 };
                 stats.record_fill(q.side, q.price, q.qty, mark);
-                fills.push((q.side, q.price, q.qty));
+                fills.push(MakerFill {
+                    side: q.side,
+                    price: q.price,
+                    qty: q.qty,
+                    trade_id: None,
+                    order_id: None,
+                    trade_ts: None,
+                    origin: "paper",
+                });
             } else {
                 i += 1;
             }
@@ -371,7 +540,7 @@ pub(super) async fn maker_cycle(
                     if let Some(reason) = unhealthy_order_response(order_response_health) {
                         return Err(anyhow::anyhow!("{reason}; refusing live placement"));
                     }
-                    let cl_ord_id = format!("{}{}", MAKER_CL_ORD_ID_PREFIX, uuid::Uuid::new_v4());
+                    let cl_ord_id = quote_client_order_id(run_order_prefix, cycle, q.side, q.level);
                     match client
                         .create_order(CreateOrderParams {
                             symbol: symbol.to_string(),
@@ -445,7 +614,7 @@ pub(super) async fn maker_cycle(
             if let Some(reason) = unhealthy_order_response(order_response_health) {
                 return Err(anyhow::anyhow!("{reason}; refusing inventory exit"));
             }
-            let cl_ord_id = format!("{}exit-{}", MAKER_CL_ORD_ID_PREFIX, uuid::Uuid::new_v4());
+            let cl_ord_id = exit_client_order_id(run_order_prefix, cycle);
             client
                 .create_order(CreateOrderParams {
                     symbol: symbol.to_string(),
@@ -492,6 +661,7 @@ pub(super) async fn maker_cycle(
         best_bid,
         best_ask,
         position,
+        starting_position,
         account_balance.as_ref(),
         &actions,
         &fills,
@@ -663,5 +833,109 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("invalid price"));
+    }
+
+    #[test]
+    fn current_run_fill_is_recorded_once_with_trade_identity() {
+        let trade = trade(Some("buy"), "59.50", "0.20");
+        let start = chrono::DateTime::parse_from_rfc3339("2026-07-10T00:00:00Z")
+            .unwrap()
+            .timestamp();
+        let mut stats = MakerStats::default();
+        let mut seen = HashSet::new();
+        let maker_orders = HashSet::from([7]);
+        let mut fills = Vec::new();
+        let mut expected_position = 0.0;
+
+        collect_current_run_fills(
+            vec![trade.clone()],
+            &maker_orders,
+            &HashSet::new(),
+            &mut seen,
+            start,
+            start + 60,
+            59.50,
+            &mut stats,
+            &mut fills,
+            &mut expected_position,
+        )
+        .unwrap();
+        collect_current_run_fills(
+            vec![trade],
+            &maker_orders,
+            &HashSet::new(),
+            &mut seen,
+            start,
+            start + 60,
+            59.50,
+            &mut stats,
+            &mut fills,
+            &mut expected_position,
+        )
+        .unwrap();
+
+        assert_eq!(stats.fills(), 1);
+        assert_eq!(fills.len(), 1);
+        assert_eq!(fills[0].trade_id, Some(42));
+        assert_eq!(fills[0].order_id, Some(7));
+        assert_eq!(fills[0].origin, "current_run");
+        assert!((expected_position - 0.2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn historical_trade_without_current_run_order_is_ignored() {
+        let mut stats = MakerStats::default();
+        let mut seen = HashSet::new();
+        let mut fills = Vec::new();
+        let mut expected_position = -0.13;
+        collect_current_run_fills(
+            vec![trade(Some("sell"), "59.50", "0.20")],
+            &HashSet::new(),
+            &HashSet::new(),
+            &mut seen,
+            1_783_000_000,
+            1_784_000_000,
+            59.50,
+            &mut stats,
+            &mut fills,
+            &mut expected_position,
+        )
+        .unwrap();
+        assert_eq!(stats.fills(), 0);
+        assert!(fills.is_empty());
+        assert_eq!(expected_position, -0.13);
+    }
+
+    #[test]
+    fn current_run_trade_outside_session_is_rejected() {
+        let mut stats = MakerStats::default();
+        let mut seen = HashSet::new();
+        let mut fills = Vec::new();
+        let mut expected_position = 0.0;
+        let error = collect_current_run_fills(
+            vec![trade(Some("buy"), "59.50", "0.20")],
+            &HashSet::from([7]),
+            &HashSet::new(),
+            &mut seen,
+            1_783_700_000,
+            1_783_700_100,
+            59.50,
+            &mut stats,
+            &mut fills,
+            &mut expected_position,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("outside the session"));
+    }
+
+    #[test]
+    fn current_run_client_order_ids_are_bounded_and_scoped() {
+        let prefix = "sxmk-0123456789ab-";
+        let quote = quote_client_order_id(prefix, u64::MAX, OrderSide::Sell, u32::MAX);
+        let exit = exit_client_order_id(prefix, u64::MAX);
+        assert!(quote.starts_with(prefix));
+        assert!(exit.starts_with(prefix));
+        assert!(quote.len() <= 41, "{quote}");
+        assert!(exit.len() <= 41, "{exit}");
     }
 }

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -17,7 +17,7 @@ mod cycle;
 mod feed;
 mod output;
 
-use cycle::{cancel_maker_orders_with_retry, maker_cycle};
+use cycle::{cancel_maker_orders_with_retry, maker_cycle, PositionReconciliationError};
 use feed::{market_snapshot, spawn_market_feed};
 
 // ============================================================================
@@ -38,6 +38,8 @@ enum MakerExit {
     OrderResponse(String),
     /// Three consecutive transient maker-cycle failures.
     ConsecutiveErrors(String),
+    /// Venue position cannot be explained by fills owned by this run.
+    PositionReconciliation(String),
 }
 
 impl MakerExit {
@@ -49,6 +51,9 @@ impl MakerExit {
             }
             Self::ConsecutiveErrors(error) => {
                 format!("fail-safe: 3 consecutive maker cycle errors: {error}")
+            }
+            Self::PositionReconciliation(error) => {
+                format!("fail-safe: position reconciliation failed: {error}")
             }
         }
     }
@@ -62,8 +67,22 @@ impl MakerExit {
             Self::ConsecutiveErrors(error) => Some(format!(
                 "maker stopped after 3 consecutive maker cycle errors (fail-safe): {error}"
             )),
+            Self::PositionReconciliation(error) => Some(format!(
+                "maker stopped immediately (fail-safe): position reconciliation failed: {error}"
+            )),
         }
     }
+}
+
+#[derive(Clone, Debug)]
+struct MakerFill {
+    side: OrderSide,
+    price: f64,
+    qty: f64,
+    trade_id: Option<u64>,
+    order_id: Option<u64>,
+    trade_ts: Option<String>,
+    origin: &'static str,
 }
 
 /// Pending place awaiting order-id adoption in live mode. The HTTP request is
@@ -87,6 +106,39 @@ fn is_maker_order(order: &Order) -> bool {
         .cl_ord_id
         .as_deref()
         .is_some_and(|id| id.starts_with(MAKER_CL_ORD_ID_PREFIX))
+}
+
+fn is_current_run_order(order: &Order, run_order_prefix: &str) -> bool {
+    order
+        .cl_ord_id
+        .as_deref()
+        .is_some_and(|id| id.starts_with(run_order_prefix))
+}
+
+fn position_for_symbol(positions: &[Position], symbol: &str) -> Result<f64> {
+    positions
+        .iter()
+        .filter(|position| position.symbol.eq_ignore_ascii_case(symbol))
+        .try_fold(0.0, |total, position| {
+            let qty = position.qty.parse::<f64>().map_err(|_| {
+                anyhow::anyhow!("position on {symbol} has invalid qty '{}'", position.qty)
+            })?;
+            if !qty.is_finite() || qty < 0.0 {
+                return Err(anyhow::anyhow!(
+                    "position on {symbol} has invalid non-finite/negative qty"
+                ));
+            }
+            Ok(total
+                + match position.side {
+                    Some(OrderSide::Sell) => -qty,
+                    _ => qty,
+                })
+        })
+}
+
+fn starting_position_within_limit(position: f64, max_position: f64, qty_decimals: u32) -> bool {
+    let qty_tolerance = 10_f64.powi(-(qty_decimals as i32)) / 2.0;
+    position.abs() <= max_position + qty_tolerance
 }
 
 /// A submitted placement reserves its `(side, level)` until it is either
@@ -250,6 +302,81 @@ async fn notify_lifecycle(
         } else {
             tokio::spawn(post_webhook(client.clone(), url.clone(), body));
         }
+    }
+}
+
+fn emit_ledger_sync(
+    output_format: OutputFormat,
+    symbol: &str,
+    starting_position: f64,
+    baseline_mark: f64,
+    historical_orders: usize,
+    historical_trades: usize,
+) {
+    if output_format == OutputFormat::Json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                "symbol": symbol,
+                "action": "ledger_sync",
+                "event": "complete",
+                "starting_position": starting_position,
+                "baseline_mark": baseline_mark,
+                "pnl_baseline": 0.0,
+                "historical_maker_orders": historical_orders,
+                "historical_maker_trades_ignored": historical_trades,
+                "history_window_seconds": 24 * 60 * 60,
+                "history_order_limit": 100,
+                "history_trade_limit": 500,
+                "current_run_fills": 0,
+            })
+        );
+        if starting_position.abs() > f64::EPSILON {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                    "symbol": symbol,
+                    "action": "inventory_adopted",
+                    "event": "complete",
+                    "starting_position": starting_position,
+                    "baseline_mark": baseline_mark,
+                    "pnl_baseline": 0.0,
+                })
+            );
+        }
+    } else {
+        eprintln!(
+            "✅ maker ledger synchronized: position={starting_position:+.8}, baseline mark={baseline_mark:.8}, ignored historical fills={historical_trades}"
+        );
+    }
+}
+
+fn emit_startup_rejected(
+    output_format: OutputFormat,
+    symbol: &str,
+    position: f64,
+    max_position: f64,
+) {
+    let message = format!(
+        "starting position {position:+.8} exceeds max_position {max_position:.8}; refusing live maker"
+    );
+    if output_format == OutputFormat::Json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                "symbol": symbol,
+                "action": "startup_rejected",
+                "event": "position_over_limit",
+                "position": position,
+                "max_position": max_position,
+                "message": message,
+            })
+        );
+    } else {
+        eprintln!("⚠️  {message}");
     }
 }
 
@@ -454,6 +581,7 @@ fn order_response_reconnect_available(failure: &str, attempts_used: u32, max: u3
 
 fn validate_reconnect_snapshot(
     symbol: &str,
+    run_order_prefix: &str,
     open_orders: &[Order],
     positions: &[Position],
     filled_orders: &[Order],
@@ -495,7 +623,7 @@ fn validate_reconnect_snapshot(
 
     let maker_filled_order_ids = filled_orders
         .iter()
-        .filter(|order| is_maker_order(order))
+        .filter(|order| is_current_run_order(order, run_order_prefix))
         .map(|order| {
             order.id.parse::<u64>().map_err(|_| {
                 anyhow::anyhow!(
@@ -535,6 +663,7 @@ async fn query_reconnect_snapshot(
     client: &StandXClient,
     symbol: &str,
     session_started_at: i64,
+    run_order_prefix: &str,
 ) -> Result<ReconnectSnapshot> {
     let now = chrono::Utc::now().timestamp();
     let (open_orders, positions, filled_orders, trades) = tokio::join!(
@@ -545,6 +674,7 @@ async fn query_reconnect_snapshot(
     );
     validate_reconnect_snapshot(
         symbol,
+        run_order_prefix,
         &open_orders?,
         &positions?,
         &filled_orders?,
@@ -557,6 +687,9 @@ async fn reconnect_order_response(
     cleanup_client: StandXClient,
     symbol: &str,
     session_started_at: i64,
+    run_order_prefix: &str,
+    expected_position: f64,
+    qty_tolerance: f64,
     output_format: OutputFormat,
     attempts_used: u32,
     max_attempts: u32,
@@ -590,10 +723,22 @@ async fn reconnect_order_response(
             let stream = OrderResponseStream::new(&session_id)?;
             match tokio::time::timeout(Duration::from_secs(15), stream.connect()).await {
                 Ok(Ok((responses, health, handle))) => {
-                    match query_reconnect_snapshot(&candidate_client, symbol, session_started_at)
-                        .await
+                    match query_reconnect_snapshot(
+                        &candidate_client,
+                        symbol,
+                        session_started_at,
+                        run_order_prefix,
+                    )
+                    .await
                     {
                         Ok(snapshot) => {
+                            if (snapshot.position - expected_position).abs() > qty_tolerance {
+                                handle.abort();
+                                return Err(anyhow::Error::new(PositionReconciliationError {
+                                    expected: expected_position,
+                                    observed: snapshot.position,
+                                }));
+                            }
                             if !health.is_healthy() {
                                 let reason = health.failure_reason().unwrap_or_else(|| {
                                     "new order-response session became unhealthy during reconciliation without a recorded reason".to_string()
@@ -682,6 +827,11 @@ async fn reconnect_order_response(
 
 async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputFormat) -> Result<()> {
     let order_session_id = args.live.then(|| uuid::Uuid::new_v4().to_string());
+    let run_uuid = uuid::Uuid::new_v4().simple().to_string();
+    let run_order_prefix = format!("{}{}-", MAKER_CL_ORD_ID_PREFIX, &run_uuid[..12]);
+    let mut starting_position = 0.0_f64;
+    let mut baseline_mark = 0.0_f64;
+    let mut session_started_at = chrono::Utc::now().timestamp();
 
     if let Some(after) = args.controlled_disconnect_after {
         if !args.live {
@@ -836,6 +986,56 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
         // be adopted or cancelled as stale.
         cancel_maker_orders_with_retry(&client, &symbol, 3, output_format).await?;
 
+        // Establish the session ledger boundary before any new order can be
+        // submitted. Existing inventory is adopted at the current mark, so
+        // maker-session PnL starts at zero while account upnl remains intact.
+        let history_to = chrono::Utc::now().timestamp();
+        let history_from = history_to.saturating_sub(24 * 60 * 60);
+        let (positions, startup_market, filled_orders, historical_trades) = tokio::join!(
+            client.get_positions(Some(&symbol)),
+            market_snapshot(&client, &symbol, None),
+            client.get_order_history(Some(&symbol), Some(100)),
+            client.get_user_trades(&symbol, history_from, history_to, Some(500)),
+        );
+        let positions = positions?;
+        let (mark, _, _, _) = startup_market?;
+        let filled_orders = filled_orders?;
+        let historical_trades = historical_trades?;
+        starting_position = position_for_symbol(&positions, &symbol)?;
+        baseline_mark = mark;
+
+        let historical_order_ids = filled_orders
+            .iter()
+            .filter(|order| is_maker_order(order))
+            .map(|order| {
+                order.id.parse::<u64>().map_err(|_| {
+                    anyhow::anyhow!(
+                        "historical maker order has non-integer exchange ID '{}'",
+                        order.id
+                    )
+                })
+            })
+            .collect::<Result<HashSet<_>>>()?;
+        let historical_maker_orders = historical_order_ids.len();
+        let historical_maker_trades = historical_trades
+            .iter()
+            .filter(|trade| {
+                trade
+                    .order_id
+                    .is_some_and(|order_id| historical_order_ids.contains(&order_id))
+            })
+            .count();
+
+        if !starting_position_within_limit(starting_position, cfg.max_position, cfg.qty_decimals) {
+            emit_startup_rejected(output_format, &symbol, starting_position, cfg.max_position);
+            return Err(anyhow::anyhow!(
+                "starting position {:+.8} exceeds max_position {:.8}",
+                starting_position,
+                cfg.max_position
+            ));
+        }
+        session_started_at = chrono::Utc::now().timestamp();
+
         let stream = OrderResponseStream::new(
             order_session_id
                 .as_deref()
@@ -862,6 +1062,14 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
         order_responses = Some(responses);
         order_response_health = Some(health);
         order_response_handle = Some(handle);
+        emit_ledger_sync(
+            output_format,
+            &symbol,
+            starting_position,
+            baseline_mark,
+            historical_maker_orders,
+            historical_maker_trades,
+        );
     }
 
     let mode = if args.live { "LIVE" } else { "PAPER" };
@@ -989,7 +1197,6 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     let mut inventory_exit_pending = false;
     let mut maker_order_ids: HashSet<u64> = HashSet::new();
     let mut seen_fill_ids: HashSet<u64> = HashSet::new();
-    let session_started_at = chrono::Utc::now().timestamp();
     let mut consecutive_errors: u32 = 0;
     let mut total_places: u64 = 0;
     let mut total_cancels: u64 = 0;
@@ -997,7 +1204,12 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
     let mut total_fills: u64 = 0;
     let mut total_halted: u64 = 0;
     let mut sim_position: f64 = 0.0; // paper-mode simulated inventory
-    let mut stats = MakerStats::default();
+    let mut expected_position = starting_position;
+    let mut stats = if args.live {
+        MakerStats::with_inventory_baseline(starting_position, baseline_mark)
+    } else {
+        MakerStats::default()
+    };
     let mut breaker = VolBreaker::new(args.vol_window.max(1) as usize, args.vol_pause_bps);
     let mut alerts =
         AlertMonitor::new(args.alert_loss, args.alert_inventory_pct, args.alert_uptime);
@@ -1029,6 +1241,9 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
                         client.clone(),
                         &symbol,
                         session_started_at,
+                        &run_order_prefix,
+                        expected_position,
+                        10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0,
                         output_format,
                         order_response_reconnect_attempts_used,
                         args.order_response_reconnect_attempts,
@@ -1052,6 +1267,25 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
                             continue;
                         }
                         Err(error) => {
+                            if let Some(reconciliation) =
+                                error.downcast_ref::<PositionReconciliationError>()
+                            {
+                                if output_format == OutputFormat::Json {
+                                    println!(
+                                        "{}",
+                                        serde_json::json!({
+                                            "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                                            "symbol": symbol,
+                                            "action": "position_reconciliation",
+                                            "event": "failed_during_reconnect",
+                                            "expected_position": reconciliation.expected,
+                                            "observed_position": reconciliation.observed,
+                                            "message": "post-reconnect venue position cannot be explained by current-run maker fills",
+                                        })
+                                    );
+                                }
+                                break MakerExit::PositionReconciliation(error.to_string());
+                            }
                             break MakerExit::OrderResponse(format!(
                                 "{detail}; safe reconnect failed: {error}; refusing further live orders"
                             ));
@@ -1115,6 +1349,9 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
                 &mut maker_order_ids,
                 &mut seen_fill_ids,
                 session_started_at,
+                &run_order_prefix,
+                starting_position,
+                &mut expected_position,
                 &mut sim_position,
                 &mut stats,
                 &mut breaker,
@@ -1165,6 +1402,9 @@ async fn run_maker(symbol: String, args: MakerRunArgs, output_format: OutputForm
                 }
             }
             Err(e) => {
+                if e.downcast_ref::<PositionReconciliationError>().is_some() {
+                    break 'main MakerExit::PositionReconciliation(e.to_string());
+                }
                 consecutive_errors += 1;
                 eprintln!("⚠️  maker cycle failed ({}/3): {}", consecutive_errors, e);
                 if consecutive_errors >= 3 {
@@ -1332,6 +1572,23 @@ mod tests {
     }
 
     #[test]
+    fn position_reconciliation_exit_is_immediate() {
+        let exit = MakerExit::PositionReconciliation(
+            "expected position -0.13000000, venue reported +0.07000000".to_string(),
+        );
+        let terminal = exit.terminal_error().unwrap();
+        assert!(terminal.contains("stopped immediately"));
+        assert!(!terminal.contains("3 consecutive"));
+    }
+
+    #[test]
+    fn inherited_position_allows_half_tick_tolerance_but_rejects_real_excess() {
+        assert!(starting_position_within_limit(0.800_05, 0.8, 3));
+        assert!(!starting_position_within_limit(0.800_6, 0.8, 3));
+        assert!(starting_position_within_limit(-0.8, 0.8, 3));
+    }
+
+    #[test]
     fn reconnect_policy_is_bounded_and_preserves_controlled_fail_safe() {
         assert!(order_response_reconnect_available(
             "order-response WebSocket error: reset",
@@ -1443,6 +1700,7 @@ mod tests {
         let filled = test_order("42", Some("sxmk-filled"));
         let snapshot = validate_reconnect_snapshot(
             "XAG-USD",
+            "sxmk-",
             &[manual],
             &[test_position("sell", "0.2")],
             &[filled],
@@ -1459,6 +1717,7 @@ mod tests {
     fn reconnect_snapshot_rejects_residual_maker_order() {
         let error = validate_reconnect_snapshot(
             "XAG-USD",
+            "sxmk-",
             &[test_order("42", Some("sxmk-still-open"))],
             &[],
             &[],
@@ -1473,6 +1732,7 @@ mod tests {
     fn reconnect_snapshot_rejects_unstable_maker_trade_id() {
         let error = validate_reconnect_snapshot(
             "XAG-USD",
+            "sxmk-",
             &[],
             &[],
             &[test_order("42", Some("sxmk-filled"))],

--- a/crates/standx-cli/src/commands/maker/output.rs
+++ b/crates/standx-cli/src/commands/maker/output.rs
@@ -13,11 +13,11 @@ pub(super) fn emit_maker_cycle(
     best_bid: Option<f64>,
     best_ask: Option<f64>,
     position: f64,
+    starting_position: f64,
     // Real venue account snapshot. Present only in live mode.
     account: Option<&Balance>,
     actions: &[Action],
-    // Paper-mode simulated fills this cycle: (side, price, qty). Empty in live.
-    fills: &[(OrderSide, f64, f64)],
+    fills: &[MakerFill],
     stats: &MakerStats,
     // Some(vol_bps) when the volatility breaker halted quoting this cycle.
     halt_vol_bps: Option<f64>,
@@ -41,14 +41,18 @@ pub(super) fn emit_maker_cycle(
     match output_format {
         OutputFormat::Json => {
             let ts = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-            for (side, price, qty) in fills {
+            for fill in fills {
                 println!(
                     "{}",
                     serde_json::json!({
                         "ts": ts, "cycle": cycle, "mode": mode, "symbol": symbol,
-                        "action": "fill", "side": side,
-                        "price": format_decimals(*price, cfg.price_decimals),
-                        "qty": format_decimals(*qty, cfg.qty_decimals),
+                        "action": "fill", "side": fill.side,
+                        "price": format_decimals(fill.price, cfg.price_decimals),
+                        "qty": format_decimals(fill.qty, cfg.qty_decimals),
+                        "trade_id": fill.trade_id,
+                        "order_id": fill.order_id,
+                        "trade_ts": fill.trade_ts,
+                        "origin": fill.origin,
                     })
                 );
             }
@@ -99,6 +103,7 @@ pub(super) fn emit_maker_cycle(
                     "mark": format_decimals(mark, cfg.price_decimals),
                     "best_bid": best_bid, "best_ask": best_ask,
                     "position": position,
+                    "starting_position": starting_position,
                     "account": account.map(account_json),
                     "holds": holds, "places": places, "cancels": cancels,
                     "fills": fills.len(),
@@ -112,12 +117,12 @@ pub(super) fn emit_maker_cycle(
             );
         }
         OutputFormat::Quiet => {
-            for (side, price, qty) in fills {
+            for fill in fills {
                 println!(
                     "fill {} @ {} x {}",
-                    side_str(*side),
-                    format_decimals(*price, cfg.price_decimals),
-                    format_decimals(*qty, cfg.qty_decimals)
+                    side_str(fill.side),
+                    format_decimals(fill.price, cfg.price_decimals),
+                    format_decimals(fill.qty, cfg.qty_decimals)
                 );
             }
             // Only mutations and their reasons.
@@ -183,12 +188,12 @@ pub(super) fn emit_maker_cycle(
                     format_account_amount(&account.upnl),
                 );
             }
-            for (side, price, qty) in fills {
+            for fill in fills {
                 println!(
                     "    FILL   {} @ {} x {}",
-                    side_str(*side),
-                    format_decimals(*price, cfg.price_decimals),
-                    format_decimals(*qty, cfg.qty_decimals)
+                    side_str(fill.side),
+                    format_decimals(fill.price, cfg.price_decimals),
+                    format_decimals(fill.qty, cfg.qty_decimals)
                 );
             }
             for a in actions {

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -287,6 +287,18 @@ pub struct MakerStats {
 }
 
 impl MakerStats {
+    /// Start a maker session while adopting an existing venue position.
+    /// Session PnL is zero at `baseline_mark`; venue/account PnL retains its
+    /// historical cost basis and is reported separately by the CLI.
+    pub fn with_inventory_baseline(position: f64, baseline_mark: f64) -> Self {
+        Self {
+            cash: -position * baseline_mark,
+            max_abs_position: position.abs(),
+            last_position: position,
+            ..Self::default()
+        }
+    }
+
     /// Record an executed fill at `price` against `mark` at fill time.
     pub fn record_fill(&mut self, side: OrderSide, price: f64, qty: f64, mark: f64) {
         self.filled_qty += qty;
@@ -1487,6 +1499,24 @@ mod tests {
         s.record_fill(OrderSide::Buy, 100.0, 2.0, 100.0);
         assert!((s.pnl(2.0, 101.0) - 2.0).abs() < 1e-9);
         assert!((s.pnl(2.0, 100.0)).abs() < 1e-9); // flat at entry mark
+    }
+
+    #[test]
+    fn stats_adopted_inventory_starts_at_zero_for_long_and_short() {
+        let long = MakerStats::with_inventory_baseline(0.13, 59.72);
+        let short = MakerStats::with_inventory_baseline(-0.13, 59.72);
+        assert!(long.pnl(0.13, 59.72).abs() < 1e-9);
+        assert!(short.pnl(-0.13, 59.72).abs() < 1e-9);
+        assert!((long.pnl(0.13, 60.72) - 0.13).abs() < 1e-9);
+        assert!((short.pnl(-0.13, 60.72) + 0.13).abs() < 1e-9);
+    }
+
+    #[test]
+    fn stats_adopted_inventory_and_new_fill_share_session_basis() {
+        let mut stats = MakerStats::with_inventory_baseline(-0.2, 60.0);
+        stats.record_fill(OrderSide::Buy, 59.5, 0.2, 59.5);
+        assert!((stats.pnl(0.0, 59.5) - 0.1).abs() < 1e-9);
+        assert_eq!(stats.fills(), 1);
     }
 
     #[test]

--- a/crates/standx-sdk/src/client/account.rs
+++ b/crates/standx-sdk/src/client/account.rs
@@ -4,6 +4,7 @@ use crate::auth::{Credentials, StandXSigner};
 use crate::client::StandXClient;
 use crate::error::{Error, Result};
 use crate::models::{Balance, Order, Position};
+use chrono::{SecondsFormat, TimeZone, Utc};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use serde::Deserialize;
 
@@ -16,6 +17,38 @@ struct ApiListResponse<T> {
     #[serde(rename = "page_size")]
     _page_size: Option<i32>,
     result: Vec<T>,
+}
+
+fn trade_history_query(
+    symbol: &str,
+    from: i64,
+    to: i64,
+    limit: Option<u32>,
+) -> Result<Vec<(&'static str, String)>> {
+    if from > to {
+        return Err(Error::Validation {
+            field: "from".to_string(),
+            message: "trade history start must not be after end".to_string(),
+        });
+    }
+    let format = |field: &str, value: i64| {
+        Utc.timestamp_opt(value, 0)
+            .single()
+            .map(|time| time.to_rfc3339_opts(SecondsFormat::Secs, true))
+            .ok_or_else(|| Error::Validation {
+                field: field.to_string(),
+                message: format!("invalid Unix timestamp: {value}"),
+            })
+    };
+    let mut query = vec![
+        ("symbol", symbol.to_string()),
+        ("start", format("from", from)?),
+        ("end", format("to", to)?),
+    ];
+    if let Some(limit) = limit {
+        query.push(("limit", limit.to_string()));
+    }
+    Ok(query)
 }
 
 /// Account-related API methods
@@ -206,14 +239,7 @@ impl StandXClient {
         let url = format!("{}/api/query_trades", self.base_url);
         let headers = self.auth_headers()?;
 
-        let mut query: Vec<(&str, String)> = vec![
-            ("symbol", symbol.to_string()),
-            ("from", from.to_string()),
-            ("to", to.to_string()),
-        ];
-        if let Some(l) = limit {
-            query.push(("limit", l.to_string()));
-        }
+        let query = trade_history_query(symbol, from, to, limit)?;
 
         let response = self
             .client
@@ -382,6 +408,28 @@ impl StandXClient {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod trade_history_tests {
+    use super::*;
+
+    #[test]
+    fn trade_history_query_uses_iso_start_and_end() {
+        let query = trade_history_query("XAG-USD", 1_783_696_499, 1_783_696_560, Some(500))
+            .expect("valid query");
+        assert_eq!(query[0], ("symbol", "XAG-USD".to_string()));
+        assert_eq!(query[1], ("start", "2026-07-10T15:14:59Z".to_string()));
+        assert_eq!(query[2], ("end", "2026-07-10T15:16:00Z".to_string()));
+        assert_eq!(query[3], ("limit", "500".to_string()));
+        assert!(query.iter().all(|(key, _)| *key != "from" && *key != "to"));
+    }
+
+    #[test]
+    fn trade_history_query_rejects_reversed_range() {
+        let error = trade_history_query("XAG-USD", 20, 10, None).unwrap_err();
+        assert!(matches!(error, Error::Validation { field, .. } if field == "from"));
     }
 }
 

--- a/docs/13-maker.md
+++ b/docs/13-maker.md
@@ -69,7 +69,7 @@ standx maker run <SYMBOL> [OPTIONS]
 | `--level-step-bps` | `2` | 档间距（bps，`--levels > 1` 时生效） |
 | `--refresh-bps` | `3` | anti-flicker：报价中心相对下单时漂移超过此值才重报 |
 | `-i, --interval` | `5` | 循环间隔（秒） |
-| `--max-position` | `0.05` | 最大绝对持仓；会把继续加仓的一侧压制掉 |
+| `--max-position` | `0.05` | 最大绝对持仓；会把继续加仓的一侧压制掉；live 启动仓位超过该值时拒绝启动 |
 | `--skew-bps` | `0` | 库存 skew：满仓时把报价中心向减仓侧偏移的最大幅度（bps），0 关闭。见 [13.3](#库存-skew) |
 | `--inventory-exit-pct` | `0` | 主动减仓触发线：仓位达到 `--max-position` 的此百分比时启动退出流程；需同时设置 `--inventory-exit-qty`，0 关闭 |
 | `--inventory-exit-qty` | `0` | 单次 reduce-only 主动退出的最大数量；先确认 maker 空簿再下市价单，提交后未确认会 fail-safe，0 关闭 |
@@ -182,7 +182,9 @@ center = mark × (1 − skew_bps × clamp(position / max_position, ±1) / 1e4)
 三种输出格式：
 
 - **表格（默认）**：每轮一行 `[时间] #轮次 mark= bid= ask= pos= pnl= | hold= place= cancel=`，其下缩进列出 PLACE / CANCEL / HOLD / FILL 明细。Live 模式还会打印 `ACCOUNT balance= equity= available= upnl=`，数据来自该轮交易所账户快照；这里的账户 `upnl` 与机器人本次会话的 `pnl` 是两个不同口径。
-- **JSON（`--output json` 或 `--openclaw`）**：每个动作一行 JSON；每轮末尾一条 `cycle_summary`，含 `position`、`pnl`、`fills_total`、`uptime_pct`、`avg_capture_bps`、`halted`、`vol_bps`，以及 live 模式下的 `account`（`balance`、`equity`、`available`、`upnl`；paper 模式为 `null`）。
+- **JSON（`--output json` 或 `--openclaw`）**：每个动作一行 JSON；每轮末尾一条 `cycle_summary`，含 `position`、`starting_position`、`pnl`、`fills_total`、`uptime_pct`、`avg_capture_bps`、`halted`、`vol_bps`，以及 live 模式下的 `account`（`balance`、`equity`、`available`、`upnl`；paper 模式为 `null`）。`pnl` 和 `fills_total` 只属于当前 maker session：已有仓位按启动 mark 自动接管并把 session PnL 归零，历史交易所盈亏仍看 `account.upnl`。live fill 还包含 `trade_id`、`order_id`、`trade_ts` 与 `origin=current_run`。
+
+live 启动时会先清理旧 `sxmk-` 订单并同步账本。绝对仓位不超过 `max_position` 时自动接管，输出 `ledger_sync` / `inventory_adopted`；超过上限（允许半个数量 tick 误差）则输出 `startup_rejected` 并退出。之后若交易所仓位无法由本 run 的 maker fills 解释，复查一次仍不一致就立即 fail-safe 清理退出。
 - **Quiet（`--quiet`）**：只打印成交与增删挂单。
 
 退出时打印本次会话统计：

--- a/docs/14-maker-live-gate.md
+++ b/docs/14-maker-live-gate.md
@@ -17,7 +17,9 @@ maker by itself.
 
 - Paper mode completes a recorded multi-hour session without panic or invariant failure.
 - Order-response authentication succeeds; a forced disconnect produces fail-safe shutdown and maker-order cleanup.
-- Fill ledger records only `sxmk-` correlated venue fills and does not duplicate trade IDs.
+- Fill ledger records only venue fills whose client-order ID carries the current run tag, enforces the session time boundary, and does not duplicate trade IDs. Historical `sxmk-` trades are ledger-sync evidence, not current-run fills.
+- Existing inventory at or below `max_position` is adopted at the startup mark with maker-session PnL zeroed; inventory above the limit rejects startup after maker-order cleanup.
+- A venue position change that cannot be explained by current-run fills is rechecked once, then immediately triggers fail-safe cleanup and shutdown.
 - Inventory-exit configuration remains disabled unless a supervised test has approved its exact threshold and chunk; the recorded XAG-USD test approves only `max_position=0.8`, trigger `25%`, and chunk `0.2`.
 
 ## Supervised canary

--- a/examples/maker-xag-100u.toml
+++ b/examples/maker-xag-100u.toml
@@ -10,8 +10,9 @@
 #
 # Active exit was production-tested only for this exact tuple:
 # max_position=0.8, inventory_exit_pct=25, inventory_exit_qty=0.2.
-# Do not run against manual/pre-existing XAG inventory: maker PnL and
-# alert_loss track maker-correlated fills, not external cost basis.
+# Pre-existing XAG inventory up to max_position is adopted automatically at
+# the startup mark, so maker-session PnL starts at zero. Larger inventory is
+# rejected after maker-order cleanup. Account upnl keeps the venue cost basis.
 
 # Quote geometry
 spread_bps = 7.0

--- a/scripts/openobserve_dashboard.py
+++ b/scripts/openobserve_dashboard.py
@@ -339,13 +339,15 @@ FROM ranked WHERE rn = 1 ORDER BY _timestamp DESC LIMIT 50''',
         panel(
             "standx_key_events",
             "table",
-            "Fail-safe, Cleanup, Exit and Fill Events",
-            "Operational event timeline for the selected run.",
+            "Ledger, Fail-safe, Cleanup, Exit and Fill Events",
+            "Operational and session-ledger event timeline for the selected run.",
             query(
                 stream,
                 f'''SELECT _timestamp, action, event, side, price, qty, reason, message
 FROM "{stream}" WHERE {selected}
-  AND action IN ('fill', 'cancel', 'alert', 'maker_cleanup', 'inventory_exit', 'order_response_reconnect', 'lifecycle')
+  AND action IN ('fill', 'cancel', 'alert', 'maker_cleanup', 'inventory_exit',
+                 'order_response_reconnect', 'position_reconciliation',
+                 'ledger_sync', 'inventory_adopted', 'startup_rejected', 'lifecycle')
 ORDER BY _timestamp DESC LIMIT 200''',
                 [axis("_timestamp", "Time"), axis("action", "Action"), axis("event", "Event"), axis("side", "Side"), axis("reason", "Reason"), axis("message", "Message")],
                 [axis("price", "Price"), axis("qty", "Qty")],


### PR DESCRIPTION
## Summary
- Adopt the venue’s starting position at maker startup and baseline live PnL from the current mark.
- Scope live order IDs to the current run so fills, reconnect validation, and exit orders are attributed deterministically.
- Reconcile observed venue position against current-run fills, with an immediate fail-safe on unexplained drift.
- Emit richer fill metadata in maker output and add coverage for reconciliation and scoped client order IDs.

## Testing
- Added unit tests for current-run fill deduplication, session boundary validation, scoped order IDs, and immediate reconciliation exits.
- Updated reconnect snapshot tests to use the new run-order prefix.
- Not run (not requested).