### PR TITLE
Dashboard DISTINCT counts, equity/freshness panels, structured precursor events (fixes #224)

### DIFF
--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -187,10 +187,29 @@ pub(super) async fn cancel_maker_orders_with_retry(
                 return Ok(());
             }
             Err(error) => {
-                eprintln!(
-                    "⚠️  maker-order cancellation attempt {}/{} incomplete: {}",
-                    attempt, attempts, error
-                );
+                // Precursor signal: an incomplete cleanup retry often precedes a
+                // failed shutdown. Emit it on stdout (JSON mode) so the ingest
+                // pipeline uploads it, instead of leaving it only in local stderr.
+                if output_format == OutputFormat::Json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                            "symbol": symbol,
+                            "action": "maker_cleanup",
+                            "event": "retry_incomplete",
+                            "severity": "warning",
+                            "attempt": attempt,
+                            "max_attempts": attempts,
+                            "message": error.to_string(),
+                        })
+                    );
+                } else {
+                    eprintln!(
+                        "⚠️  maker-order cancellation attempt {}/{} incomplete: {}",
+                        attempt, attempts, error
+                    );
+                }
                 last_err = Some(error);
                 if attempt < attempts {
                     tokio::time::sleep(MAKER_CLEANUP_RETRY_DELAY).await;

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -253,6 +253,34 @@ fn emit_stop_loss_triggered(
     }
 }
 
+fn emit_reconciliation_snapshot_error(
+    output_format: OutputFormat,
+    symbol: &str,
+    cycle: u64,
+    message: &str,
+) {
+    // Precursor signal: a failed reconciliation snapshot inside the freeze
+    // window is an early warning that the fail-safe may not converge. Surface
+    // it on stdout (JSON mode) so ingest uploads it rather than losing it to
+    // local stderr only.
+    if output_format == OutputFormat::Json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                "symbol": symbol,
+                "cycle": cycle,
+                "action": "position_reconciliation",
+                "event": "snapshot_failed",
+                "severity": "warning",
+                "message": message,
+            })
+        );
+    } else {
+        eprintln!("⚠️  bounded position reconciliation snapshot failed: {message}");
+    }
+}
+
 fn emit_ledger_sync(
     output_format: OutputFormat,
     symbol: &str,
@@ -1877,8 +1905,11 @@ pub(super) async fn run_maker(
                                     break;
                                 }
                             }
-                            Err(error) => eprintln!(
-                                "⚠️  bounded position reconciliation snapshot failed: {error}"
+                            Err(error) => emit_reconciliation_snapshot_error(
+                                output_format,
+                                &symbol,
+                                cycle,
+                                &error.to_string(),
                             ),
                         }
                     }

--- a/docs/15-openobserve.md
+++ b/docs/15-openobserve.md
@@ -100,6 +100,11 @@ python3 scripts/openobserve_ingest.py \
 产生相同 `event_id` 的重复行，分析查询应继续使用 `count(DISTINCT event_id)`。手工导入
 已结束的不可变日志仍保持原有的文件哈希 checkpoint 语义。
 
+checkpoint 记录文件身份（inode + 大小）：日志轮转（inode 变化）或截断（大小变小）时
+自动从头重扫，避免行号错位；重复行仍靠 `event_id` 去重。状态文件损坏（非法 JSON）时
+自动重置而非启动即失败，`--follow` 不再需要人工删除。checkpoint 条目数量有上界，超出时
+淘汰最久未更新的条目，`openobserve-uploaded.json` 不会无界增长。
+
 JWT、private key、token、password、authorization、webhook 等字段在上传前会递归
 替换为 `[REDACTED]`。原始本地文件不被修改。
 
@@ -154,7 +159,12 @@ python3 scripts/openobserve_dashboard.py
 
 Dashboard 默认选择最新 maker run，包含 `Overview` 和 `Runs & Events` 两个页签。
 PnL 面板展示 maker session 自身的 PnL；reduce-only exit 演练所用的外部预置库存，
