### PR TITLE
Add --stop-loss and equity/margin threshold alerts (fixes #219)

### DIFF
--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -443,6 +443,11 @@ pub enum MakerCommands {
         /// Number of recent cycles the volatility breaker measures range over
         #[arg(long)]
         vol_window: Option<u32>,
+        /// Financial brake: when session mark-to-market PnL drops to -this
+        /// (quote units), run the fail-safe shutdown (freeze, cancel the maker
+        /// book, await critical webhook, exit). 0 disables
+        #[arg(long)]
+        stop_loss: Option<f64>,
         /// Risk alert: fire when mark-to-market PnL drops to -this (quote
         /// units). 0 disables
         #[arg(long)]
@@ -460,6 +465,14 @@ pub enum MakerCommands {
         /// (after warmup). 0 disables
         #[arg(long)]
         alert_uptime: Option<f64>,
+        /// Risk alert: fire when account equity drops below this (quote
+        /// units). Live-only (needs an account snapshot). 0 disables
+        #[arg(long)]
+        alert_equity_below: Option<f64>,
+        /// Risk alert: fire when available cross margin drops below this
+        /// (quote units). Live-only. 0 disables
+        #[arg(long)]
+        alert_margin_below: Option<f64>,
         /// Also POST risk alerts to this URL. stderr/JSON always get them
         /// regardless. Payload shape is set by --alert-webhook-format
         #[arg(long)]

--- a/crates/standx-cli/src/commands/maker/config.rs
+++ b/crates/standx-cli/src/commands/maker/config.rs
@@ -23,10 +23,13 @@ pub(super) struct MakerFileConfig {
     pub max_divergence_bps: Option<f64>,
     pub vol_pause_bps: Option<f64>,
     pub vol_window: Option<u32>,
+    pub stop_loss: Option<f64>,
     pub alert_loss: Option<f64>,
     pub alert_inventory_pct: Option<f64>,
     pub alert_position_change_pct: Option<f64>,
     pub alert_uptime: Option<f64>,
+    pub alert_equity_below: Option<f64>,
+    pub alert_margin_below: Option<f64>,
     pub no_ws: Option<bool>,
     pub order_response_reconnect_attempts: Option<u32>,
     pub order_response_reconnect_backoff: Option<u64>,
@@ -71,6 +74,16 @@ mod tests {
         assert_eq!(config.account_stream_reconnect_attempts, Some(3));
         assert_eq!(config.account_stream_reconnect_backoff, Some(2));
         assert_eq!(config.size, None);
+    }
+
+    #[test]
+    fn parses_stop_loss_and_account_floor_fields() {
+        let config: MakerFileConfig =
+            toml::from_str("stop_loss = 25\nalert_equity_below = 100\nalert_margin_below = 40\n")
+                .unwrap();
+        assert_eq!(config.stop_loss, Some(25.0));
+        assert_eq!(config.alert_equity_below, Some(100.0));
+        assert_eq!(config.alert_margin_below, Some(40.0));
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -575,6 +575,7 @@ pub(super) async fn maker_cycle(
         cancels,
         holds,
         fills: fills.len() as u64,
+        balance: account_balance,
     })
 }
 

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -81,10 +81,13 @@ pub async fn handle_maker(
             max_divergence_bps,
             vol_pause_bps,
             vol_window,
+            stop_loss,
             alert_loss,
             alert_inventory_pct,
             alert_position_change_pct,
             alert_uptime,
+            alert_equity_below,
+            alert_margin_below,
             alert_webhook,
             alert_webhook_format,
             no_ws,
@@ -113,6 +116,7 @@ pub async fn handle_maker(
                     max_divergence_bps: choose(max_divergence_bps, file.max_divergence_bps, 25.0),
                     vol_pause_bps: choose(vol_pause_bps, file.vol_pause_bps, 0.0),
                     vol_window: choose(vol_window, file.vol_window, 12),
+                    stop_loss: choose(stop_loss, file.stop_loss, 0.0),
                     alert_loss: choose(alert_loss, file.alert_loss, 0.0),
                     alert_inventory_pct: choose(alert_inventory_pct, file.alert_inventory_pct, 0.0),
                     alert_position_change_pct: choose(
@@ -121,6 +125,8 @@ pub async fn handle_maker(
                         0.0,
                     ),
                     alert_uptime: choose(alert_uptime, file.alert_uptime, 0.0),
+                    alert_equity_below: choose(alert_equity_below, file.alert_equity_below, 0.0),
+                    alert_margin_below: choose(alert_margin_below, file.alert_margin_below, 0.0),
                     alert_webhook,
                     alert_webhook_format,
                     no_ws: no_ws || file.no_ws.unwrap_or(false),
@@ -174,10 +180,13 @@ struct MakerRunArgs {
     max_divergence_bps: f64,
     vol_pause_bps: f64,
     vol_window: u32,
+    stop_loss: f64,
     alert_loss: f64,
     alert_inventory_pct: f64,
     alert_position_change_pct: f64,
     alert_uptime: f64,
+    alert_equity_below: f64,
+    alert_margin_below: f64,
     alert_webhook: Option<String>,
     alert_webhook_format: AlertWebhookFormat,
     no_ws: bool,
@@ -245,6 +254,17 @@ mod tests {
         let terminal = exit.terminal_error().unwrap();
         assert!(terminal.contains("stopped immediately"));
         assert!(!terminal.contains("3 consecutive"));
+    }
+
+    #[test]
+    fn stop_loss_exit_reports_the_breach_and_is_terminal() {
+        let exit = MakerExit::StopLoss("session PnL -12.50 <= -10.00".to_string());
+        let lifecycle = exit.lifecycle_reason();
+        let terminal = exit.terminal_error().unwrap();
+        assert!(lifecycle.contains("stop-loss breached"), "{lifecycle}");
+        assert!(lifecycle.contains("-12.50"), "{lifecycle}");
+        assert!(terminal.contains("stopped immediately"), "{terminal}");
+        assert!(terminal.contains("stop-loss breached"), "{terminal}");
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/model.rs
+++ b/crates/standx-cli/src/commands/maker/model.rs
@@ -6,6 +6,7 @@ pub(super) enum MakerExit {
     OrderResponse(String),
     ConsecutiveErrors(String),
     PositionReconciliation(String),
+    StopLoss(String),
 }
 
 impl MakerExit {
@@ -21,6 +22,9 @@ impl MakerExit {
             Self::PositionReconciliation(error) => {
                 format!("fail-safe: position reconciliation failed: {error}")
             }
+            Self::StopLoss(detail) => {
+                format!("fail-safe: stop-loss breached: {detail}")
+            }
         }
     }
 
@@ -35,6 +39,9 @@ impl MakerExit {
             )),
             Self::PositionReconciliation(error) => Some(format!(
                 "maker stopped immediately (fail-safe): position reconciliation failed: {error}"
+            )),
+            Self::StopLoss(detail) => Some(format!(
+                "maker stopped immediately (fail-safe): stop-loss breached: {detail}"
             )),
         }
     }

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -37,12 +37,14 @@ pub(super) struct CycleState<'a> {
     pub(super) breaker: &'a mut VolBreaker,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(super) struct CycleResult {
     pub(super) places: u64,
     pub(super) cancels: u64,
     pub(super) holds: u64,
     pub(super) fills: u64,
+    /// Latest account snapshot (live mode only; `None` in paper mode).
+    pub(super) balance: Option<Balance>,
 }
 
 pub(super) struct VenueSnapshot {

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -226,6 +226,33 @@ fn emit_reconciliation_state(
     }
 }
 
+fn emit_stop_loss_triggered(
+    output_format: OutputFormat,
+    symbol: &str,
+    cycle: u64,
+    pnl: f64,
+    stop_loss: f64,
+) {
+    if output_format == OutputFormat::Json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                "symbol": symbol,
+                "cycle": cycle,
+                "action": "stop_loss",
+                "event": "triggered",
+                "pnl": pnl,
+                "stop_loss": stop_loss,
+            })
+        );
+    } else {
+        eprintln!(
+            "🛑 stop-loss triggered: session PnL {pnl:+.2} breached -{stop_loss:.2}; shutting down"
+        );
+    }
+}
+
 fn emit_ledger_sync(
     output_format: OutputFormat,
     symbol: &str,
@@ -724,10 +751,18 @@ pub(super) async fn run_maker(
                 args.vol_pause_bps / 2.0
             );
         }
