### PR TITLE
Normalize maker fill/position quantity handling

### DIFF
--- a/crates/standx-cli/src/commands/maker/ledger.rs
+++ b/crates/standx-cli/src/commands/maker/ledger.rs
@@ -46,7 +46,14 @@ pub(super) fn apply_order_update(
         .fill_qty
         .parse::<f64>()
         .map_err(|_| anyhow::anyhow!("account order {} has invalid fill_qty", update.order_id))?;
-    if qty <= 0.0 {
+    if !qty.is_finite() {
+        return Err(anyhow::anyhow!(
+            "account order {} has non-finite fill_qty",
+            update.order_id
+        ));
+    }
+    let qty = qty.abs();
+    if qty == 0.0 {
         return Ok(false);
     }
     let average = update.fill_avg_price.parse::<f64>().map_err(|_| {
@@ -163,4 +170,70 @@ pub(super) fn maker_trade_fill(trade: &Trade) -> Result<(OrderSide, f64, f64)> {
         ));
     }
     Ok((side, price, qty))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use standx_sdk::models::OrderStatus;
+
+    fn order_update(side: OrderSide, fill_qty: &str) -> OrderUpdate {
+        OrderUpdate {
+            seq: 1,
+            order_id: 7,
+            cl_ord_id: Some("sxmk-run-q00000001a0".to_string()),
+            symbol: "BTC-USD".to_string(),
+            side,
+            qty: "0.20".to_string(),
+            fill_qty: fill_qty.to_string(),
+            fill_avg_price: "100.00".to_string(),
+            price: "100.00".to_string(),
+            status: OrderStatus::Filled,
+            reduce_only: false,
+            updated_at: "2026-07-13T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn signed_sell_fill_quantity_is_normalized_before_ledger_ingestion() {
+        let mut ledger = MakerLedger::new(0.0);
+        let mut stats = MakerStats::default();
+        let mut fills = Vec::new();
+
+        apply_order_update(
+            &mut ledger,
+            &order_update(OrderSide::Sell, "-0.20"),
+            "BTC-USD",
+            "sxmk-run-",
+            100.0,
+            &mut stats,
+            &mut fills,
+        )
+        .unwrap();
+
+        assert_eq!(fills.len(), 1);
+        assert_eq!(fills[0].side, OrderSide::Sell);
+        assert!((fills[0].qty - 0.20).abs() < 1e-9);
+        assert!((ledger.expected_position + 0.20).abs() < 1e-9);
+    }
+
+    #[test]
+    fn non_finite_ws_fill_quantity_is_rejected_explicitly() {
+        let mut ledger = MakerLedger::new(0.0);
+        let mut stats = MakerStats::default();
+        let mut fills = Vec::new();
+
+        let error = apply_order_update(
+            &mut ledger,
+            &order_update(OrderSide::Sell, "NaN"),
+            "BTC-USD",
+            "sxmk-run-",
+            100.0,
+            &mut stats,
+            &mut fills,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("non-finite fill_qty"));
+    }
 }

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -255,6 +255,14 @@ mod tests {
             -0.13
         );
         assert!(position_for_symbol(&[test_position("sell", "NaN")], "XAG-USD").is_err());
+        assert_eq!(
+            model::signed_position_quantity("-0.13", None).unwrap(),
+            -0.13
+        );
+        assert_eq!(
+            model::signed_position_quantity("0.13", Some(OrderSide::Sell)).unwrap(),
+            -0.13
+        );
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/model.rs
+++ b/crates/standx-cli/src/commands/maker/model.rs
@@ -64,21 +64,29 @@ pub(super) fn position_for_symbol(positions: &[Position], symbol: &str) -> anyho
         .iter()
         .filter(|position| position.symbol.eq_ignore_ascii_case(symbol))
         .try_fold(0.0, |total, position| {
-            let qty = position.qty.parse::<f64>().map_err(|_| {
-                anyhow::anyhow!("position on {symbol} has invalid qty '{}'", position.qty)
-            })?;
-            if !qty.is_finite() {
-                return Err(anyhow::anyhow!(
-                    "position on {symbol} has invalid non-finite qty"
-                ));
-            }
-            let signed_qty = match position.side {
-                Some(OrderSide::Sell) => -qty.abs(),
-                Some(OrderSide::Buy) => qty.abs(),
-                None => qty,
-            };
+            let signed_qty =
+                signed_position_quantity(&position.qty, position.side).map_err(|error| {
+                    anyhow::anyhow!("position on {symbol} has invalid qty: {error}")
+                })?;
             Ok(total + signed_qty)
         })
+}
+
+pub(super) fn signed_position_quantity(
+    raw_qty: &str,
+    side: Option<OrderSide>,
+) -> anyhow::Result<f64> {
+    let qty = raw_qty
+        .parse::<f64>()
+        .map_err(|_| anyhow::anyhow!("'{raw_qty}' is not numeric"))?;
+    if !qty.is_finite() {
+        return Err(anyhow::anyhow!("'{raw_qty}' is not finite"));
+    }
+    Ok(match side {
+        Some(OrderSide::Sell) => -qty.abs(),
+        Some(OrderSide::Buy) => qty.abs(),
+        None => qty,
+    })
 }
 
 pub(super) fn is_order_rejection(error: &StandxError) -> bool {

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -1,10 +1,12 @@
 use super::ledger::{adopt_order, apply_rest_trade};
-use super::model::{is_current_run_order, is_maker_order, position_for_symbol};
+use super::model::{
+    is_current_run_order, is_maker_order, position_for_symbol, signed_position_quantity,
+};
 use crate::cli::OutputFormat;
 use anyhow::Result;
 use standx_maker::{MakerFill, MakerLedger, MakerStats};
 use standx_sdk::client::StandXClient;
-use standx_sdk::models::{Order, OrderSide, Position, Trade};
+use standx_sdk::models::{Order, Position, Trade};
 use standx_sdk::order_response::{OrderResponse, OrderResponseHealth, OrderResponseStream};
 use std::collections::HashSet;
 use std::fmt;
@@ -316,21 +318,11 @@ pub(super) fn validate_reconnect_snapshot(
         .iter()
         .filter(|position| position.symbol.eq_ignore_ascii_case(symbol))
     {
-        let qty = item.qty.parse::<f64>().map_err(|_| {
+        position += signed_position_quantity(&item.qty, item.side).map_err(|error| {
             anyhow::anyhow!(
-                "reconnect reconciliation found invalid position qty '{}' on {symbol}",
-                item.qty
+                "reconnect reconciliation found invalid position qty on {symbol}: {error}"
             )
         })?;
-        if !qty.is_finite() {
-            return Err(anyhow::anyhow!(
-                "reconnect reconciliation found non-finite position qty on {symbol}"
-            ));
-        }
-        position += match item.side {
-            Some(OrderSide::Sell) => -qty,
-            _ => qty,
-        };
     }
 
     let maker_filled_order_ids = filled_orders

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -142,14 +142,10 @@ fn apply_account_event(
             if !update.symbol.eq_ignore_ascii_case(context.symbol) {
                 return Ok((0, None));
             }
-            let qty = update.qty.parse::<f64>().map_err(|_| {
-                anyhow::anyhow!("account position update has invalid qty '{}'", update.qty)
-            })?;
-            if !qty.is_finite() {
-                return Err(anyhow::anyhow!(
-                    "account position update has non-finite qty"
-                ));
-            }
+            let qty =
+                model::signed_position_quantity(&update.qty, update.side).map_err(|error| {
+                    anyhow::anyhow!("account position update has invalid qty: {error}")
+                })?;
             Ok((0, Some(qty)))
         }
         AccountEvent::TradeShadow { seq, data } => {

--- a/crates/standx-sdk/src/account_stream.rs
+++ b/crates/standx-sdk/src/account_stream.rs
@@ -2,7 +2,7 @@
 
 use crate::auth::Credentials;
 use crate::error::{Error, Result};
-use crate::models::{OrderSide, OrderStatus};
+use crate::models::{deserialize_order_side_optional, OrderSide, OrderStatus};
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::sync::{
@@ -87,6 +87,8 @@ pub struct PositionUpdate {
     #[serde(default, deserialize_with = "u64_string_or_number")]
     pub id: u64,
     pub symbol: String,
+    #[serde(default, deserialize_with = "deserialize_order_side_optional")]
+    pub side: Option<OrderSide>,
     #[serde(deserialize_with = "string_or_number")]
     pub qty: String,
     #[serde(default, deserialize_with = "string_or_number")]
@@ -404,7 +406,17 @@ mod tests {
         .unwrap()
         .unwrap();
         assert!(
-            matches!(position, AccountEvent::Position(update) if update.qty == "0.201" && update.seq == 36)
+            matches!(position, AccountEvent::Position(update) if update.qty == "0.201" && update.side.is_none() && update.seq == 36)
+        );
+
+        let short_position = parse_account_event(
+            r#"{"seq":37,"channel":"position","data":{"id":80853,"symbol":"XAG-USD","qty":"-0.116","entry_price":"58.24","realized_pnl":"7.12","status":"open","updated_at":"2026-07-13T05:56:25Z"}}"#,
+            &health,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(
+            matches!(short_position, AccountEvent::Position(update) if update.side.is_none() && update.qty == "-0.116" && update.seq == 37)
         );
     }
 

--- a/crates/standx-sdk/src/models.rs
+++ b/crates/standx-sdk/src/models.rs
@@ -35,14 +35,16 @@ where
 }
 
 /// Helper to deserialize optional OrderSide from string
-fn deserialize_order_side_optional<'de, D>(deserializer: D) -> Result<Option<OrderSide>, D::Error>
+pub(crate) fn deserialize_order_side_optional<'de, D>(
+    deserializer: D,
+) -> Result<Option<OrderSide>, D::Error>
 where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
     match s.to_lowercase().as_str() {
-        "buy" => Ok(Some(OrderSide::Buy)),
-        "sell" => Ok(Some(OrderSide::Sell)),
+        "buy" | "long" => Ok(Some(OrderSide::Buy)),
+        "sell" | "short" => Ok(Some(OrderSide::Sell)),
         _ => Ok(None),
     }
 }


### PR DESCRIPTION
## Summary
- Reject non-finite WS `fill_qty`/position `qty` values explicitly instead of silently coercing them, and normalize signed quantities (abs + side) consistently across ledger, recovery, and runtime code paths.
- Extract shared `signed_position_quantity` helper in `model.rs` and reuse it from `recovery.rs` and `runtime.rs` to avoid duplicated sign-handling logic.
- Add `side` field to `PositionUpdate` (accepting `buy`/`long`/`sell`/`short`) and improve error messages to include the underlying parse failure reason.

## Test plan
- [x] `cargo test` covers new unit tests in `ledger.rs`, `mod.rs`, and `account_stream.rs`