-通过 Inventory 和 Events 面板单独判断。
+通过 Inventory 和 Events 面板单独判断。计数类面板统一使用 `count(DISTINCT event_id)`，
+重复上传不会虚增指标。
+
+`Overview` 另含权益/uPnL/可用保证金趋势（live 模式的 `account` 字段；paper 为 null）
+与数据新鲜度（`max(_timestamp)`）；`Runs & Events` 含拒单/错误信号与流健康/重连面板，
+便于在告警触发前观察前兆。
 
 ## 6. Deadman 告警（进程静默死亡）
 
@@ -185,6 +195,8 @@ push 通道与 maker 进程解耦：即使进程已经无法自己发通知，de
 
 - OpenObserve 仅监听 `127.0.0.1:5080`，不要直接暴露公网。
 - `deploy/openobserve/.env` 使用独立密码，不复用交易所凭证。
-- stdout 才进入分析 stream；stderr 只本地保存，避免诊断噪声污染事件表。
+- stdout 才进入分析 stream；stderr 只本地保存，避免诊断噪声污染事件表。撤单重试失败、
+  reconciliation 快照失败等前兆信号在 JSON 模式下以结构化 stdout 事件（`severity=warning`）
+  输出，随 stdout 一并上传；非 JSON 模式仍打印人类可读的 stderr 行。
 - verbose WebSocket 日志不得包含认证载荷；SDK 只记录认证动作和 stream 数量。
 - 先落盘、后上传是有意设计：日志后端绝不能给 maker 施加背压。

--- a/scripts/openobserve_dashboard.py
+++ b/scripts/openobserve_dashboard.py
@@ -111,7 +111,7 @@ def markdown_panel(content: str) -> dict[str, Any]:
                 "config": {"promql_legend": ""},
             }
         ],
-        "layout": {"x": 0, "y": 29, "w": 192, "h": 4, "i": 11},
+        "layout": {"x": 0, "y": 37, "w": 192, "h": 4, "i": 11},
         "htmlContent": "",
         "markdownContent": content,
     }
@@ -128,7 +128,7 @@ def build_dashboard(stream: str, latest_run: str) -> dict[str, Any]:
             "Fill events in the selected maker run and dashboard time range.",
             query(
                 stream,
-                f'SELECT count(*) AS fills FROM "{stream}" WHERE action = \'fill\' AND {selected}',
+                f'SELECT count(DISTINCT event_id) AS fills FROM "{stream}" WHERE action = \'fill\' AND {selected}',
                 [],
                 [axis("fills", "Fills")],
             ),