+        if args.stop_loss > 0.0 {
+            println!(
+                "│ stop-loss: session PnL -{} → fail-safe shutdown",
+                args.stop_loss
+            );
+        }
         if args.alert_loss > 0.0
             || args.alert_inventory_pct > 0.0
             || args.alert_position_change_pct > 0.0
             || args.alert_uptime > 0.0
+            || args.alert_equity_below > 0.0
+            || args.alert_margin_below > 0.0
         {
             let mut parts = Vec::new();
             if args.alert_loss > 0.0 {
@@ -741,6 +776,12 @@ pub(super) async fn run_maker(
             }
             if args.alert_uptime > 0.0 {
                 parts.push(format!("uptime {}%", args.alert_uptime));
+            }
+            if args.alert_equity_below > 0.0 {
+                parts.push(format!("equity <{}", args.alert_equity_below));
+            }
+            if args.alert_margin_below > 0.0 {
+                parts.push(format!("margin <{}", args.alert_margin_below));
             }
             let sink = if args.alert_webhook.is_some() {
                 format!("stderr + webhook ({:?})", args.alert_webhook_format).to_lowercase()
@@ -807,7 +848,8 @@ pub(super) async fn run_maker(
     };
     let mut breaker = VolBreaker::new(args.vol_window.max(1) as usize, args.vol_pause_bps);
     let mut alerts =
-        AlertMonitor::new(args.alert_loss, args.alert_inventory_pct, args.alert_uptime);
+        AlertMonitor::new(args.alert_loss, args.alert_inventory_pct, args.alert_uptime)
+            .with_account_floors(args.alert_equity_below, args.alert_margin_below);
     let mut last_mark: Option<f64> = None;
     let mut last_src: Option<&'static str> = None;
     let mut order_response_reconnect_attempts_used = 0_u32;
@@ -1286,6 +1328,7 @@ pub(super) async fn run_maker(
                 src,
                 breaker.halted(),
                 inventory_exit_pending,
+                result.balance,
             ))
         };
         let account_during_work = async {
@@ -1399,7 +1442,7 @@ pub(super) async fn run_maker(
         }
 
         match cycle_result {
-            Ok((places, cancels, holds, fills, mark, src, halted, exit_pending_after)) => {
+            Ok((places, cancels, holds, fills, mark, src, halted, exit_pending_after, balance)) => {
                 consecutive_errors = 0;
                 total_places += places;
                 total_cancels += cancels;
@@ -1492,6 +1535,60 @@ pub(super) async fn run_maker(
                         alerts.evaluate(&stats, stats.position(), mark, cfg.max_position, cycle);
                     for alert in fired {
                         notifier.alert(&alert, &symbol);
+                    }
+                }
+                // Account equity / available-margin floors. The snapshot is
+                // only fetched in live mode, so these stay quiet in paper.
+                if alerts.account_enabled() {
+                    if let Some(balance) = balance.as_ref() {
+                        let equity = balance.equity.parse::<f64>().ok();
+                        let available = balance.cross_available.parse::<f64>().ok();
+                        if let (Some(equity), Some(available)) = (equity, available) {
+                            let fired = alerts.evaluate_account(equity, available);
+                            for alert in fired {
+                                notifier.alert(&alert, &symbol);
+                            }
+                        }
+                    }
+                }
+                // Financial brake: a session loss breaching --stop-loss routes
+                // through the fail-safe shutdown (freeze, cancel the maker
+                // book, await the critical webhook, exit) — the same path the
+                // other MakerExit variants use.
+                if args.stop_loss > 0.0 {
+                    let pnl = stats.pnl(stats.position(), mark);
+                    if pnl <= -args.stop_loss {
+                        emit_stop_loss_triggered(
+                            output_format,
+                            &symbol,
+                            cycle,
+                            pnl,
+                            args.stop_loss,
+                        );
+                        notifier
+                            .risk(
+                                RiskNotice {
+                                    kind: "stop_loss",
+                                    severity: "critical",
+                                    event: "triggered",
+                                    message: &format!(
+                                        "session PnL {pnl:+.2} breached stop-loss -{:.2}; shutting down",
+                                        args.stop_loss
+                                    ),
+                                    symbol: &symbol,
+                                    cycle,
+                                    position_before: None,
+                                    position_after: Some(ledger.expected_position),
+                                    expected: Some(ledger.expected_position),
+                                    observed: None,
+                                },
+                                true,
+                            )
+                            .await;
+                        break 'main MakerExit::StopLoss(format!(
+                            "session PnL {pnl:+.2} <= -{:.2}",
+                            args.stop_loss
+                        ));
                     }
                 }
             }

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -626,9 +626,16 @@ pub struct AlertMonitor {
     inventory_pct: f64,
     /// Alert when two-sided uptime% < uptime_floor (after warmup). 0 = off.
     uptime_floor: f64,
+    /// Alert when account equity drops below this (quote units). 0 = off.
+    equity_floor: f64,
+    /// Alert when available cross margin drops below this (quote units).
+    /// 0 = off.
+    margin_floor: f64,
     loss_on: bool,
     inv_on: bool,
     uptime_on: bool,
+    equity_on: bool,
+    margin_on: bool,
 }
 
 impl AlertMonitor {
@@ -645,9 +652,22 @@ impl AlertMonitor {
         }
     }
 
+    /// Configure the account equity / available-margin floors (quote units).
+    /// 0 disables either floor.
+    pub fn with_account_floors(mut self, equity_floor: f64, margin_floor: f64) -> Self {
+        self.equity_floor = equity_floor;
+        self.margin_floor = margin_floor;
+        self
+    }
+
     /// Whether any threshold is configured.
     pub fn enabled(&self) -> bool {
         self.loss_limit > 0.0 || self.inventory_pct > 0.0 || self.uptime_floor > 0.0
+    }
+
+    /// Whether an account equity or available-margin floor is configured.
+    pub fn account_enabled(&self) -> bool {
+        self.equity_floor > 0.0 || self.margin_floor > 0.0
     }
 
     /// Evaluate the current metrics and return only the alerts whose state
@@ -728,6 +748,59 @@ impl AlertMonitor {
                     kind: "uptime",
                     firing: false,
                     message: format!("uptime recovered to {:.0}%", uptime),
+                });
+            }
+        }
+
+        out
+    }
+
+    /// Evaluate the account equity / available-margin floors against the latest
+    /// account snapshot and return only the alerts whose state changed this
+    /// cycle. Like [`AlertMonitor::evaluate`], each floor is edge-triggered: it
+    /// fires once when it drops below the floor and clears once it recovers to
+    /// 10% above the floor (hysteresis avoids flapping around the threshold).
+    pub fn evaluate_account(&mut self, equity: f64, available: f64) -> Vec<Alert> {
+        let mut out = Vec::new();
+
+        if self.equity_floor > 0.0 {
+            if !self.equity_on && equity < self.equity_floor {
+                self.equity_on = true;
+                out.push(Alert {
+                    kind: "equity",
+                    firing: true,
+                    message: format!(
+                        "account equity {:.2} below floor {:.2}",
+                        equity, self.equity_floor
+                    ),
+                });
+            } else if self.equity_on && equity >= self.equity_floor * 1.1 {
+                self.equity_on = false;
+                out.push(Alert {
+                    kind: "equity",
+                    firing: false,
+                    message: format!("account equity recovered to {:.2}", equity),
+                });
+            }
+        }
+
+        if self.margin_floor > 0.0 {
+            if !self.margin_on && available < self.margin_floor {
+                self.margin_on = true;
+                out.push(Alert {
+                    kind: "margin",
+                    firing: true,
+                    message: format!(
+                        "available margin {:.2} below floor {:.2}",
+                        available, self.margin_floor
+                    ),
+                });
+            } else if self.margin_on && available >= self.margin_floor * 1.1 {
+                self.margin_on = false;
+                out.push(Alert {
+                    kind: "margin",
+                    firing: false,
+                    message: format!("available margin recovered to {:.2}", available),
                 });
             }
         }
@@ -1925,6 +1998,48 @@ mod tests {
         let a = m.evaluate(&s, 0.0, 100.0, 0.05, 25);
         assert_eq!(a.len(), 1);
         assert_eq!(a[0].kind, "uptime");
+        assert!(a[0].firing);
+    }
+
+    // 32. Account floors disabled by default; account_enabled reflects config.
+    #[test]
+    fn alerts_account_disabled_by_default() {
+        let mut m = AlertMonitor::new(0.0, 0.0, 0.0);
+        assert!(!m.account_enabled());
+        assert!(m.evaluate_account(10.0, 5.0).is_empty());
+    }
+
+    // 33. Equity floor: edge-triggered fire then clear with hysteresis.
+    #[test]
+    fn alerts_equity_floor_edge() {
+        let mut m = AlertMonitor::new(0.0, 0.0, 0.0).with_account_floors(100.0, 0.0);
+        assert!(m.account_enabled());
+        // Above floor -> no alert.
+        assert!(m.evaluate_account(120.0, 999.0).is_empty());
+        // Drop below floor -> fire.
+        let a = m.evaluate_account(90.0, 999.0);
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].kind, "equity");
+        assert!(a[0].firing);
+        // Held breach -> no repeat.
+        assert!(m.evaluate_account(90.0, 999.0).is_empty());
+        // Back above floor but within hysteresis band (< 110) -> still on.
+        assert!(m.evaluate_account(105.0, 999.0).is_empty());
+        // Recover to >= floor*1.1 -> clear.
+        let a = m.evaluate_account(111.0, 999.0);
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].kind, "equity");
+        assert!(!a[0].firing);
+    }
+
+    // 34. Available-margin floor fires independently of equity.
+    #[test]
+    fn alerts_margin_floor_fires() {
+        let mut m = AlertMonitor::new(0.0, 0.0, 0.0).with_account_floors(0.0, 50.0);
+        assert!(m.evaluate_account(9999.0, 60.0).is_empty());
+        let a = m.evaluate_account(9999.0, 40.0);
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].kind, "margin");
         assert!(a[0].firing);
     }
 }

