### PR TITLE
Fix account-stream reconnect: retry with backoff + REST fill backfill

### DIFF
--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -483,6 +483,17 @@ pub enum MakerCommands {
         /// Later attempts use bounded exponential backoff.
         #[arg(long)]
         order_response_reconnect_backoff: Option<u64>,
+        /// Maximum account-stream reconnect attempts after an unhealthy
+        /// disconnect during a live maker run. Each attempt reconnects the
+        /// authenticated account stream, replays buffered events, and backs
+        /// fill gaps with REST trades before reconciling the venue position.
+        /// 0 disables reconnect entirely (fail closed immediately).
+        #[arg(long)]
+        account_stream_reconnect_attempts: Option<u32>,
+        /// Base delay in seconds between account-stream reconnect attempts.
+        /// Later attempts use bounded exponential backoff.
+        #[arg(long)]
+        account_stream_reconnect_backoff: Option<u64>,
         /// Supervised fault injection: close the local order-response stream
         /// after this many seconds. Hidden because it is only for live-gate
         /// validation and is limited by the maker command to 60 seconds.

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -125,7 +125,7 @@ pub enum Commands {
     #[command(visible_alias = "mk")]
     Maker {
         #[command(subcommand)]
-        command: MakerCommands,
+        command: Box<MakerCommands>,
     },
 }
 

--- a/crates/standx-cli/src/commands/maker/config.rs
+++ b/crates/standx-cli/src/commands/maker/config.rs
@@ -30,6 +30,8 @@ pub(super) struct MakerFileConfig {
     pub no_ws: Option<bool>,
     pub order_response_reconnect_attempts: Option<u32>,
     pub order_response_reconnect_backoff: Option<u64>,
+    pub account_stream_reconnect_attempts: Option<u32>,
+    pub account_stream_reconnect_backoff: Option<u64>,
 }
 
 pub(super) fn load(path: Option<&Path>) -> Result<MakerFileConfig> {
@@ -57,7 +59,7 @@ mod tests {
     #[test]
     fn parses_partial_non_sensitive_strategy_file() {
         let config: MakerFileConfig = toml::from_str(
-            "spread_bps = 8\nmax_position = 0.02\nalert_position_change_pct = 20\nno_ws = true\norder_response_reconnect_attempts = 3\norder_response_reconnect_backoff = 2\n",
+            "spread_bps = 8\nmax_position = 0.02\nalert_position_change_pct = 20\nno_ws = true\norder_response_reconnect_attempts = 3\norder_response_reconnect_backoff = 2\naccount_stream_reconnect_attempts = 3\naccount_stream_reconnect_backoff = 2\n",
         )
         .unwrap();
         assert_eq!(config.spread_bps, Some(8.0));
@@ -66,6 +68,8 @@ mod tests {
         assert_eq!(config.no_ws, Some(true));
         assert_eq!(config.order_response_reconnect_attempts, Some(3));
         assert_eq!(config.order_response_reconnect_backoff, Some(2));
+        assert_eq!(config.account_stream_reconnect_attempts, Some(3));
+        assert_eq!(config.account_stream_reconnect_backoff, Some(2));
         assert_eq!(config.size, None);
     }
 
@@ -81,6 +85,8 @@ mod tests {
         assert_eq!(config.inventory_exit_qty, Some(0.0));
         assert_eq!(config.order_response_reconnect_attempts, Some(3));
         assert_eq!(config.order_response_reconnect_backoff, Some(2));
+        assert_eq!(config.account_stream_reconnect_attempts, Some(3));
+        assert_eq!(config.account_stream_reconnect_backoff, Some(2));
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -91,6 +91,8 @@ pub async fn handle_maker(
             live,
             order_response_reconnect_attempts,
             order_response_reconnect_backoff,
+            account_stream_reconnect_attempts,
+            account_stream_reconnect_backoff,
             controlled_disconnect_after,
         } => {
             let file = config::load(maker_config.as_deref())?;
@@ -133,6 +135,16 @@ pub async fn handle_maker(
                         file.order_response_reconnect_backoff,
                         2,
                     ),
+                    account_stream_reconnect_attempts: choose(
+                        account_stream_reconnect_attempts,
+                        file.account_stream_reconnect_attempts,
+                        3,
+                    ),
+                    account_stream_reconnect_backoff: choose(
+                        account_stream_reconnect_backoff,
+                        file.account_stream_reconnect_backoff,
+                        2,
+                    ),
                     controlled_disconnect_after,
                     verbose,
                 },
@@ -172,6 +184,8 @@ struct MakerRunArgs {
     live: bool,
     order_response_reconnect_attempts: u32,
     order_response_reconnect_backoff: u64,
+    account_stream_reconnect_attempts: u32,
+    account_stream_reconnect_backoff: u64,
     controlled_disconnect_after: Option<u64>,
     verbose: bool,
 }

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -337,6 +337,18 @@ pub(super) async fn run_maker(
             "--order-response-reconnect-backoff must be between 1 and 60 seconds when reconnect is enabled"
         ));
     }
+    if args.account_stream_reconnect_attempts > 10 {
+        return Err(anyhow::anyhow!(
+            "--account-stream-reconnect-attempts must be between 0 and 10"
+        ));
+    }
+    if args.account_stream_reconnect_attempts > 0
+        && !(1..=60).contains(&args.account_stream_reconnect_backoff)
+    {
+        return Err(anyhow::anyhow!(
+            "--account-stream-reconnect-backoff must be between 1 and 60 seconds when reconnect is enabled"
+        ));
+    }
     let mut client = match order_session_id.as_deref() {
         Some(session_id) => StandXClient::new()?.with_session_id(session_id),
         None => StandXClient::new()?,
@@ -691,6 +703,10 @@ pub(super) async fn run_maker(
                 "│ order-response recovery: {} attempt(s), {}s base backoff",
                 args.order_response_reconnect_attempts, args.order_response_reconnect_backoff
             );
+            println!(
+                "│ account-stream recovery: {} attempt(s), {}s base backoff",
+                args.account_stream_reconnect_attempts, args.account_stream_reconnect_backoff
+            );
         }
         if args.no_ws {
             println!("│ feed: REST polling (--no-ws)");
@@ -795,6 +811,7 @@ pub(super) async fn run_maker(
     let mut last_mark: Option<f64> = None;
     let mut last_src: Option<&'static str> = None;
     let mut order_response_reconnect_attempts_used = 0_u32;
+    let mut account_stream_reconnect_attempts_used = 0_u32;
     let mut account_position_mismatch: Option<f64> = None;
     let mut runtime_state = MakerState::starting();
     runtime_state.reduce(MakerEvent::StartupReady);
@@ -846,21 +863,125 @@ pub(super) async fn run_maker(
                     handle.abort();
                 }
                 account_events.take();
-                account_stream_epoch = account_stream_epoch.saturating_add(1);
-                let reconnect = async {
-                    let stream = AccountStream::new(account_stream_epoch)?;
-                    stream
-                        .connect(&[
-                            AccountChannel::Order,
-                            AccountChannel::Position,
-                            AccountChannel::Trade,
-                        ])
-                        .await
-                        .map_err(anyhow::Error::from)
+
+                let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
+                if account_stream_reconnect_attempts_used >= args.account_stream_reconnect_attempts
+                {
+                    break MakerExit::PositionReconciliation(format!(
+                        "account stream disconnected ({detail}); reconnect disabled or budget exhausted ({}/{})",
+                        account_stream_reconnect_attempts_used, args.account_stream_reconnect_attempts
+                    ));
+                }
+
+                let mut last_connect_error: Option<String> = None;
+                let mut reconnected = None;
+                while account_stream_reconnect_attempts_used
+                    < args.account_stream_reconnect_attempts
+                {
+                    account_stream_reconnect_attempts_used += 1;
+                    let attempt = account_stream_reconnect_attempts_used;
+                    account_stream_epoch = account_stream_epoch.saturating_add(1);
+                    let reconnect = async {
+                        let stream = AccountStream::new(account_stream_epoch)?;
+                        stream
+                            .connect(&[
+                                AccountChannel::Order,
+                                AccountChannel::Position,
+                                AccountChannel::Trade,
+                            ])
+                            .await
+                            .map_err(anyhow::Error::from)
+                    };
+                    match tokio::time::timeout(Duration::from_secs(15), reconnect).await {
+                        Ok(Ok(triple)) => {
+                            reconnected = Some(triple);
+                            break;
+                        }
+                        Ok(Err(error)) => {
+                            last_connect_error = Some(format!("connect failed: {error}"));
+                        }
+                        Err(_) => {
+                            last_connect_error =
+                                Some("connect timed out after 15 seconds".to_string());
+                        }
+                    }
+                    eprintln!(
+                        "⚠️  account stream reconnect attempt {}/{} failed: {}",
+                        attempt,
+                        args.account_stream_reconnect_attempts,
+                        last_connect_error.as_deref().unwrap_or("unknown error")
+                    );
+                    if attempt < args.account_stream_reconnect_attempts {
+                        let multiplier = 1_u32 << attempt.saturating_sub(1).min(4);
+                        tokio::time::sleep(
+                            Duration::from_secs(args.account_stream_reconnect_backoff)
+                                .saturating_mul(multiplier),
+                        )
+                        .await;
+                    }
+                }
+
+                let Some((mut events, health, handle)) = reconnected else {
+                    runtime_state.reduce(MakerEvent::RecoveryFailed(format!(
+                        "account stream reconnect exhausted: {}",
+                        last_connect_error
+                            .clone()
+                            .unwrap_or_else(|| "no attempts available".to_string())
+                    )));
+                    break MakerExit::PositionReconciliation(format!(
+                        "account stream disconnected ({detail}); reconnect exhausted: {}",
+                        last_connect_error.unwrap_or_else(|| "no attempts available".to_string())
+                    ));
                 };
-                match tokio::time::timeout(Duration::from_secs(3), reconnect).await {
-                    Ok(Ok((mut events, health, handle))) => {
-                        let reconnect_fills = match apply_account_events(
+
+                let mut reconnect_fills = match apply_account_events(
+                    &mut events,
+                    &mut AccountEventState {
+                        ledger: &mut ledger,
+                        stats: &mut stats,
+                    },
+                    &AccountEventContext {
+                        symbol: &symbol,
+                        run_order_prefix: &run_order_prefix,
+                        mark: last_mark.unwrap_or(baseline_mark),
+                        cycle,
+                        output_format,
+                    },
+                ) {
+                    Ok((fills, _)) => fills,
+                    Err(error) => {
+                        handle.abort();
+                        break MakerExit::PositionReconciliation(format!(
+                            "account stream reconnect event validation failed: {error}"
+                        ));
+                    }
+                };
+                let positions = match client.get_positions(Some(&symbol)).await {
+                    Ok(positions) => positions,
+                    Err(error) => {
+                        handle.abort();
+                        break MakerExit::PositionReconciliation(format!(
+                            "account stream reconnect snapshot failed: {error}"
+                        ));
+                    }
+                };
+                let mut observed = match position_for_symbol(&positions, &symbol) {
+                    Ok(position) => position,
+                    Err(error) => {
+                        handle.abort();
+                        break MakerExit::PositionReconciliation(error.to_string());
+                    }
+                };
+
+                if (observed - ledger.expected_position).abs() > qty_tolerance {
+                    // WS events can lag REST settlement across a reconnect: give
+                    // a bounded window to explain the gap with REST trades
+                    // (mirrors the in-cycle freeze-path reconciliation) before
+                    // failing closed.
+                    let mut gap_closed = false;
+                    for delay in [500_u64, 1_000, 1_500] {
+                        tokio::time::sleep(Duration::from_millis(delay)).await;
+                        match apply_account_events(
                             &mut events,
                             &mut AccountEventState {
                                 ledger: &mut ledger,
@@ -874,78 +995,77 @@ pub(super) async fn run_maker(
                                 output_format,
                             },
                         ) {
-                            Ok((fills, _)) => fills,
+                            Ok((fills, _)) => reconnect_fills += fills,
                             Err(error) => {
                                 handle.abort();
-                                break MakerExit::PositionReconciliation(format!(
-                                    "account stream reconnect event validation failed: {error}"
+                                break 'main MakerExit::PositionReconciliation(format!(
+                                    "account stream reconnect event validation failed during REST backfill: {error}"
                                 ));
                             }
-                        };
-                        let positions = match client.get_positions(Some(&symbol)).await {
-                            Ok(positions) => positions,
-                            Err(error) => {
-                                handle.abort();
-                                break MakerExit::PositionReconciliation(format!(
-                                    "account stream reconnect snapshot failed: {error}"
-                                ));
-                            }
-                        };
-                        let observed = match position_for_symbol(&positions, &symbol) {
-                            Ok(position) => position,
-                            Err(error) => {
-                                handle.abort();
-                                break MakerExit::PositionReconciliation(error.to_string());
-                            }
-                        };
-                        if (observed - ledger.expected_position).abs()
-                            > 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0
-                        {
-                            handle.abort();
-                            break MakerExit::PositionReconciliation(format!(
-                                "account stream reconnect snapshot expected {:+.8}, observed {:+.8}",
-                                ledger.expected_position, observed
-                            ));
                         }
-                        account_events = Some(events);
-                        account_stream_health = Some(health);
-                        account_stream_handle = Some(handle);
-                        total_fills += reconnect_fills;
-                        runtime_state.reduce(MakerEvent::CleanupComplete);
-                        runtime_state.reduce(MakerEvent::RecoverySucceeded);
-                        notifier
-                            .risk(
-                                RiskNotice {
-                                    kind: "account_stream",
-                                    severity: "resolved",
-                                    event: "reconnected",
-                                    message: "account stream reauthenticated; empty maker book and position snapshot reconciled",
-                                    symbol: &symbol,
-                                    cycle,
-                                    position_before: None,
-                                    position_after: None,
-                                    expected: Some(ledger.expected_position),
-                                    observed: Some(observed),
-                                },
-                                false,
-                            )
-                        .await;
-                        continue;
+                        match reconcile_ledger_snapshot(
+                            &client,
+                            ReconcileRequest {
+                                symbol: &symbol,
+                                session_started_at,
+                                run_order_prefix: &run_order_prefix,
+                                qty_tolerance,
+                                mark: last_mark.unwrap_or(baseline_mark),
+                            },
+                            &mut ledger,
+                            &mut stats,
+                        )
+                        .await
+                        {
+                            Ok((obs, fills)) => {
+                                observed = obs;
+                                reconnect_fills += fills.len() as u64;
+                                for fill in &fills {
+                                    emit_live_fill(fill, &symbol, cycle, output_format);
+                                }
+                                if (observed - ledger.expected_position).abs() <= qty_tolerance {
+                                    gap_closed = true;
+                                    break;
+                                }
+                            }
+                            Err(error) => eprintln!(
+                                "⚠️  account stream reconnect REST trade backfill failed: {error}"
+                            ),
+                        }
                     }
-                    Ok(Err(error)) => {
+                    if !gap_closed {
+                        handle.abort();
                         break MakerExit::PositionReconciliation(format!(
-                            "account stream reconnect failed after freeze: {error}"
+                            "account stream reconnect snapshot expected {:+.8}, observed {:+.8} (REST trade backfill did not close the gap)",
+                            ledger.expected_position, observed
                         ));
-                    }
-                    Err(_) => {
-                        runtime_state.reduce(MakerEvent::RecoveryFailed(
-                            "account stream reconnect timed out after 3 seconds".to_string(),
-                        ));
-                        break MakerExit::PositionReconciliation(
-                            "account stream reconnect timed out after 3 seconds".to_string(),
-                        );
                     }
                 }
+
+                account_events = Some(events);
+                account_stream_health = Some(health);
+                account_stream_handle = Some(handle);
+                total_fills += reconnect_fills;
+                runtime_state.reduce(MakerEvent::CleanupComplete);
+                runtime_state.reduce(MakerEvent::RecoverySucceeded);
+                notifier
+                    .risk(
+                        RiskNotice {
+                            kind: "account_stream",
+                            severity: "resolved",
+                            event: "reconnected",
+                            message: "account stream reauthenticated; buffered events and REST trades reconciled against the venue position",
+                            symbol: &symbol,
+                            cycle,
+                            position_before: None,
+                            position_after: None,
+                            expected: Some(ledger.expected_position),
+                            observed: Some(observed),
+                        },
+                        false,
+                    )
+                .await;
+                continue;
             }
             if let Some(health) = order_response_health
                 .as_ref()

--- a/crates/standx-cli/src/main.rs
+++ b/crates/standx-cli/src/main.rs
@@ -184,7 +184,7 @@ async fn execute_command(
             commands::handle_block(command, output).await?;
         }
         Commands::Maker { command } => {
-            commands::handle_maker(command, output, verbose).await?;
+            commands::handle_maker(*command, output, verbose).await?;
         }
     }
     Ok(())

--- a/examples/maker.toml
+++ b/examples/maker.toml
@@ -35,5 +35,12 @@ inventory_exit_qty = 0.0
 order_response_reconnect_attempts = 3
 order_response_reconnect_backoff = 2
 
+# Account-stream recovery: each attempt reconnects the authenticated account
+# stream, replays buffered events, and backs any gap with REST trades before
+# reconciling the venue position. Set attempts to 0 to retain immediate
+# fail-safe shutdown on disconnect.
+account_stream_reconnect_attempts = 3
+account_stream_reconnect_backoff = 2
+
 # Use REST market polling instead of the WebSocket feed (normally false)
 no_ws = false


### PR DESCRIPTION
## Summary
Fixes #216.

The account-stream reconnect path (`runtime.rs`, hit on every unhealthy disconnect and guaranteed at least once per day via the 23h50m stream rotation) had two gaps versus the order-response reconnect path:

- **Single attempt, 3s hard timeout** for the whole reconnect (credential load + TCP + TLS + WS handshake + auth), vs. order-response's multi-attempt exponential backoff with a 15s per-attempt timeout.
- **No REST-trade backfill**: any position mismatch after reconnect went straight to a hard `PositionReconciliation` stop, with no attempt to explain the gap via REST trades — unlike the in-cycle freeze path, which retries `reconcile_ledger_snapshot` for up to 3 bounded delays before giving up.

A partial fill landing in the disconnect-to-reconnect window (most likely exactly during the daily rotation) previously meant an immediate live-trading halt with inventory stuck and no exit orders.

## Changes
- Account-stream reconnect now retries with the same bounded exponential backoff pattern as order-response reconnect, using a 15s per-attempt timeout instead of one 3s total timeout.
- On a post-reconnect position mismatch, run the same REST-trade reconciliation (`reconcile_ledger_snapshot`) used by the freeze path, with up to 3 bounded delays, before failing closed.
- New `--account-stream-reconnect-attempts` / `--account-stream-reconnect-backoff` CLI flags and matching `maker.toml` fields (default 3 attempts / 2s backoff, mirroring order-response defaults). Setting attempts to `0` preserves the old fail-closed-on-first-mismatch behavior.
- Updated `examples/maker.toml` and config parsing tests for the new fields.

## Test plan
- [x] `cargo test -p standx-cli` (all maker + config tests pass)
- [x] `cargo clippy -p standx-cli --all-targets` (no new warnings)
- [x] `cargo build --workspace`