@@ -237,19 +237,55 @@ def build_dashboard(stream: str, latest_run: str) -> dict[str, Any]:
             legends=True,
         ),
         panel(
+            "standx_account_trend",
+            "line",
+            "Equity / uPnL / Available",
+            "Authenticated account equity, unrealized PnL, and cross-available margin (live runs only; account is null in paper mode).",
+            query(
+                stream,
+                f'''SELECT histogram(_timestamp) AS ts,
+       avg(cast(account_equity AS DOUBLE)) AS equity,
+       avg(cast(account_upnl AS DOUBLE)) AS upnl,
+       avg(cast(account_available AS DOUBLE)) AS available
+FROM "{stream}" WHERE {cycles}
+GROUP BY histogram(_timestamp) ORDER BY ts''',
+                [axis("ts", "Time")],
+                [axis("equity", "Equity"), axis("upnl", "uPnL"), axis("available", "Available")],
+            ),
+            (0, 21, 96, 8, 12),
+            unit="currency-dollar",
+            legends=True,
+        ),
+        panel(
+            "standx_data_freshness",
+            "table",
+            "Data Freshness",
+            "Newest ingested event for the selected run. A stale max(_timestamp) signals a stalled maker or a stalled upload pipeline.",
+            query(
+                stream,
+                f'''SELECT max(_timestamp) AS last_event,
+       count(DISTINCT event_id) AS events
+FROM "{stream}" WHERE {selected}''',
+                [axis("last_event", "Last event")],
+                [axis("events", "Events")],
+            ),
+            (96, 21, 96, 8, 13),
+            decimals=None,
+        ),
+        panel(
             "standx_cancel_reasons",
             "bar",
             "Cancel Reasons",
             "Maker order cancellations grouped by reason.",
             query(
                 stream,
-                f'''SELECT coalesce(reason, 'unknown') AS reason, count(*) AS cancels
+                f'''SELECT coalesce(reason, 'unknown') AS reason, count(DISTINCT event_id) AS cancels
 FROM "{stream}" WHERE action = 'cancel' AND {selected}
 GROUP BY reason ORDER BY cancels DESC''',
                 [axis("reason", "Reason")],
                 [axis("cancels", "Cancels")],
             ),
-            (0, 21, 64, 8, 9),
+            (0, 29, 64, 8, 9),
             decimals=0,
         ),
         panel(
@@ -265,7 +301,7 @@ ORDER BY _timestamp DESC LIMIT 1''',
                 [axis("_timestamp", "Time"), axis("run_id", "Run"), axis("symbol", "Symbol"), axis("mode", "Mode"), axis("config_hash", "Config")],
                 [axis("fills_total", "Fills"), axis("pnl", "PnL"), axis("uptime_pct", "Uptime"), axis("position", "Position")],
             ),
-            (64, 21, 128, 8, 10),
+            (64, 29, 128, 8, 10),
             decimals=None,
         ),
         markdown_panel(
@@ -281,7 +317,7 @@ ORDER BY _timestamp DESC LIMIT 1''',
             "Alert events for the selected run.",
             query(
                 stream,
-                f'SELECT count(*) AS alerts FROM "{stream}" WHERE action = \'alert\' AND {selected}',
+                f'SELECT count(DISTINCT event_id) AS alerts FROM "{stream}" WHERE action = \'alert\' AND {selected}',
                 [],
                 [axis("alerts", "Alerts")],
             ),
@@ -295,7 +331,7 @@ ORDER BY _timestamp DESC LIMIT 1''',
             "Structured maker order cleanup events for the selected run.",
             query(
                 stream,
-                f'SELECT count(*) AS cleanups FROM "{stream}" WHERE action = \'maker_cleanup\' AND {selected}',
+                f"SELECT count(DISTINCT event_id) AS cleanups FROM \"{stream}\" WHERE action = 'maker_cleanup' AND event = 'complete' AND {selected}",
                 [],
                 [axis("cleanups", "Cleanups")],
             ),
@@ -309,7 +345,7 @@ ORDER BY _timestamp DESC LIMIT 1''',
             "Reduce-only inventory-exit events for the selected run.",
             query(
                 stream,
-                f'SELECT count(*) AS exits FROM "{stream}" WHERE action = \'inventory_exit\' AND {selected}',
+                f'SELECT count(DISTINCT event_id) AS exits FROM "{stream}" WHERE action = \'inventory_exit\' AND {selected}',
                 [],
                 [axis("exits", "Exits")],
             ),
@@ -356,6 +392,42 @@ ORDER BY _timestamp DESC LIMIT 200''',
             ),
             (0, 15, 192, 12, 5),
             decimals=None,
+        ),
+        panel(
+            "standx_error_reject",
+            "bar",
+            "Rejections & Error Signals",
+            "Order rejections, startup rejections, warning/critical risk notifications, and reconciliation/cleanup precursor failures for the selected run.",
+            query(
+                stream,
+                f'''SELECT action AS action, count(DISTINCT event_id) AS events
+FROM "{stream}" WHERE {selected}
+  AND (action IN ('place_rejected', 'place_rejected_async', 'startup_rejected')
+       OR (action = 'risk_notification' AND severity IN ('warning', 'critical'))
+       OR (action = 'position_reconciliation' AND event IN ('frozen', 'snapshot_failed'))
+       OR (action = 'maker_cleanup' AND event = 'retry_incomplete'))
+GROUP BY action ORDER BY events DESC''',
+                [axis("action", "Signal")],
+                [axis("events", "Events")],
+            ),
+            (0, 27, 96, 8, 6),
+            decimals=0,
+        ),
+        panel(
+            "standx_stream_health",
+            "bar",
+            "Stream Health / Reconnects",
+            "Account/order-response reconnect lifecycle events by phase; repeated attempts or failures expose disconnect windows.",
+            query(
+                stream,
+                f'''SELECT coalesce(event, 'unknown') AS event, count(DISTINCT event_id) AS events
+FROM "{stream}" WHERE action = 'order_response_reconnect' AND {selected}
+GROUP BY event ORDER BY events DESC''',
+                [axis("event", "Phase")],
+                [axis("events", "Events")],
+            ),
+            (96, 27, 96, 8, 7),
+            decimals=0,
         ),
     ]
 

