### PR TITLE
Decay unmatched order-response buffer and exempt benign acks (fixes #218)

### DIFF
--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -515,10 +515,10 @@ pub(super) async fn maker_cycle(
                 return Err(anyhow::anyhow!("{reason}; refusing inventory exit"));
             }
             let cl_ord_id = maker::exit_client_order_id(run_order_prefix, cycle);
-            client
+            let submission = client
                 .create_order(CreateOrderParams {
                     symbol: symbol.to_string(),
-                    cl_ord_id: Some(cl_ord_id),
+                    cl_ord_id: Some(cl_ord_id.clone()),
                     side: exit.side,
                     order_type: OrderType::Market,
                     quantity: format_decimals(exit.qty, cfg.qty_decimals),
@@ -530,6 +530,21 @@ pub(super) async fn maker_cycle(
                     tp_price: None,
                 })
                 .await?;
+            // Register the exit submission so its asynchronous ack correlates
+            // to a pending entry instead of counting as an unmatched response.
+            // The sentinel level keeps it out of quote-slot reservation; a
+            // reduce-only market order never rests, so reconciliation drops it
+            // when `pending` ages out.
+            pending.push(PendingPlace {
+                request_id: submission.id,
+                cl_ord_id,
+                side: exit.side,
+                price: mark,
+                qty: exit.qty,
+                level: u32::MAX,
+                ref_center: mark,
+                cycle,
+            });
             *inventory_exit_pending = true;
             log_maker_event(MakerLogEvent {
                 output_format,

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -33,7 +33,7 @@ pub(super) fn apply_order_responses(
             runtime_state.reduce(if matched {
                 MakerEvent::OrderResponseMatched(request_id)
             } else {
-                MakerEvent::OrderResponseUnmatched(request_id)
+                MakerEvent::OrderResponseUnmatched { request_id, cycle }
             });
         }
         if runtime_state.is_frozen() {
@@ -1366,7 +1366,7 @@ pub(super) async fn run_maker(
                 runtime_state.reduce(if matched {
                     MakerEvent::OrderResponseMatched(request_id)
                 } else {
-                    MakerEvent::OrderResponseUnmatched(request_id)
+                    MakerEvent::OrderResponseUnmatched { request_id, cycle }
                 });
             }
             if runtime_state.is_frozen() {

--- a/crates/standx-maker/src/runtime.rs
+++ b/crates/standx-maker/src/runtime.rs
@@ -3,6 +3,13 @@
 use std::collections::VecDeque;
 
 const MAX_UNMATCHED_ORDER_RESPONSES: usize = 256;
+// Benign responses (cancel acks, the reduce-only inventory-exit ack, late acks
+// for pending places that already expired) carry a request_id with no matching
+// pending place, but arrive at a bounded rate. Age unmatched entries out by
+// cycle so those steady sources cannot grow the buffer without limit; only a
+// sustained flood of genuinely-uncorrelated responses within the window can
+// still overflow and fail closed.
+const UNMATCHED_ORDER_RESPONSE_TTL_CYCLES: u64 = 8;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RuntimePhase {
@@ -34,7 +41,7 @@ pub enum MakerEvent {
     CleanupComplete,
     RecoverySucceeded,
     RecoveryFailed(String),
-    OrderResponseUnmatched(String),
+    OrderResponseUnmatched { request_id: String, cycle: u64 },
     OrderResponseMatched(String),
     CtrlC,
 }
@@ -52,7 +59,7 @@ pub struct MakerState {
     generation: u64,
     in_flight: Option<WorkToken>,
     replan_requested: bool,
-    unmatched_order_responses: VecDeque<String>,
+    unmatched_order_responses: VecDeque<(u64, String)>,
 }
 impl MakerState {
     pub fn starting() -> Self {
@@ -126,8 +133,12 @@ impl MakerState {
                 self.phase = RuntimePhase::Ready;
                 self.request_snapshot()
             }
-            MakerEvent::OrderResponseUnmatched(request_id) => {
-                self.unmatched_order_responses.push_back(request_id);
+            MakerEvent::OrderResponseUnmatched { request_id, cycle } => {
+                self.unmatched_order_responses
+                    .push_back((cycle, request_id));
+                self.unmatched_order_responses.retain(|(seen, _)| {
+                    cycle.saturating_sub(*seen) <= UNMATCHED_ORDER_RESPONSE_TTL_CYCLES
+                });
                 if self.unmatched_order_responses.len() > MAX_UNMATCHED_ORDER_RESPONSES {
                     self.freeze("unmatched order-response buffer overflow".to_string())
                 } else {
@@ -138,7 +149,7 @@ impl MakerState {
                 if let Some(index) = self
                     .unmatched_order_responses
                     .iter()
-                    .position(|candidate| candidate == &request_id)
+                    .position(|(_, candidate)| candidate == &request_id)
                 {
                     self.unmatched_order_responses.remove(index);
                 }
@@ -238,9 +249,39 @@ mod tests {
     fn unmatched_response_overflow_fails_closed() {
         let mut state = MakerState::starting();
         state.reduce(MakerEvent::StartupReady);
+        // A sustained flood inside one decay window is a genuine correlation
+        // failure and must still fail closed.
         for index in 0..=MAX_UNMATCHED_ORDER_RESPONSES {
-            state.reduce(MakerEvent::OrderResponseUnmatched(index.to_string()));
+            state.reduce(MakerEvent::OrderResponseUnmatched {
+                request_id: index.to_string(),
+                cycle: 0,
+            });
         }
         assert!(state.is_frozen());
+    }
+
+    #[test]
+    fn benign_unmatched_responses_decay_over_a_long_session() {
+        let mut state = MakerState::starting();
+        state.reduce(MakerEvent::StartupReady);
+        // Simulate a long live run where every cycle produces a few unmatched
+        // responses from benign sources (cancel acks, the inventory-exit ack,
+        // late acks for expired pending places). Without decay the buffer would
+        // pass 256 after ~a hundred cycles and falsely fail closed; with decay
+        // it stays bounded and the session never freezes.
+        for cycle in 0..10_000u64 {
+            for seq in 0..4 {
+                state.reduce(MakerEvent::OrderResponseUnmatched {
+                    request_id: format!("cycle-{cycle}-{seq}"),
+                    cycle,
+                });
+            }
+            assert!(!state.is_frozen(), "froze at cycle {cycle}");
+        }
+        assert!(
+            state.unmatched_order_responses.len() <= MAX_UNMATCHED_ORDER_RESPONSES,
+            "buffer grew unbounded: {}",
+            state.unmatched_order_responses.len()
+        );
     }
 }


### PR DESCRIPTION
## Summary

`0c076b1` started routing every order-response whose `request_id` did not match a pending place into `unmatched_order_responses`, freezing the maker (cancel all quotes + reconnect) once the buffer exceeded 256 entries. The buffer never decayed, and it had stable benign sources, so any long live session grew the count monotonically until it hit the cap and *falsely* failed closed:

1. The reduce-only inventory-exit market order (`cycle.rs`) used `.await?` and discarded its submission id, so its async ack was never registered as pending and always counted as unmatched.
2. Late acks for places already dropped by `pending.retain(|p| cycle - p.cycle <= 2)`.
3. Cancel acks, which legitimately carry a `request_id` with no matching pending place.

### Changes
- **Decay** (`standx-maker/src/runtime.rs`): unmatched entries are now stamped with the cycle they arrived and aged out after `UNMATCHED_ORDER_RESPONSE_TTL_CYCLES` (8). Bounded-rate benign responses can no longer grow the buffer without limit; only a sustained flood of genuinely-uncorrelated responses within the window still overflows and fails closed, preserving the real protection.
- **Exempt the inventory-exit ack** (`standx-cli/src/commands/maker/cycle.rs`): the exit submission id is registered into `pending` with a sentinel level (so it never reserves a real quote slot) so its async ack correlates as matched. A reduce-only market order never rests, so reconciliation drops it when `pending` ages out.
- Event `OrderResponseUnmatched` now carries the current `cycle` (`standx-cli/src/commands/maker/runtime.rs`).

Auth acks are consumed inside `OrderResponseStream::connect()` and never reach the channel, so they were already exempt.

## Test plan
- `cargo fmt -- --check` — no diff
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p standx-maker` and `cargo test -p standx-cli` — pass
- New regression test `benign_unmatched_responses_decay_over_a_long_session` drives 10,000 cycles of steady benign unmatched responses and asserts the buffer stays bounded and never freezes; the existing `unmatched_response_overflow_fails_closed` test confirms a same-cycle flood still fails closed.

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)