--- a/examples/maker.toml
+++ b/examples/maker.toml
@@ -22,10 +22,19 @@ max_divergence_bps = 25.0
 vol_pause_bps = 40.0
 vol_window = 12
 
+# Financial brake: when session mark-to-market PnL drops to -stop_loss (quote
+# units), the bot runs the fail-safe shutdown (freeze, cancel the maker book,
+# await the critical webhook, exit). 0 disables.
+stop_loss = 0.0
+
 # Alerts and optional active inventory exit (0 disables)
 alert_loss = 50.0
 alert_inventory_pct = 80.0
 alert_uptime = 70.0
+# Account floors (live-only; need an account snapshot). Fire once when the
+# metric drops below the floor and clear once it recovers 10% above it.
+alert_equity_below = 0.0
+alert_margin_below = 0.0
 inventory_exit_pct = 0.0
 inventory_exit_qty = 0.0
 


### PR DESCRIPTION
## Summary

The maker bot had no automatic financial brake. `alert_loss` only sent a notification while the bot kept quoting, and account equity / available margin were fetched every cycle but never compared to any threshold — liquidation risk was watched only by a human.

This PR adds three opt-in financial guards:

- **`--stop-loss <X>`** — when session mark-to-market PnL breaches `-X` (quote units), the bot routes through the **existing** fail-safe shutdown path (freeze, cancel the maker book via `cancel_maker_orders_with_retry`, await the critical webhook, exit) using a new `MakerExit::StopLoss` variant. No new shutdown mechanism is introduced. The check runs in the runtime cycle loop over the just-updated stats.
- **`--alert-equity-below <X>`** — edge-triggered alert when account equity drops below `X`.
- **`--alert-margin-below <X>`** — edge-triggered alert when available cross margin drops below `X`.

The account snapshot already fetched each cycle is threaded out of the cycle (`CycleResult.balance`) and compared in `AlertMonitor::evaluate_account` with a 10% recovery hysteresis to avoid flapping. The two account alerts are live-only (no account snapshot in paper mode).

All three flags flow CLI → file → default via the existing `choose()` pattern (`cli.rs`, `mod.rs` `MakerRunArgs`, `config.rs` `MakerFileConfig`). The `STANDX_ENABLE_LIVE_MAKER` live lock is untouched.

## Test plan

- `cargo fmt -- --check` (clean)
- `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- `cargo test -p standx-cli -p standx-maker` (all pass)
- New unit tests:
  - `AlertMonitor` equity-floor edge fire/clear with hysteresis, and margin-floor firing independently (`standx-maker`)
  - `MakerExit::StopLoss` lifecycle/terminal messaging (`standx-cli`)
  - config parsing of `stop_loss`, `alert_equity_below`, `alert_margin_below`
- Stop-loss is verifiable in paper mode: paper fills feed `MakerStats`, so an adverse mark drives `stats.pnl` below `-stop_loss` and the fail-safe shutdown fires.

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)