--- a/scripts/openobserve_ingest.py
+++ b/scripts/openobserve_ingest.py
@@ -30,6 +30,10 @@ SENSITIVE_KEYS = {
 }
 STREAM_RE = re.compile(r"^[A-Za-z0-9_]+$")
 STOP_REQUESTED = False
+# Cap the number of per-run/per-file checkpoints retained so the state file does
+# not grow without bound over many runs. Evicted keys simply re-scan from zero on
+# the rare chance they reappear; event_id idempotency suppresses duplicate rows.
+MAX_STATE_ENTRIES = 512
 
 
 def redact(value: Any) -> Any:
@@ -62,21 +66,105 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def load_state(path: Path) -> dict[str, int]:
+def checkpoint_line(entry: Any) -> int:
+    """Return the last-processed line number recorded for a checkpoint entry.
+
+    Legacy state files stored the line number as a bare int; the current format
+    stores a dict that also carries the file identity used for reset detection.
+    """
+    if isinstance(entry, bool):
+        return 0
+    if isinstance(entry, int):
+        return entry
+    if isinstance(entry, dict) and isinstance(entry.get("line"), int):
+        return entry["line"]
+    return 0
+
+
+def file_identity(path: Path) -> tuple[int, int]:
+    stat = path.stat()
+    return stat.st_ino, stat.st_size
+
+
+def resume_checkpoint(entry: Any, identity: tuple[int, int]) -> int:
+    """Resolve where to resume, resetting to 0 when the log's identity changed.
+
+    A different inode (rotation) or a smaller size (truncation) means the stored
+    line number no longer points at the same bytes, so replaying from zero is
+    the only safe choice. Duplicate rows are harmless: they share the same
+    ``event_id`` and OpenObserve analytics de-duplicate on it.
+    """
+    line = checkpoint_line(entry)
+    if line <= 0 or not isinstance(entry, dict):
+        return max(line, 0)
+    inode = entry.get("inode")
+    size = entry.get("size")
+    if not isinstance(inode, int) or not isinstance(size, int):
+        return line  # legacy entry without identity: trust the line number
+    current_inode, current_size = identity
+    if inode != current_inode or current_size < size:
+        return 0
+    return line
+
+
+def make_checkpoint(line: int, identity: tuple[int, int]) -> dict[str, int]:
+    inode, size = identity
+    return {"line": line, "inode": inode, "size": size, "updated": int(time.time())}
+
+
+def bound_state(state: dict[str, Any], limit: int = MAX_STATE_ENTRIES) -> None:
+    """Evict the least-recently-updated checkpoints so the file stays bounded."""
+    if len(state) <= limit:
+        return
+
+    def updated_at(item: tuple[str, Any]) -> int:
+        _, value = item
+        return value.get("updated", 0) if isinstance(value, dict) else 0
+
+    for key, _ in sorted(state.items(), key=updated_at)[: len(state) - limit]:
+        del state[key]
+
+
+def load_state(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
         raise RuntimeError(f"cannot read upload state {path}: {exc}") from exc
-    if not isinstance(value, dict) or not all(
-        isinstance(key, str) and isinstance(line, int) for key, line in value.items()
-    ):
-        raise RuntimeError(f"invalid upload state format in {path}")
-    return value
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        # A corrupt state file must never wedge --follow at startup. Reset and
+        # rely on event_id idempotency to suppress any re-uploaded rows.
+        print(
+            f"OpenObserve upload state {path} is unreadable ({exc}); "
+            "resetting checkpoints",
+            file=sys.stderr,
+        )
+        return {}
+    if not isinstance(value, dict):
+        print(
+            f"OpenObserve upload state {path} has an unexpected shape; "
+            "resetting checkpoints",
+            file=sys.stderr,
+        )
+        return {}
+    normalized: dict[str, Any] = {}
+    for key, entry in value.items():
+        if not isinstance(key, str):
+            continue
+        if isinstance(entry, bool):
+            continue
+        if isinstance(entry, int):
+            normalized[key] = entry
+        elif isinstance(entry, dict) and isinstance(entry.get("line"), int):
+            normalized[key] = entry
+        # Malformed entries are dropped; they simply re-scan under event_id dedup.
+    return normalized
 
 
-def save_state(path: Path, state: dict[str, int]) -> None:
+def save_state(path: Path, state: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_suffix(path.suffix + ".tmp")
     temporary.write_text(
@@ -204,7 +292,11 @@ def upload_once(
             state_key = hashlib.sha256(
                 f"{url}|{org}|{stream}|{file_hash}".encode()
             ).hexdigest()
-        checkpoint = 0 if args.force or args.dry_run else state.get(state_key, 0)
+        identity = file_identity(path)
+        if args.force or args.dry_run:
+            checkpoint = 0
+        else:
+            checkpoint = resume_checkpoint(state.get(state_key), identity)
         batch: list[dict[str, Any]] = []
         last_processed = checkpoint
 
@@ -256,7 +348,8 @@ def upload_once(
                     if not args.dry_run:
                         post_batch(endpoint, username, password, batch, args.retries)
                         summary["uploaded"] += len(batch)
-                        state[state_key] = last_processed
+                        state[state_key] = make_checkpoint(last_processed, identity)
+                        bound_state(state)
                         save_state(args.state_file, state)
                     batch.clear()
 
@@ -264,7 +357,8 @@ def upload_once(
             post_batch(endpoint, username, password, batch, args.retries)
             summary["uploaded"] += len(batch)
         if not args.dry_run:
-            state[state_key] = last_processed
+            state[state_key] = make_checkpoint(last_processed, identity)
+            bound_state(state)
             save_state(args.state_file, state)
 
     return summary
@@ -395,8 +489,8 @@ def main() -> int:
             )
             merge_summary(totals, summary)
             if summary["uploaded"]:
-                checkpoint = state.get(
-                    incremental_state_key(url, org, stream, args.run_id), 0
+                checkpoint = checkpoint_line(
+                    state.get(incremental_state_key(url, org, stream, args.run_id))
                 )
                 print(
                     f"OpenObserve live upload: run_id={args.run_id} "

--- a/scripts/test_openobserve_ingest.py
+++ b/scripts/test_openobserve_ingest.py
@@ -102,8 +102,62 @@ class IncrementalIngestTests(unittest.TestCase):
             )
             self.assertEqual(first["uploaded"], 1)
             self.assertEqual(second["uploaded"], 1)
-            self.assertEqual(state[key], 2)
+            self.assertEqual(ingest.checkpoint_line(state[key]), 2)
             self.assertEqual([event["cycle"] for event in posted], [1, 2])
+
+    def test_truncated_file_resets_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "run.ndjson"
+            state_file = root / "state.json"
+            log.write_text(
+                '{"action":"cycle_summary","cycle":1}\n'
+                '{"action":"cycle_summary","cycle":2}\n',
+                encoding="utf-8",
+            )
+            args = self.args(log, state_file)
+            state: dict[str, object] = {}
+            posted: list[dict[str, object]] = []
+
+            with mock.patch.object(
+                ingest,
+                "post_batch",
+                side_effect=lambda _endpoint, _user, _password, events, _retries: posted.extend(events),
+            ):
+                first = self.upload(args, state)
+                # Rotation/truncation: the file is replaced with fewer lines.
+                log.write_text(
+                    '{"action":"cycle_summary","cycle":9}\n', encoding="utf-8"
+                )
+                second = self.upload(args, state)
+
+            self.assertEqual(first["uploaded"], 2)
+            # A naive line checkpoint (>=2) would skip the whole truncated file;
+            # identity validation resets it so the new line is uploaded.
+            self.assertEqual(second["uploaded"], 1)
+            self.assertEqual(posted[-1]["cycle"], 9)
+
+    def test_corrupt_state_file_auto_resets(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_file = Path(directory) / "state.json"
+            state_file.write_text("{not json", encoding="utf-8")
+            self.assertEqual(ingest.load_state(state_file), {})
+
+    def test_legacy_int_state_is_still_honored(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_file = Path(directory) / "state.json"
+            state_file.write_text('{"abc": 7}', encoding="utf-8")
+            loaded = ingest.load_state(state_file)
+            self.assertEqual(ingest.checkpoint_line(loaded["abc"]), 7)
+
+    def test_bound_state_evicts_least_recently_updated(self) -> None:
+        state: dict[str, object] = {
+            f"key-{index}": {"line": 1, "inode": 1, "size": 1, "updated": index}
+            for index in range(5)
+        }
+        ingest.bound_state(state, limit=3)
+        self.assertEqual(len(state), 3)
+        self.assertEqual(set(state), {"key-2", "key-3", "key-4"})
 
     def test_failed_upload_does_not_advance_checkpoint(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

Closes the four dashboard + log-pipeline gaps in issue #224.

1. **DISTINCT counts** — the Fills, Alerts, Cleanups, Cancel Reasons and Inventory Exits panels now use `count(DISTINCT event_id)` instead of `count(*)`, matching the guidance in `docs/15-openobserve.md`. Daily duplicate uploads on network jitter (at-least-once retry) no longer inflate key metrics. The Cleanups metric also filters `event='complete'` so it is not skewed by the new retry-incomplete precursor rows.
2. **New panels** —
   - `Equity / uPnL / Available` trend (Overview), consuming `cycle_summary.account` (live runs only; `account` is null in paper mode).
   - `Data Freshness` (Overview) — `max(_timestamp)` + event count for the selected run.
   - `Rejections & Error Signals` (Runs & Events) — order/startup rejections, warning/critical risk notifications, and reconciliation/cleanup precursor failures.
   - `Stream Health / Reconnects` (Runs & Events) — order-response reconnect lifecycle by phase.
3. **Structured precursor events** — the two named precursor `eprintln!` signals now emit structured stdout JSON events in JSON mode (so the existing stdout ingest uploads them), while keeping the human-readable stderr line for non-JSON output, matching the existing `emit_*` pattern:
   - cancel-retry failures — `recovery.rs`, `action=maker_cleanup`, `event=retry_incomplete`, `severity=warning`.
   - reconciliation-snapshot failures — `runtime.rs`, `action=position_reconciliation`, `event=snapshot_failed`, `severity=warning`.
4. **Ingest edge cases** — checkpoints now record file identity (inode + size) and reset to zero on rotation/truncation; a corrupt state file auto-resets instead of wedging `--follow` at startup; and the checkpoint map is bounded via LRU eviction so `openobserve-uploaded.json` no longer grows unbounded. `event_id` idempotency remains the dedup safety net. Legacy int-valued state entries are still honored.

The `STANDX_ENABLE_LIVE_MAKER` live lock is untouched.

## Test plan

- `cargo fmt -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p standx-cli` — all green.
- `python3 -m py_compile scripts/openobserve_dashboard.py scripts/openobserve_ingest.py scripts/test_openobserve_ingest.py`.
- `python3 -m unittest test_openobserve_ingest` — 7 tests pass, including new coverage for truncation reset, corrupt-state auto-reset, legacy int state, and LRU bounding.
- Offline `build_dashboard()` smoke check: JSON-serializable, unique panel ids/layout indices per tab (Overview 13 panels, Runs & Events 7).

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)