### PR TITLE
Move maker recovery and runtime reducer logic into standx-maker

### DIFF
--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -1,8 +1,9 @@
 use crate::cli::*;
 use anyhow::Result;
 use standx_maker::{
-    self as maker, AlertMonitor, MakerConfig, MakerEvent, MakerFill, MakerLedger, MakerState,
-    MakerStats, PositionAlertAnchor, RestingQuote, VolBreaker, MAKER_CL_ORD_ID_PREFIX,
+    self as maker, AlertMonitor, MakerConfig, MakerEffect, MakerEvent, MakerFill, MakerLedger,
+    MakerState, MakerStats, PositionAlertAnchor, RecoveryTarget, RestingQuote, RuntimeStopReason,
+    VolBreaker, WorkToken, MAKER_CL_ORD_ID_PREFIX,
 };
 use standx_sdk::account_stream::{
     AccountChannel, AccountEvent, AccountStream, AccountStreamHealth,

--- a/crates/standx-cli/src/commands/maker/model.rs
+++ b/crates/standx-cli/src/commands/maker/model.rs
@@ -78,6 +78,29 @@ impl MakerExit {
     }
 }
 
+impl From<standx_maker::RuntimeStopReason> for MakerExit {
+    fn from(reason: standx_maker::RuntimeStopReason) -> Self {
+        match reason {
+            standx_maker::RuntimeStopReason::CtrlC => Self::CtrlC,
+            standx_maker::RuntimeStopReason::OrderResponse(detail) => Self::OrderResponse(detail),
+            standx_maker::RuntimeStopReason::PositionReconciliation(detail) => {
+                Self::PositionReconciliation(detail)
+            }
+            standx_maker::RuntimeStopReason::CleanupFailure { target, reason } => match target {
+                standx_maker::RecoveryTarget::OrderResponse => Self::OrderResponse(reason),
+                standx_maker::RecoveryTarget::AccountStream
+                | standx_maker::RecoveryTarget::PositionReconciliation => {
+                    Self::PositionReconciliation(reason)
+                }
+            },
+            standx_maker::RuntimeStopReason::ConsecutiveCycleErrors(detail) => {
+                Self::ConsecutiveErrors(detail)
+            }
+            standx_maker::RuntimeStopReason::StopLoss(detail) => Self::StopLoss(detail),
+        }
+    }
+}
+
 pub(super) struct PendingPlace {
     pub(super) request_id: String,
     pub(super) cl_ord_id: String,

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -438,6 +438,10 @@ pub(super) async fn reconnect_order_response(
     let mut cleanup_client = cleanup_client;
     let first_attempt = attempts_used.saturating_add(1);
     let mut last_error = None;
+    // The runtime Cleanup effect has already emptied and verified the maker
+    // book before it emits Recover. Only repeat cleanup between failed
+    // reconnect attempts, when a late venue-side request may have surfaced.
+    let mut cleanup_needed = false;
 
     for attempt in first_attempt..=max_attempts {
         emit_order_response_reconnect(
@@ -449,11 +453,18 @@ pub(super) async fn reconnect_order_response(
             original_failure,
         );
 
-        if let Err(error) =
-            cancel_maker_orders_with_retry(&cleanup_client, symbol, 3, output_format).await
-        {
-            last_error = Some(anyhow::anyhow!("pre-reconnect cleanup failed: {error}"));
+        let cleanup_ok = if cleanup_needed {
+            match cancel_maker_orders_with_retry(&cleanup_client, symbol, 3, output_format).await {
+                Ok(()) => true,
+                Err(error) => {
+                    last_error = Some(anyhow::anyhow!("retry cleanup failed: {error}"));
+                    false
+                }
+            }
         } else {
+            true
+        };
+        if cleanup_ok {
             // Give just-submitted HTTP orders time to become visible, then
             // require a second authoritative snapshot after authentication.
             tokio::time::sleep(Duration::from_secs(1)).await;
@@ -536,6 +547,7 @@ pub(super) async fn reconnect_order_response(
                 }
             }
         }
+        cleanup_needed = true;
 
         let error_text = last_error
             .as_ref()

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -1,6 +1,87 @@
 use super::*;
 use standx_sdk::order_response::OrderResponse;
 
+fn next_runtime_effect(runtime_state: &mut MakerState) -> Option<MakerEffect> {
+    runtime_state.next_effect().map(|effect| match effect {
+        MakerEffect::RunCycle(token) => MakerEffect::RunCycle(token),
+        MakerEffect::AbortInFlight(token) => MakerEffect::AbortInFlight(token),
+        MakerEffect::CommitCycle(token) => MakerEffect::CommitCycle(token),
+        MakerEffect::Cleanup { token, target } => MakerEffect::Cleanup { token, target },
+        MakerEffect::Recover { token, target } => MakerEffect::Recover { token, target },
+        MakerEffect::Stop(reason) => MakerEffect::Stop(reason),
+    })
+}
+
+fn take_cleanup_effect(
+    runtime_state: &mut MakerState,
+    expected_target: RecoveryTarget,
+) -> Result<WorkToken> {
+    loop {
+        match next_runtime_effect(runtime_state) {
+            Some(MakerEffect::AbortInFlight(_)) => {}
+            Some(MakerEffect::Cleanup { token, target }) if target == expected_target => {
+                return Ok(token);
+            }
+            Some(effect) => {
+                return Err(anyhow::anyhow!(
+                    "runtime expected {expected_target:?} cleanup, got {effect:?}"
+                ));
+            }
+            None => {
+                return Err(anyhow::anyhow!(
+                    "runtime did not emit {expected_target:?} cleanup"
+                ));
+            }
+        }
+    }
+}
+
+fn take_recovery_effect(
+    runtime_state: &mut MakerState,
+    expected_target: RecoveryTarget,
+) -> Result<WorkToken> {
+    match next_runtime_effect(runtime_state) {
+        Some(MakerEffect::Recover { token, target }) if target == expected_target => Ok(token),
+        Some(effect) => Err(anyhow::anyhow!(
+            "runtime expected {expected_target:?} recovery, got {effect:?}"
+        )),
+        None => Err(anyhow::anyhow!(
+            "runtime did not emit {expected_target:?} recovery"
+        )),
+    }
+}
+
+fn take_stop_effect(runtime_state: &mut MakerState) -> Result<MakerExit> {
+    loop {
+        match next_runtime_effect(runtime_state) {
+            Some(MakerEffect::AbortInFlight(_)) => {}
+            Some(MakerEffect::Stop(reason)) => return Ok(reason.into()),
+            Some(effect) => {
+                return Err(anyhow::anyhow!(
+                    "runtime expected stop effect, got {effect:?}"
+                ));
+            }
+            None => return Err(anyhow::anyhow!("runtime did not emit stop effect")),
+        }
+    }
+}
+
+fn recovery_failed_exit(
+    runtime_state: &mut MakerState,
+    token: WorkToken,
+    reason: String,
+) -> MakerExit {
+    runtime_state.handle(MakerEvent::RecoveryFailed { token, reason });
+    take_stop_effect(runtime_state)
+        .unwrap_or_else(|error| MakerExit::PositionReconciliation(error.to_string()))
+}
+
+fn stop_requested_exit(runtime_state: &mut MakerState, reason: RuntimeStopReason) -> MakerExit {
+    runtime_state.handle(MakerEvent::StopRequested(reason));
+    take_stop_effect(runtime_state)
+        .unwrap_or_else(|error| MakerExit::PositionReconciliation(error.to_string()))
+}
+
 pub(super) fn apply_order_responses(
     receiver: &mut tokio::sync::mpsc::Receiver<OrderResponse>,
     pending: &mut Vec<PendingPlace>,
@@ -30,13 +111,20 @@ pub(super) fn apply_order_responses(
             price_decimals,
         );
         if let Some(request_id) = request_id {
-            runtime_state.reduce(if matched {
+            runtime_state.handle(if matched {
                 MakerEvent::OrderResponseMatched(request_id)
             } else {
                 MakerEvent::OrderResponseUnmatched { request_id, cycle }
             });
         }
-        if runtime_state.is_frozen() {
+        if matches!(
+            runtime_state.pending_effect(),
+            Some(MakerEffect::AbortInFlight(_))
+                | Some(MakerEffect::Cleanup {
+                    target: RecoveryTarget::OrderResponse,
+                    ..
+                })
+        ) {
             return Err(anyhow::anyhow!("order-response correlation failed closed"));
         }
     }
@@ -936,7 +1024,7 @@ pub(super) async fn run_maker(
     let mut token_expiry_alerted = TokenExpiryLevel::Ok;
     let mut last_token_expiry_check: Option<std::time::Instant> = None;
     let mut runtime_state = MakerState::starting();
-    runtime_state.reduce(MakerEvent::StartupReady);
+    runtime_state.handle(MakerEvent::StartupReady);
 
     let exit = 'main: loop {
         if args.live {
@@ -992,7 +1080,20 @@ pub(super) async fn run_maker(
                 let detail = health.failure_reason().unwrap_or_else(|| {
                     "account stream became unhealthy without a recorded reason".to_string()
                 });
-                runtime_state.reduce(MakerEvent::AccountStreamDisconnected(detail.clone()));
+                runtime_state.handle(MakerEvent::AccountStreamDisconnected(detail.clone()));
+                let cleanup_token =
+                    match take_cleanup_effect(&mut runtime_state, RecoveryTarget::AccountStream) {
+                        Ok(token) => token,
+                        Err(error) => {
+                            break stop_requested_exit(
+                                &mut runtime_state,
+                                RuntimeStopReason::CleanupFailure {
+                                    target: RecoveryTarget::AccountStream,
+                                    reason: error.to_string(),
+                                },
+                            );
+                        }
+                    };
                 let message = format!(
                     "account stream unavailable; placements frozen and cleanup starting: {detail}"
                 );
@@ -1018,9 +1119,16 @@ pub(super) async fn run_maker(
                 if let Err(cleanup_error) =
                     cancel_maker_orders_with_retry(&client, &symbol, 3, output_format).await
                 {
-                    break MakerExit::PositionReconciliation(format!(
-                        "account stream disconnected ({detail}); freeze cleanup failed: {cleanup_error}"
-                    ));
+                    runtime_state.handle(MakerEvent::CleanupFailed {
+                        token: cleanup_token,
+                        reason: format!(
+                            "account stream disconnected ({detail}); freeze cleanup failed: {cleanup_error}"
+                        ),
+                    });
+                    break match take_stop_effect(&mut runtime_state) {
+                        Ok(exit) => exit,
+                        Err(error) => MakerExit::PositionReconciliation(error.to_string()),
+                    };
                 }
                 resting.clear();
                 adopted.clear();
@@ -1030,14 +1138,30 @@ pub(super) async fn run_maker(
                     handle.abort();
                 }
                 account_events.take();
+                runtime_state.handle(MakerEvent::CleanupCompleted(cleanup_token));
+                let recovery_token =
+                    match take_recovery_effect(&mut runtime_state, RecoveryTarget::AccountStream) {
+                        Ok(token) => token,
+                        Err(error) => {
+                            break stop_requested_exit(
+                                &mut runtime_state,
+                                RuntimeStopReason::PositionReconciliation(error.to_string()),
+                            );
+                        }
+                    };
 
                 let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
                 if account_stream_reconnect_attempts_used >= args.account_stream_reconnect_attempts
                 {
-                    break MakerExit::PositionReconciliation(format!(
-                        "account stream disconnected ({detail}); reconnect disabled or budget exhausted ({}/{})",
-                        account_stream_reconnect_attempts_used, args.account_stream_reconnect_attempts
-                    ));
+                    break recovery_failed_exit(
+                        &mut runtime_state,
+                        recovery_token,
+                        format!(
+                            "account stream disconnected ({detail}); reconnect disabled or budget exhausted ({}/{})",
+                            account_stream_reconnect_attempts_used,
+                            args.account_stream_reconnect_attempts
+                        ),
+                    );
                 }
 
                 let mut last_connect_error: Option<String> = None;
@@ -1089,16 +1213,18 @@ pub(super) async fn run_maker(
                 }
 
                 let Some((mut events, health, handle)) = reconnected else {
-                    runtime_state.reduce(MakerEvent::RecoveryFailed(format!(
-                        "account stream reconnect exhausted: {}",
-                        last_connect_error
-                            .clone()
-                            .unwrap_or_else(|| "no attempts available".to_string())
-                    )));
-                    break MakerExit::PositionReconciliation(format!(
-                        "account stream disconnected ({detail}); reconnect exhausted: {}",
-                        last_connect_error.unwrap_or_else(|| "no attempts available".to_string())
-                    ));
+                    runtime_state.handle(MakerEvent::RecoveryFailed {
+                        token: recovery_token,
+                        reason: format!(
+                            "account stream disconnected ({detail}); reconnect exhausted: {}",
+                            last_connect_error
+                                .unwrap_or_else(|| "no attempts available".to_string())
+                        ),
+                    });
+                    break match take_stop_effect(&mut runtime_state) {
+                        Ok(exit) => exit,
+                        Err(error) => MakerExit::PositionReconciliation(error.to_string()),
+                    };
                 };
 
                 let mut reconnect_fills = match apply_account_events(
@@ -1118,25 +1244,33 @@ pub(super) async fn run_maker(
                     Ok((fills, _)) => fills,
                     Err(error) => {
                         handle.abort();
-                        break MakerExit::PositionReconciliation(format!(
-                            "account stream reconnect event validation failed: {error}"
-                        ));
+                        break recovery_failed_exit(
+                            &mut runtime_state,
+                            recovery_token,
+                            format!("account stream reconnect event validation failed: {error}"),
+                        );
                     }
                 };
                 let positions = match client.get_positions(Some(&symbol)).await {
                     Ok(positions) => positions,
                     Err(error) => {
                         handle.abort();
-                        break MakerExit::PositionReconciliation(format!(
-                            "account stream reconnect snapshot failed: {error}"
-                        ));
+                        break recovery_failed_exit(
+                            &mut runtime_state,
+                            recovery_token,
+                            format!("account stream reconnect snapshot failed: {error}"),
+                        );
                     }
                 };
                 let mut observed = match position_for_symbol(&positions, &symbol) {
                     Ok(position) => position,
                     Err(error) => {
                         handle.abort();
-                        break MakerExit::PositionReconciliation(error.to_string());
+                        break recovery_failed_exit(
+                            &mut runtime_state,
+                            recovery_token,
+                            error.to_string(),
+                        );
                     }
                 };
 
@@ -1165,9 +1299,13 @@ pub(super) async fn run_maker(
                             Ok((fills, _)) => reconnect_fills += fills,
                             Err(error) => {
                                 handle.abort();
-                                break 'main MakerExit::PositionReconciliation(format!(
-                                    "account stream reconnect event validation failed during REST backfill: {error}"
-                                ));
+                                break 'main recovery_failed_exit(
+                                    &mut runtime_state,
+                                    recovery_token,
+                                    format!(
+                                        "account stream reconnect event validation failed during REST backfill: {error}"
+                                    ),
+                                );
                             }
                         }
                         match reconcile_ledger_snapshot(
@@ -1202,10 +1340,14 @@ pub(super) async fn run_maker(
                     }
                     if !gap_closed {
                         handle.abort();
-                        break MakerExit::PositionReconciliation(format!(
-                            "account stream reconnect snapshot expected {:+.8}, observed {:+.8} (REST trade backfill did not close the gap)",
-                            ledger.expected_position, observed
-                        ));
+                        break recovery_failed_exit(
+                            &mut runtime_state,
+                            recovery_token,
+                            format!(
+                                "account stream reconnect snapshot expected {:+.8}, observed {:+.8} (REST trade backfill did not close the gap)",
+                                ledger.expected_position, observed
+                            ),
+                        );
                     }
                 }
 
@@ -1213,8 +1355,7 @@ pub(super) async fn run_maker(
                 account_stream_health = Some(health);
                 account_stream_handle = Some(handle);
                 total_fills += reconnect_fills;
-                runtime_state.reduce(MakerEvent::CleanupComplete);
-                runtime_state.reduce(MakerEvent::RecoverySucceeded);
+                runtime_state.handle(MakerEvent::RecoverySucceeded(recovery_token));
                 notifier
                     .risk(
                         RiskNotice {
@@ -1241,7 +1382,17 @@ pub(super) async fn run_maker(
                 let detail = health.failure_reason().unwrap_or_else(|| {
                     "order-response stream became unhealthy without a recorded reason".to_string()
                 });
-                runtime_state.reduce(MakerEvent::OrderResponseDisconnected(detail.clone()));
+                runtime_state.handle(MakerEvent::OrderResponseDisconnected(detail.clone()));
+                let cleanup_token =
+                    match take_cleanup_effect(&mut runtime_state, RecoveryTarget::OrderResponse) {
+                        Ok(token) => token,
+                        Err(error) => {
+                            break stop_requested_exit(
+                                &mut runtime_state,
+                                RuntimeStopReason::OrderResponse(error.to_string()),
+                            );
+                        }
+                    };
                 let controlled_fault = detail.starts_with("controlled fault injection");
                 let reconnect_available = order_response_reconnect_available(
                     &detail,
@@ -1269,6 +1420,33 @@ pub(super) async fn run_maker(
                         false,
                     )
                     .await;
+                if let Err(error) =
+                    cancel_maker_orders_with_retry(&client, &symbol, 3, output_format).await
+                {
+                    runtime_state.handle(MakerEvent::CleanupFailed {
+                        token: cleanup_token,
+                        reason: format!("order-response freeze cleanup failed: {error}"),
+                    });
+                    break match take_stop_effect(&mut runtime_state) {
+                        Ok(exit) => exit,
+                        Err(error) => MakerExit::OrderResponse(error.to_string()),
+                    };
+                }
+                resting.clear();
+                adopted.clear();
+                pending.clear();
+                inventory_exit_pending = false;
+                runtime_state.handle(MakerEvent::CleanupCompleted(cleanup_token));
+                let recovery_token =
+                    match take_recovery_effect(&mut runtime_state, RecoveryTarget::OrderResponse) {
+                        Ok(token) => token,
+                        Err(error) => {
+                            break stop_requested_exit(
+                                &mut runtime_state,
+                                RuntimeStopReason::OrderResponse(error.to_string()),
+                            );
+                        }
+                    };
                 if reconnect_available {
                     if let Some(handle) = order_response_handle.take() {
                         handle.abort();
@@ -1301,6 +1479,7 @@ pub(super) async fn run_maker(
                             adopted.clear();
                             pending.clear();
                             consecutive_errors = 0;
+                            runtime_state.handle(MakerEvent::RecoverySucceeded(recovery_token));
                             notifier
                                 .risk(
                                     RiskNotice {
@@ -1358,7 +1537,16 @@ pub(super) async fn run_maker(
                                         true,
                                     )
                                     .await;
-                                break MakerExit::PositionReconciliation(error.to_string());
+                                runtime_state.handle(MakerEvent::RecoveryFailed {
+                                    token: recovery_token,
+                                    reason: error.to_string(),
+                                });
+                                break match take_stop_effect(&mut runtime_state) {
+                                    Ok(exit) => exit,
+                                    Err(runtime_error) => {
+                                        MakerExit::PositionReconciliation(runtime_error.to_string())
+                                    }
+                                };
                             }
                             let reconnect_failed_message = format!(
                                 "{detail}; safe reconnect failed: {error}; refusing further live orders"
@@ -1380,7 +1568,14 @@ pub(super) async fn run_maker(
                                     true,
                                 )
                                 .await;
-                            break MakerExit::OrderResponse(reconnect_failed_message);
+                            runtime_state.handle(MakerEvent::RecoveryFailed {
+                                token: recovery_token,
+                                reason: reconnect_failed_message,
+                            });
+                            break match take_stop_effect(&mut runtime_state) {
+                                Ok(exit) => exit,
+                                Err(error) => MakerExit::OrderResponse(error.to_string()),
+                            };
                         }
                     }
                 }
@@ -1414,7 +1609,14 @@ pub(super) async fn run_maker(
                         true,
                     )
                     .await;
-                break MakerExit::OrderResponse(refuse_message);
+                runtime_state.handle(MakerEvent::RecoveryFailed {
+                    token: recovery_token,
+                    reason: refuse_message,
+                });
+                break match take_stop_effect(&mut runtime_state) {
+                    Ok(exit) => exit,
+                    Err(error) => MakerExit::OrderResponse(error.to_string()),
+                };
             }
         }
         if let Some(receiver) = order_responses.as_mut() {
@@ -1431,7 +1633,10 @@ pub(super) async fn run_maker(
                     health.mark_unhealthy(error.to_string());
                     continue;
                 }
-                break MakerExit::OrderResponse(error.to_string());
+                break stop_requested_exit(
+                    &mut runtime_state,
+                    RuntimeStopReason::OrderResponse(error.to_string()),
+                );
             }
         }
         if let Some(receiver) = account_events.as_mut() {
@@ -1479,7 +1684,10 @@ pub(super) async fn run_maker(
                         health.mark_unhealthy(error.to_string());
                         continue;
                     }
-                    break MakerExit::PositionReconciliation(error.to_string());
+                    break stop_requested_exit(
+                        &mut runtime_state,
+                        RuntimeStopReason::PositionReconciliation(error.to_string()),
+                    );
                 }
             }
         }
@@ -1495,8 +1703,22 @@ pub(super) async fn run_maker(
         let mismatch = account_position_mismatch.take();
         let exit_pending_before = inventory_exit_pending;
         let breaker_halted_before = breaker.halted();
-        runtime_state.reduce(MakerEvent::Timer);
-        let cycle_work_token = runtime_state.in_flight();
+        if runtime_state.pending_effect().is_none() {
+            runtime_state.handle(MakerEvent::Timer);
+        }
+        let cycle_work_token = match next_runtime_effect(&mut runtime_state) {
+            Some(MakerEffect::RunCycle(token)) => token,
+            Some(MakerEffect::Stop(reason)) => break reason.into(),
+            Some(effect) => {
+                break stop_requested_exit(
+                    &mut runtime_state,
+                    RuntimeStopReason::PositionReconciliation(format!(
+                        "runtime emitted unexpected effect before cycle: {effect:?}"
+                    )),
+                );
+            }
+            None => continue,
+        };
         let work = async {
             if let Some(observed) = mismatch {
                 return Err(anyhow::Error::new(PositionReconciliationError {
@@ -1549,14 +1771,12 @@ pub(super) async fn run_maker(
                 result.balance,
             ))
         };
-        // Stream events that arrive while `work` is placing/cancelling orders
-        // are buffered rather than acted on immediately: interrupting the work
-        // future would drop an in-flight create/cancel HTTP call, and a live
-        // cycle's own placements produce account events almost instantly, so
-        // acting mid-flight tore a multi-order cycle apart. We still keep the
-        // channels drained so the WS reader never backpressures and so a
-        // disconnect is noticed promptly. Buffered events are applied once the
-        // work future completes and releases its ledger/pending borrows.
+        // Normal stream events that arrive while `work` is placing/cancelling
+        // are buffered so a cycle's own acknowledgements cannot tear apart a
+        // multi-order plan. A stream disconnect is different: it immediately
+        // invalidates the generation, drops this future via `continue 'main`,
+        // and lets the queued Cleanup effect compensate for any request that
+        // may already have reached the venue.
         let mut buffered_account: Vec<AccountEvent> = Vec::new();
         let mut buffered_orders: Vec<OrderResponse> = Vec::new();
         // Scope the pinned work future so it (and its ledger/pending borrows)
@@ -1578,13 +1798,16 @@ pub(super) async fn run_maker(
                 };
                 tokio::select! {
                     _ = signal::ctrl_c() => {
-                        runtime_state.reduce(MakerEvent::CtrlC);
-                        break 'main MakerExit::CtrlC;
+                        runtime_state.handle(MakerEvent::CtrlC);
+                        break 'main match take_stop_effect(&mut runtime_state) {
+                            Ok(exit) => exit,
+                            Err(error) => MakerExit::PositionReconciliation(error.to_string()),
+                        };
                     },
                     event = account_during_work => {
                         let Some(event) = event else {
                             let reason = "authenticated account stream disconnected during cycle".to_string();
-                            runtime_state.reduce(MakerEvent::AccountStreamDisconnected(reason.clone()));
+                            runtime_state.handle(MakerEvent::AccountStreamDisconnected(reason.clone()));
                             if let Some(health) = account_stream_health.as_ref() {
                                 health.mark_unhealthy(reason);
                             }
@@ -1595,7 +1818,7 @@ pub(super) async fn run_maker(
                     response = order_during_work => {
                         let Some(response) = response else {
                             let reason = "order-response stream disconnected during cycle".to_string();
-                            runtime_state.reduce(MakerEvent::OrderResponseDisconnected(reason.clone()));
+                            runtime_state.handle(MakerEvent::OrderResponseDisconnected(reason.clone()));
                             if let Some(health) = order_response_health.as_ref() {
                                 health.mark_unhealthy(reason);
                             }
@@ -1607,10 +1830,6 @@ pub(super) async fn run_maker(
                 }
             }
         };
-        if let Some(token) = cycle_work_token {
-            runtime_state.reduce(MakerEvent::WorkFinished(token));
-        }
-
         // Apply the events buffered during work, ordering order-responses
         // before account events to mirror the top-of-loop drain.
         for response in buffered_orders {
@@ -1624,13 +1843,20 @@ pub(super) async fn run_maker(
                 cfg.price_decimals,
             );
             if let Some(request_id) = request_id {
-                runtime_state.reduce(if matched {
+                runtime_state.handle(if matched {
                     MakerEvent::OrderResponseMatched(request_id)
                 } else {
                     MakerEvent::OrderResponseUnmatched { request_id, cycle }
                 });
             }
-            if runtime_state.is_frozen() {
+            if matches!(
+                runtime_state.pending_effect(),
+                Some(MakerEffect::AbortInFlight(_))
+                    | Some(MakerEffect::Cleanup {
+                        target: RecoveryTarget::OrderResponse,
+                        ..
+                    })
+            ) {
                 if let Some(health) = order_response_health.as_ref() {
                     health.mark_unhealthy("order-response correlation failed closed");
                 }
@@ -1671,13 +1897,14 @@ pub(super) async fn run_maker(
                         if (position - ledger.expected_position).abs()
                             > 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0
                         {
-                            runtime_state.reduce(MakerEvent::PositionMismatch);
                             account_position_mismatch = Some(position);
+                        } else {
+                            account_position_mismatch = None;
                         }
                     }
                 }
                 Err(error) => {
-                    runtime_state.reduce(MakerEvent::AccountStreamDisconnected(error.to_string()));
+                    runtime_state.handle(MakerEvent::AccountStreamDisconnected(error.to_string()));
                     if let Some(health) = account_stream_health.as_ref() {
                         health.mark_unhealthy(error.to_string());
                     }
@@ -1685,8 +1912,35 @@ pub(super) async fn run_maker(
             }
         }
 
+        let cycle_result = if let Some(observed) = mismatch.or(account_position_mismatch.take()) {
+            Err(anyhow::Error::new(PositionReconciliationError {
+                expected: ledger.expected_position,
+                observed,
+            }))
+        } else {
+            cycle_result
+        };
+
+        if !matches!(
+            runtime_state.pending_effect(),
+            None | Some(MakerEffect::RunCycle(_))
+        ) && cycle_result.is_ok()
+        {
+            // A fail-closed event invalidated the generation while cycle work
+            // was running. Do not commit its counters/alerts; the queued
+            // abort/cleanup effects are consumed by the recovery path.
+            continue 'main;
+        }
+
         match cycle_result {
             Ok((places, cancels, holds, fills, mark, src, halted, exit_pending_after, balance)) => {
+                runtime_state.handle(MakerEvent::CycleCompleted(cycle_work_token));
+                if !matches!(
+                    next_runtime_effect(&mut runtime_state),
+                    Some(MakerEffect::CommitCycle(token)) if token == cycle_work_token
+                ) {
+                    continue 'main;
+                }
                 consecutive_errors = 0;
                 total_places += places;
                 total_cancels += cancels;
@@ -1833,15 +2087,37 @@ pub(super) async fn run_maker(
                                 true,
                             )
                             .await;
-                        break 'main MakerExit::StopLoss(format!(
-                            "session PnL {pnl:+.2} <= -{:.2}",
-                            args.stop_loss
+                        runtime_state.handle(MakerEvent::StopRequested(
+                            RuntimeStopReason::StopLoss(format!(
+                                "session PnL {pnl:+.2} <= -{:.2}",
+                                args.stop_loss
+                            )),
                         ));
+                        break 'main match take_stop_effect(&mut runtime_state) {
+                            Ok(exit) => exit,
+                            Err(error) => MakerExit::PositionReconciliation(error.to_string()),
+                        };
                     }
                 }
             }
             Err(e) => {
                 if let Some(mismatch) = e.downcast_ref::<PositionReconciliationError>() {
+                    runtime_state.handle(MakerEvent::PositionMismatch);
+                    let cleanup_token = match take_cleanup_effect(
+                        &mut runtime_state,
+                        RecoveryTarget::PositionReconciliation,
+                    ) {
+                        Ok(token) => token,
+                        Err(error) => {
+                            break 'main stop_requested_exit(
+                                &mut runtime_state,
+                                RuntimeStopReason::CleanupFailure {
+                                    target: RecoveryTarget::PositionReconciliation,
+                                    reason: error.to_string(),
+                                },
+                            );
+                        }
+                    };
                     // A mismatch is not a normal cycle error. Freeze quoting,
                     // empty the maker book, and give account-order callbacks
                     // plus REST settlement a bounded three-second window to
@@ -1874,14 +2150,32 @@ pub(super) async fn run_maker(
                     if let Err(cleanup_error) =
                         cancel_maker_orders_with_retry(&client, &symbol, 3, output_format).await
                     {
-                        break 'main MakerExit::PositionReconciliation(format!(
-                            "freeze cleanup failed: {cleanup_error}"
-                        ));
+                        runtime_state.handle(MakerEvent::CleanupFailed {
+                            token: cleanup_token,
+                            reason: format!("freeze cleanup failed: {cleanup_error}"),
+                        });
+                        break 'main match take_stop_effect(&mut runtime_state) {
+                            Ok(exit) => exit,
+                            Err(error) => MakerExit::PositionReconciliation(error.to_string()),
+                        };
                     }
                     resting.clear();
                     adopted.clear();
                     pending.clear();
                     inventory_exit_pending = false;
+                    runtime_state.handle(MakerEvent::CleanupCompleted(cleanup_token));
+                    let recovery_token = match take_recovery_effect(
+                        &mut runtime_state,
+                        RecoveryTarget::PositionReconciliation,
+                    ) {
+                        Ok(token) => token,
+                        Err(error) => {
+                            break 'main stop_requested_exit(
+                                &mut runtime_state,
+                                RuntimeStopReason::PositionReconciliation(error.to_string()),
+                            );
+                        }
+                    };
                     let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
                     let mut recovered = false;
                     let mut last_observed = mismatch.observed;
@@ -1989,6 +2283,7 @@ pub(super) async fn run_maker(
                             )
                         .await;
                         consecutive_errors = 0;
+                        runtime_state.handle(MakerEvent::RecoverySucceeded(recovery_token));
                         continue;
                     }
                     emit_reconciliation_state(
@@ -2016,10 +2311,17 @@ pub(super) async fn run_maker(
                             true,
                         )
                     .await;
-                    break 'main MakerExit::PositionReconciliation(format!(
-                        "expected position {:+.8}, venue reported {:+.8} after 3s freeze",
-                        ledger.expected_position, last_observed
-                    ));
+                    runtime_state.handle(MakerEvent::RecoveryFailed {
+                        token: recovery_token,
+                        reason: format!(
+                            "expected position {:+.8}, venue reported {:+.8} after 3s freeze",
+                            ledger.expected_position, last_observed
+                        ),
+                    });
+                    break 'main match take_stop_effect(&mut runtime_state) {
+                        Ok(exit) => exit,
+                        Err(error) => MakerExit::PositionReconciliation(error.to_string()),
+                    };
                 }
                 if exit_pending_before {
                     let message = format!("inventory exit cycle failed: {e}");
@@ -2041,15 +2343,29 @@ pub(super) async fn run_maker(
                         )
                         .await;
                 }
+                runtime_state.handle(MakerEvent::CycleFailed {
+                    token: cycle_work_token,
+                    reason: e.to_string(),
+                });
                 consecutive_errors += 1;
                 eprintln!("⚠️  maker cycle failed ({}/3): {}", consecutive_errors, e);
-                if consecutive_errors >= 3 {
-                    break MakerExit::ConsecutiveErrors(e.to_string());
+                if matches!(runtime_state.pending_effect(), Some(MakerEffect::Stop(_))) {
+                    break match take_stop_effect(&mut runtime_state) {
+                        Ok(exit) => exit,
+                        Err(error) => MakerExit::ConsecutiveErrors(error.to_string()),
+                    };
                 }
             }
         }
 
         cycle += 1;
+
+        if matches!(
+            runtime_state.pending_effect(),
+            Some(MakerEffect::RunCycle(_))
+        ) {
+            continue 'main;
+        }
 
         // Sleep until the next cycle, but wake early when the cached mark
         // has already drifted beyond refresh_bps — the quotes would be
@@ -2071,7 +2387,13 @@ pub(super) async fn run_maker(
                 }
             };
             tokio::select! {
-                _ = signal::ctrl_c() => break 'main MakerExit::CtrlC,
+                _ = signal::ctrl_c() => {
+                    runtime_state.handle(MakerEvent::CtrlC);
+                    break 'main match take_stop_effect(&mut runtime_state) {
+                        Ok(exit) => exit,
+                        Err(error) => MakerExit::PositionReconciliation(error.to_string()),
+                    };
+                },
                 _ = tokio::time::sleep_until(deadline) => break,
                 event = account_update => {
                     let Some(event) = event else {
@@ -2148,7 +2470,7 @@ pub(super) async fn run_maker(
                             .is_some_and(|m| maker::bps_diff(m, prev) > cfg.refresh_bps)
                     };
                     if drifted {
-                        runtime_state.reduce(MakerEvent::MarketChanged);
+                        runtime_state.handle(MakerEvent::MarketChanged);
                         break; // early re-quote cycle
                     }
                 }
@@ -2326,6 +2648,54 @@ mod tests {
     }
 
     #[test]
+    fn runtime_effect_executor_orders_abort_cleanup_and_recovery() {
+        let mut runtime_state = MakerState::starting();
+        runtime_state.handle(MakerEvent::StartupReady);
+        let cycle_token = match next_runtime_effect(&mut runtime_state) {
+            Some(MakerEffect::RunCycle(token)) => token,
+            effect => panic!("expected cycle effect, got {effect:?}"),
+        };
+
+        runtime_state.handle(MakerEvent::PositionMismatch);
+        let cleanup =
+            take_cleanup_effect(&mut runtime_state, RecoveryTarget::PositionReconciliation)
+                .expect("abort must be drained before cleanup");
+        runtime_state.handle(MakerEvent::CycleCompleted(cycle_token));
+        assert!(runtime_state.pending_effect().is_none());
+
+        runtime_state.handle(MakerEvent::CleanupCompleted(cleanup));
+        let recovery =
+            take_recovery_effect(&mut runtime_state, RecoveryTarget::PositionReconciliation)
+                .expect("cleanup completion must schedule recovery");
+        runtime_state.handle(MakerEvent::RecoverySucceeded(recovery));
+        assert!(matches!(
+            next_runtime_effect(&mut runtime_state),
+            Some(MakerEffect::RunCycle(_))
+        ));
+    }
+
+    #[test]
+    fn runtime_recovery_failure_is_the_stop_source_of_truth() {
+        let mut runtime_state = MakerState::starting();
+        runtime_state.handle(MakerEvent::StartupReady);
+        let _ = next_runtime_effect(&mut runtime_state);
+        runtime_state.handle(MakerEvent::OrderResponseDisconnected("closed".to_string()));
+        let cleanup = take_cleanup_effect(&mut runtime_state, RecoveryTarget::OrderResponse)
+            .expect("cleanup effect");
+        runtime_state.handle(MakerEvent::CleanupCompleted(cleanup));
+        let recovery = take_recovery_effect(&mut runtime_state, RecoveryTarget::OrderResponse)
+            .expect("recovery effect");
+        let exit = recovery_failed_exit(
+            &mut runtime_state,
+            recovery,
+            "residual maker orders".to_string(),
+        );
+        assert!(
+            matches!(exit, MakerExit::OrderResponse(reason) if reason == "residual maker orders")
+        );
+    }
+
+    #[test]
     fn apply_order_response_keeps_accepted_placement() {
         let mut pending = vec![pending_place("req-1")];
         let matched = apply_order_response(
@@ -2382,7 +2752,11 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(16);
         let mut pending = vec![pending_place("req-1"), pending_place("req-2")];
         let mut runtime_state = MakerState::starting();
-        runtime_state.reduce(MakerEvent::StartupReady);
+        runtime_state.handle(MakerEvent::StartupReady);
+        assert!(matches!(
+            next_runtime_effect(&mut runtime_state),
+            Some(MakerEffect::RunCycle(_))
+        ));
 
         // Benign matched acknowledgements for placements we are tracking.
         tx.try_send(order_response(Some("req-1"), 0)).unwrap();
@@ -2399,10 +2773,7 @@ mod tests {
         )
         .expect("benign matched acks must not fail closed");
 
-        assert!(
-            !runtime_state.is_frozen(),
-            "matched acks must not overflow the unmatched buffer"
-        );
+        assert!(runtime_state.pending_effect().is_none());
         // Accepted placements remain pending; the matched arm keeps them.
         assert_eq!(pending.len(), 2);
     }
@@ -2412,7 +2783,11 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(16);
         let mut pending = Vec::new();
         let mut runtime_state = MakerState::starting();
-        runtime_state.reduce(MakerEvent::StartupReady);
+        runtime_state.handle(MakerEvent::StartupReady);
+        assert!(matches!(
+            next_runtime_effect(&mut runtime_state),
+            Some(MakerEffect::RunCycle(_))
+        ));
 
         // First response has no matching pending placement -> buffered as unmatched.
         tx.try_send(order_response(Some("req-1"), 0)).unwrap();
@@ -2426,7 +2801,7 @@ mod tests {
             2,
         )
         .unwrap();
-        assert!(!runtime_state.is_frozen());
+        assert!(runtime_state.pending_effect().is_none());
 
         // The matching placement arrives later; a matched ack clears the buffer entry.
         pending.push(pending_place("req-1"));
@@ -2441,7 +2816,7 @@ mod tests {
             2,
         )
         .unwrap();
-        assert!(!runtime_state.is_frozen());
+        assert!(runtime_state.pending_effect().is_none());
     }
 
     fn drain_positions(events: Vec<AccountEvent>) -> (u64, Option<f64>) {

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -29,7 +29,10 @@ pub use ownership::{
     MAKER_CL_ORD_ID_PREFIX,
 };
 pub use risk::{PositionAlertAnchor, PositionRiskEvent, PositionRiskKind};
-pub use runtime::{MakerEffect, MakerEvent, MakerState, RuntimePhase, WorkKind, WorkToken};
+pub use runtime::{
+    MakerEffect, MakerEvent, MakerState, RecoveryTarget, RuntimePhase, RuntimeStopReason, WorkKind,
+    WorkToken,
+};
 
 /// Static per-run configuration (CLI args + symbol metadata).
 #[derive(Debug, Clone)]

--- a/crates/standx-maker/src/runtime.rs
+++ b/crates/standx-maker/src/runtime.rs
@@ -1,15 +1,12 @@
-//! Pure maker runtime state transitions; the CLI executes returned effects.
+//! Pure maker runtime state transitions; the CLI executes queued effects.
 
 use std::collections::VecDeque;
 
 const MAX_UNMATCHED_ORDER_RESPONSES: usize = 256;
-// Benign responses (cancel acks, the reduce-only inventory-exit ack, late acks
-// for pending places that already expired) carry a request_id with no matching
-// pending place, but arrive at a bounded rate. Age unmatched entries out by
-// cycle so those steady sources cannot grow the buffer without limit; only a
-// sustained flood of genuinely-uncorrelated responses within the window can
-// still overflow and fail closed.
+// Benign cancel/exit/late placement acknowledgements age out by cycle; only a
+// sustained burst of genuinely uncorrelated responses may overflow and freeze.
 const UNMATCHED_ORDER_RESPONSE_TTL_CYCLES: u64 = 8;
+const MAX_CONSECUTIVE_CYCLE_ERRORS: u32 = 3;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RuntimePhase {
@@ -18,76 +15,150 @@ pub enum RuntimePhase {
     Frozen { reason: String },
     Stopping { reason: String },
 }
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WorkKind {
-    Snapshot,
+    Cycle,
     Cleanup,
-    Reconnect,
+    Recovery,
 }
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WorkToken {
     pub generation: u64,
     pub kind: WorkKind,
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoveryTarget {
+    AccountStream,
+    OrderResponse,
+    PositionReconciliation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeStopReason {
+    CtrlC,
+    OrderResponse(String),
+    PositionReconciliation(String),
+    ConsecutiveCycleErrors(String),
+    StopLoss(String),
+    CleanupFailure {
+        target: RecoveryTarget,
+        reason: String,
+    },
+}
+
+impl RuntimeStopReason {
+    pub fn detail(&self) -> String {
+        match self {
+            Self::CtrlC => "Ctrl+C".to_string(),
+            Self::OrderResponse(reason)
+            | Self::PositionReconciliation(reason)
+            | Self::ConsecutiveCycleErrors(reason)
+            | Self::StopLoss(reason) => reason.clone(),
+            Self::CleanupFailure { reason, .. } => reason.clone(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MakerEvent {
     StartupReady,
     Timer,
     MarketChanged,
-    WorkFinished(WorkToken),
+    CycleCompleted(WorkToken),
+    CycleFailed { token: WorkToken, reason: String },
     AccountStreamDisconnected(String),
     OrderResponseDisconnected(String),
     PositionMismatch,
-    CleanupComplete,
-    RecoverySucceeded,
-    RecoveryFailed(String),
+    CleanupCompleted(WorkToken),
+    CleanupFailed { token: WorkToken, reason: String },
+    RecoverySucceeded(WorkToken),
+    RecoveryFailed { token: WorkToken, reason: String },
     OrderResponseUnmatched { request_id: String, cycle: u64 },
     OrderResponseMatched(String),
+    StopRequested(RuntimeStopReason),
     CtrlC,
 }
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MakerEffect {
-    FetchSnapshot(WorkToken),
+    RunCycle(WorkToken),
     AbortInFlight(WorkToken),
-    Cleanup(WorkToken),
-    Reconnect(WorkToken),
-    Stop,
+    CommitCycle(WorkToken),
+    Cleanup {
+        token: WorkToken,
+        target: RecoveryTarget,
+    },
+    Recover {
+        token: WorkToken,
+        target: RecoveryTarget,
+    },
+    Stop(RuntimeStopReason),
 }
+
 #[derive(Debug)]
 pub struct MakerState {
     phase: RuntimePhase,
     generation: u64,
     in_flight: Option<WorkToken>,
+    recovery_target: Option<RecoveryTarget>,
     replan_requested: bool,
+    consecutive_cycle_errors: u32,
     unmatched_order_responses: VecDeque<(u64, String)>,
+    effects: VecDeque<MakerEffect>,
 }
+
 impl MakerState {
     pub fn starting() -> Self {
         Self {
             phase: RuntimePhase::Starting,
             generation: 0,
             in_flight: None,
+            recovery_target: None,
             replan_requested: false,
+            consecutive_cycle_errors: 0,
             unmatched_order_responses: VecDeque::new(),
+            effects: VecDeque::new(),
         }
     }
+
     pub fn phase(&self) -> &RuntimePhase {
         &self.phase
     }
+
     pub fn generation(&self) -> u64 {
         self.generation
     }
-    pub fn in_flight(&self) -> Option<WorkToken> {
-        self.in_flight
-    }
+
     pub fn is_frozen(&self) -> bool {
         matches!(self.phase, RuntimePhase::Frozen { .. })
     }
-    pub fn reduce(&mut self, event: MakerEvent) -> Vec<MakerEffect> {
+
+    /// Applies an event and retains every resulting effect until the CLI
+    /// explicitly drains it with [`Self::next_effect`].
+    pub fn handle(&mut self, event: MakerEvent) {
+        let effects = self.transition(event);
+        self.effects.extend(effects);
+    }
+
+    pub fn next_effect(&mut self) -> Option<MakerEffect> {
+        self.effects.pop_front()
+    }
+
+    pub fn pending_effect(&self) -> Option<&MakerEffect> {
+        self.effects.front()
+    }
+
+    fn transition(&mut self, event: MakerEvent) -> Vec<MakerEffect> {
         match event {
             MakerEvent::StartupReady => {
+                if !matches!(self.phase, RuntimePhase::Starting) {
+                    return Vec::new();
+                }
                 self.phase = RuntimePhase::Ready;
-                self.request_snapshot()
+                self.request_cycle()
             }
             MakerEvent::Timer | MakerEvent::MarketChanged => {
                 if !matches!(self.phase, RuntimePhase::Ready) {
@@ -97,41 +168,94 @@ impl MakerState {
                     self.replan_requested = true;
                     Vec::new()
                 } else {
-                    self.request_snapshot()
+                    self.request_cycle()
                 }
             }
-            MakerEvent::WorkFinished(token) => {
-                if token.generation != self.generation || self.in_flight != Some(token) {
+            MakerEvent::CycleCompleted(token) => {
+                if !self.matches_in_flight(token, WorkKind::Cycle) {
                     return Vec::new();
                 }
                 self.in_flight = None;
+                self.consecutive_cycle_errors = 0;
+                let mut effects = vec![MakerEffect::CommitCycle(token)];
                 if self.replan_requested && matches!(self.phase, RuntimePhase::Ready) {
                     self.replan_requested = false;
-                    self.request_snapshot()
+                    effects.extend(self.request_cycle());
+                }
+                effects
+            }
+            MakerEvent::CycleFailed { token, reason } => {
+                if !self.matches_in_flight(token, WorkKind::Cycle) {
+                    return Vec::new();
+                }
+                self.in_flight = None;
+                self.consecutive_cycle_errors = self.consecutive_cycle_errors.saturating_add(1);
+                if self.consecutive_cycle_errors >= MAX_CONSECUTIVE_CYCLE_ERRORS {
+                    self.stop(RuntimeStopReason::ConsecutiveCycleErrors(reason))
                 } else {
                     Vec::new()
                 }
             }
-            MakerEvent::AccountStreamDisconnected(reason)
-            | MakerEvent::OrderResponseDisconnected(reason)
-            | MakerEvent::RecoveryFailed(reason) => self.freeze(reason),
-            MakerEvent::PositionMismatch => self.freeze("position mismatch".to_string()),
-            MakerEvent::CleanupComplete => {
-                if !matches!(self.phase, RuntimePhase::Frozen { .. }) {
+            MakerEvent::AccountStreamDisconnected(reason) => {
+                self.freeze(reason, RecoveryTarget::AccountStream)
+            }
+            MakerEvent::OrderResponseDisconnected(reason) => {
+                self.freeze(reason, RecoveryTarget::OrderResponse)
+            }
+            MakerEvent::PositionMismatch => self.freeze(
+                "position mismatch".to_string(),
+                RecoveryTarget::PositionReconciliation,
+            ),
+            MakerEvent::CleanupCompleted(token) => {
+                if !self.matches_in_flight(token, WorkKind::Cleanup) {
                     return Vec::new();
                 }
+                let Some(target) = self.recovery_target else {
+                    return self.stop(RuntimeStopReason::CleanupFailure {
+                        target: RecoveryTarget::PositionReconciliation,
+                        reason: "cleanup completed without a recovery target".to_string(),
+                    });
+                };
                 let token = WorkToken {
                     generation: self.generation,
-                    kind: WorkKind::Reconnect,
+                    kind: WorkKind::Recovery,
                 };
                 self.in_flight = Some(token);
-                vec![MakerEffect::Reconnect(token)]
+                vec![MakerEffect::Recover { token, target }]
             }
-            MakerEvent::RecoverySucceeded => {
+            MakerEvent::CleanupFailed { token, reason } => {
+                if !self.matches_in_flight(token, WorkKind::Cleanup) {
+                    return Vec::new();
+                }
                 self.in_flight = None;
+                self.stop(RuntimeStopReason::CleanupFailure {
+                    target: self
+                        .recovery_target
+                        .unwrap_or(RecoveryTarget::PositionReconciliation),
+                    reason,
+                })
+            }
+            MakerEvent::RecoverySucceeded(token) => {
+                if !self.matches_in_flight(token, WorkKind::Recovery) {
+                    return Vec::new();
+                }
+                self.in_flight = None;
+                self.recovery_target = None;
                 self.unmatched_order_responses.clear();
+                self.consecutive_cycle_errors = 0;
                 self.phase = RuntimePhase::Ready;
-                self.request_snapshot()
+                self.request_cycle()
+            }
+            MakerEvent::RecoveryFailed { token, reason } => {
+                if !self.matches_in_flight(token, WorkKind::Recovery) {
+                    return Vec::new();
+                }
+                self.in_flight = None;
+                let stop = match self.recovery_target {
+                    Some(RecoveryTarget::OrderResponse) => RuntimeStopReason::OrderResponse(reason),
+                    _ => RuntimeStopReason::PositionReconciliation(reason),
+                };
+                self.stop(stop)
             }
             MakerEvent::OrderResponseUnmatched { request_id, cycle } => {
                 self.unmatched_order_responses
@@ -140,7 +264,10 @@ impl MakerState {
                     cycle.saturating_sub(*seen) <= UNMATCHED_ORDER_RESPONSE_TTL_CYCLES
                 });
                 if self.unmatched_order_responses.len() > MAX_UNMATCHED_ORDER_RESPONSES {
-                    self.freeze("unmatched order-response buffer overflow".to_string())
+                    self.freeze(
+                        "unmatched order-response buffer overflow".to_string(),
+                        RecoveryTarget::OrderResponse,
+                    )
                 } else {
                     Vec::new()
                 }
@@ -155,42 +282,63 @@ impl MakerState {
                 }
                 Vec::new()
             }
-            MakerEvent::CtrlC => {
-                self.generation = self.generation.saturating_add(1);
-                let mut effects = self.abort_effect();
-                self.phase = RuntimePhase::Stopping {
-                    reason: "Ctrl+C".to_string(),
-                };
-                effects.push(MakerEffect::Stop);
-                effects
-            }
+            MakerEvent::StopRequested(reason) => self.stop(reason),
+            MakerEvent::CtrlC => self.stop(RuntimeStopReason::CtrlC),
         }
     }
-    fn request_snapshot(&mut self) -> Vec<MakerEffect> {
+
+    fn matches_in_flight(&self, token: WorkToken, kind: WorkKind) -> bool {
+        token.generation == self.generation && token.kind == kind && self.in_flight == Some(token)
+    }
+
+    fn request_cycle(&mut self) -> Vec<MakerEffect> {
         let token = WorkToken {
             generation: self.generation,
-            kind: WorkKind::Snapshot,
+            kind: WorkKind::Cycle,
         };
         self.in_flight = Some(token);
-        vec![MakerEffect::FetchSnapshot(token)]
+        vec![MakerEffect::RunCycle(token)]
     }
-    fn freeze(&mut self, reason: String) -> Vec<MakerEffect> {
-        if matches!(self.phase, RuntimePhase::Stopping { .. }) {
+
+    fn freeze(&mut self, reason: String, target: RecoveryTarget) -> Vec<MakerEffect> {
+        if matches!(
+            self.phase,
+            RuntimePhase::Frozen { .. } | RuntimePhase::Stopping { .. }
+        ) {
             return Vec::new();
         }
+        self.effects.clear();
         self.generation = self.generation.saturating_add(1);
         self.replan_requested = false;
         self.unmatched_order_responses.clear();
         let mut effects = self.abort_effect();
         self.phase = RuntimePhase::Frozen { reason };
-        let cleanup = WorkToken {
+        self.recovery_target = Some(target);
+        let token = WorkToken {
             generation: self.generation,
             kind: WorkKind::Cleanup,
         };
-        self.in_flight = Some(cleanup);
-        effects.push(MakerEffect::Cleanup(cleanup));
+        self.in_flight = Some(token);
+        effects.push(MakerEffect::Cleanup { token, target });
         effects
     }
+
+    fn stop(&mut self, reason: RuntimeStopReason) -> Vec<MakerEffect> {
+        if matches!(self.phase, RuntimePhase::Stopping { .. }) {
+            return Vec::new();
+        }
+        self.effects.clear();
+        self.generation = self.generation.saturating_add(1);
+        self.replan_requested = false;
+        self.recovery_target = None;
+        let mut effects = self.abort_effect();
+        self.phase = RuntimePhase::Stopping {
+            reason: reason.detail(),
+        };
+        effects.push(MakerEffect::Stop(reason));
+        effects
+    }
+
     fn abort_effect(&mut self) -> Vec<MakerEffect> {
         self.in_flight
             .take()
@@ -203,98 +351,224 @@ impl MakerState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn next_cycle(state: &mut MakerState) -> WorkToken {
+        match state.next_effect().expect("cycle effect") {
+            MakerEffect::RunCycle(token) => token,
+            effect => panic!("expected cycle, got {effect:?}"),
+        }
+    }
+
+    #[test]
+    fn effects_are_retained_until_explicitly_drained() {
+        let mut state = MakerState::starting();
+        state.handle(MakerEvent::StartupReady);
+        let token = next_cycle(&mut state);
+        assert_eq!(token.kind, WorkKind::Cycle);
+        assert!(state.next_effect().is_none());
+    }
+
     #[test]
     fn critical_events_abort_stale_work_and_clean_up() {
         let mut state = MakerState::starting();
-        let token = match state.reduce(MakerEvent::StartupReady)[0] {
-            MakerEffect::FetchSnapshot(token) => token,
-            _ => unreachable!(),
-        };
-        let effects = state.reduce(MakerEvent::PositionMismatch);
+        state.handle(MakerEvent::StartupReady);
+        let token = next_cycle(&mut state);
+        state.handle(MakerEvent::PositionMismatch);
         assert_eq!(state.generation(), 1);
         assert!(matches!(state.phase(), RuntimePhase::Frozen { .. }));
-        assert_eq!(effects[0], MakerEffect::AbortInFlight(token));
-        assert!(matches!(effects[1], MakerEffect::Cleanup(_)));
-        assert!(state.reduce(MakerEvent::WorkFinished(token)).is_empty());
-    }
-    #[test]
-    fn coalesced_timer_replans_after_current_work() {
-        let mut state = MakerState::starting();
-        let token = match state.reduce(MakerEvent::StartupReady)[0] {
-            MakerEffect::FetchSnapshot(token) => token,
-            _ => unreachable!(),
+        assert_eq!(state.next_effect(), Some(MakerEffect::AbortInFlight(token)));
+        let cleanup = match state.next_effect().expect("cleanup") {
+            MakerEffect::Cleanup { token, target } => {
+                assert_eq!(target, RecoveryTarget::PositionReconciliation);
+                token
+            }
+            effect => panic!("expected cleanup, got {effect:?}"),
         };
-        assert!(state.reduce(MakerEvent::Timer).is_empty());
-        assert!(state.reduce(MakerEvent::MarketChanged).is_empty());
+        state.handle(MakerEvent::CycleCompleted(token));
+        assert!(state.next_effect().is_none());
+        state.handle(MakerEvent::CleanupCompleted(cleanup));
         assert!(matches!(
-            state.reduce(MakerEvent::WorkFinished(token)).as_slice(),
-            [MakerEffect::FetchSnapshot(_)]
+            state.next_effect(),
+            Some(MakerEffect::Recover {
+                target: RecoveryTarget::PositionReconciliation,
+                ..
+            })
         ));
     }
 
     #[test]
-    fn recovery_reconnects_only_after_cleanup() {
+    fn coalesced_timer_commits_then_replans() {
         let mut state = MakerState::starting();
-        state.reduce(MakerEvent::StartupReady);
-        state.reduce(MakerEvent::AccountStreamDisconnected("closed".to_string()));
+        state.handle(MakerEvent::StartupReady);
+        let token = next_cycle(&mut state);
+        state.handle(MakerEvent::Timer);
+        state.handle(MakerEvent::MarketChanged);
+        assert!(state.next_effect().is_none());
+        state.handle(MakerEvent::CycleCompleted(token));
+        assert_eq!(state.next_effect(), Some(MakerEffect::CommitCycle(token)));
         assert!(matches!(
-            state.reduce(MakerEvent::CleanupComplete).as_slice(),
-            [MakerEffect::Reconnect(_)]
+            state.next_effect(),
+            Some(MakerEffect::RunCycle(_))
         ));
-        assert!(matches!(
-            state.reduce(MakerEvent::RecoverySucceeded).as_slice(),
-            [MakerEffect::FetchSnapshot(_)]
-        ));
-        assert!(matches!(state.phase(), RuntimePhase::Ready));
+    }
+
+    #[test]
+    fn each_recovery_target_runs_only_after_cleanup() {
+        for (event, expected_target) in [
+            (
+                MakerEvent::AccountStreamDisconnected("closed".to_string()),
+                RecoveryTarget::AccountStream,
+            ),
+            (
+                MakerEvent::OrderResponseDisconnected("closed".to_string()),
+                RecoveryTarget::OrderResponse,
+            ),
+            (
+                MakerEvent::PositionMismatch,
+                RecoveryTarget::PositionReconciliation,
+            ),
+        ] {
+            let mut state = MakerState::starting();
+            state.handle(MakerEvent::StartupReady);
+            let _ = next_cycle(&mut state);
+            state.handle(event);
+            let _ = state.next_effect();
+            let cleanup = match state.next_effect().expect("cleanup") {
+                MakerEffect::Cleanup { token, target } => {
+                    assert_eq!(target, expected_target);
+                    token
+                }
+                effect => panic!("expected cleanup, got {effect:?}"),
+            };
+            state.handle(MakerEvent::CleanupCompleted(cleanup));
+            let recovery = match state.next_effect().expect("recovery") {
+                MakerEffect::Recover { token, target } => {
+                    assert_eq!(target, expected_target);
+                    token
+                }
+                effect => panic!("expected recovery, got {effect:?}"),
+            };
+            state.handle(MakerEvent::RecoverySucceeded(recovery));
+            assert!(matches!(
+                state.next_effect(),
+                Some(MakerEffect::RunCycle(_))
+            ));
+            assert!(matches!(state.phase(), RuntimePhase::Ready));
+        }
+    }
+
+    #[test]
+    fn cleanup_or_recovery_failure_stops() {
+        let mut state = MakerState::starting();
+        state.handle(MakerEvent::StartupReady);
+        let _ = next_cycle(&mut state);
+        state.handle(MakerEvent::PositionMismatch);
+        let _ = state.next_effect();
+        let cleanup = match state.next_effect().unwrap() {
+            MakerEffect::Cleanup { token, .. } => token,
+            _ => unreachable!(),
+        };
+        state.handle(MakerEvent::CleanupFailed {
+            token: cleanup,
+            reason: "residual orders".to_string(),
+        });
+        assert!(matches!(state.next_effect(), Some(MakerEffect::Stop(_))));
+
+        let mut state = MakerState::starting();
+        state.handle(MakerEvent::StartupReady);
+        let _ = next_cycle(&mut state);
+        state.handle(MakerEvent::AccountStreamDisconnected("closed".to_string()));
+        let _ = state.next_effect();
+        let cleanup = match state.next_effect().unwrap() {
+            MakerEffect::Cleanup { token, .. } => token,
+            _ => unreachable!(),
+        };
+        state.handle(MakerEvent::CleanupCompleted(cleanup));
+        let recovery = match state.next_effect().unwrap() {
+            MakerEffect::Recover { token, .. } => token,
+            _ => unreachable!(),
+        };
+        state.handle(MakerEvent::RecoveryFailed {
+            token: recovery,
+            reason: "timeout".to_string(),
+        });
+        assert!(matches!(state.next_effect(), Some(MakerEffect::Stop(_))));
+    }
+
+    #[test]
+    fn third_cycle_failure_stops_and_stale_failures_are_ignored() {
+        let mut state = MakerState::starting();
+        state.handle(MakerEvent::StartupReady);
+        for attempt in 0..3 {
+            let token = next_cycle(&mut state);
+            state.handle(MakerEvent::CycleFailed {
+                token,
+                reason: format!("failure {attempt}"),
+            });
+            state.handle(MakerEvent::CycleFailed {
+                token,
+                reason: "stale duplicate".to_string(),
+            });
+            if attempt < 2 {
+                assert!(state.pending_effect().is_none());
+                state.handle(MakerEvent::Timer);
+            }
+        }
+        assert!(matches!(state.next_effect(), Some(MakerEffect::Stop(_))));
+    }
+
+    #[test]
+    fn ctrl_c_aborts_and_stops() {
+        let mut state = MakerState::starting();
+        state.handle(MakerEvent::StartupReady);
+        let token = next_cycle(&mut state);
+        state.handle(MakerEvent::CtrlC);
+        assert_eq!(state.next_effect(), Some(MakerEffect::AbortInFlight(token)));
+        assert_eq!(
+            state.next_effect(),
+            Some(MakerEffect::Stop(RuntimeStopReason::CtrlC))
+        );
     }
 
     #[test]
     fn unmatched_response_overflow_fails_closed() {
         let mut state = MakerState::starting();
-        state.reduce(MakerEvent::StartupReady);
-        // A sustained flood inside one decay window is a genuine correlation
-        // failure and must still fail closed. Sub-threshold pushes emit no
-        // effect; the push that crosses the cap freezes and emits Cleanup.
-        for index in 0..MAX_UNMATCHED_ORDER_RESPONSES {
-            assert!(state
-                .reduce(MakerEvent::OrderResponseUnmatched {
-                    request_id: index.to_string(),
-                    cycle: 0,
-                })
-                .is_empty());
+        state.handle(MakerEvent::StartupReady);
+        let _ = next_cycle(&mut state);
+        for index in 0..=MAX_UNMATCHED_ORDER_RESPONSES {
+            state.handle(MakerEvent::OrderResponseUnmatched {
+                request_id: index.to_string(),
+                cycle: 0,
+            });
         }
-        let effects = state.reduce(MakerEvent::OrderResponseUnmatched {
-            request_id: "overflow".to_string(),
-            cycle: 0,
-        });
         assert!(state.is_frozen());
-        assert!(effects
-            .iter()
-            .any(|effect| matches!(effect, MakerEffect::Cleanup(_))));
+        assert!(matches!(
+            state.next_effect(),
+            Some(MakerEffect::AbortInFlight(_))
+        ));
+        assert!(matches!(
+            state.next_effect(),
+            Some(MakerEffect::Cleanup {
+                target: RecoveryTarget::OrderResponse,
+                ..
+            })
+        ));
     }
 
     #[test]
     fn benign_unmatched_responses_decay_over_a_long_session() {
         let mut state = MakerState::starting();
-        state.reduce(MakerEvent::StartupReady);
-        // Simulate a long live run where every cycle produces a few unmatched
-        // responses from benign sources (cancel acks, the inventory-exit ack,
-        // late acks for expired pending places). Without decay the buffer would
-        // pass 256 after ~a hundred cycles and falsely fail closed; with decay
-        // it stays bounded and the session never freezes.
+        state.handle(MakerEvent::StartupReady);
+        let _ = next_cycle(&mut state);
         for cycle in 0..10_000u64 {
             for seq in 0..4 {
-                state.reduce(MakerEvent::OrderResponseUnmatched {
+                state.handle(MakerEvent::OrderResponseUnmatched {
                     request_id: format!("cycle-{cycle}-{seq}"),
                     cycle,
                 });
             }
             assert!(!state.is_frozen(), "froze at cycle {cycle}");
         }
-        assert!(
-            state.unmatched_order_responses.len() <= MAX_UNMATCHED_ORDER_RESPONSES,
-            "buffer grew unbounded: {}",
-            state.unmatched_order_responses.len()
-        );
+        assert!(state.unmatched_order_responses.len() <= MAX_UNMATCHED_ORDER_RESPONSES);
     }
 }

--- a/crates/standx-sdk/src/account_stream.rs
+++ b/crates/standx-sdk/src/account_stream.rs
@@ -60,6 +60,14 @@ impl AccountChannel {
             Self::Trade => "trade",
         }
     }
+
+    fn index(self) -> usize {
+        match self {
+            Self::Order => 0,
+            Self::Position => 1,
+            Self::Trade => 2,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -123,7 +131,7 @@ pub struct AccountStreamHealth {
     healthy: Arc<AtomicBool>,
     failure_reason: Arc<Mutex<Option<String>>>,
     epoch: Arc<AtomicU64>,
-    last_seq: Arc<AtomicU64>,
+    last_seq: Arc<[AtomicU64; 3]>,
 }
 
 impl AccountStreamHealth {
@@ -132,7 +140,7 @@ impl AccountStreamHealth {
             healthy: Arc::new(AtomicBool::new(true)),
             failure_reason: Arc::new(Mutex::new(None)),
             epoch: Arc::new(AtomicU64::new(epoch)),
-            last_seq: Arc::new(AtomicU64::new(0)),
+            last_seq: Arc::new(std::array::from_fn(|_| AtomicU64::new(0))),
         }
     }
 
@@ -151,8 +159,8 @@ impl AccountStreamHealth {
         self.epoch.load(Ordering::Acquire)
     }
 
-    pub fn last_seq(&self) -> u64 {
-        self.last_seq.load(Ordering::Acquire)
+    pub fn last_seq(&self, channel: AccountChannel) -> u64 {
+        self.last_seq[channel.index()].load(Ordering::Acquire)
     }
 
     pub fn mark_unhealthy(&self, reason: impl Into<String>) {
@@ -397,40 +405,49 @@ fn parse_account_event(text: &str, health: &AccountStreamHealth) -> Result<Optio
     let Some(channel) = envelope.get("channel").and_then(|value| value.as_str()) else {
         return Ok(None);
     };
-    if channel == "auth" {
-        return Ok(None);
-    }
+    let account_channel = match channel {
+        "order" => AccountChannel::Order,
+        "position" => AccountChannel::Position,
+        "trade" => AccountChannel::Trade,
+        "auth" => return Ok(None),
+        _ => return Ok(None),
+    };
     let seq = envelope
         .get("seq")
         .and_then(|value| value.as_u64())
         .ok_or_else(|| Error::WebSocket {
             message: format!("{channel} event has no numeric seq"),
         })?;
-    let previous = health.last_seq.swap(seq, Ordering::AcqRel);
+    // StandX does not document whether `seq` is global or channel-local, nor
+    // whether it is contiguous. Channel-local monotonic validation is safe for
+    // either scope: reject duplicates/regressions within a channel, but allow
+    // interleaved channels and gaps without falsely declaring the stream dead.
+    let channel_seq = &health.last_seq[account_channel.index()];
+    let previous = channel_seq.load(Ordering::Acquire);
     if previous != 0 && seq <= previous {
         return Err(Error::WebSocket {
-            message: format!("account stream seq regressed from {previous} to {seq}"),
+            message: format!("account stream {channel} seq regressed from {previous} to {seq}"),
         });
     }
+    channel_seq.store(seq, Ordering::Release);
     let data = envelope
         .get("data")
         .cloned()
         .ok_or_else(|| Error::WebSocket {
             message: format!("{channel} event has no data"),
         })?;
-    match channel {
-        "order" => {
+    match account_channel {
+        AccountChannel::Order => {
             let mut order = serde_json::from_value::<OrderUpdate>(data)?;
             order.seq = seq;
             Ok(Some(AccountEvent::Order(order)))
         }
-        "position" => {
+        AccountChannel::Position => {
             let mut position = serde_json::from_value::<PositionUpdate>(data)?;
             position.seq = seq;
             Ok(Some(AccountEvent::Position(position)))
         }
-        "trade" => Ok(Some(AccountEvent::TradeShadow { seq, data })),
-        _ => Ok(None),
+        AccountChannel::Trade => Ok(Some(AccountEvent::TradeShadow { seq, data })),
     }
 }
 
@@ -478,6 +495,41 @@ mod tests {
         let health = AccountStreamHealth::new(1);
         parse_account_event(r#"{"seq":9,"channel":"trade","data":{}}"#, &health).unwrap();
         assert!(parse_account_event(r#"{"seq":8,"channel":"trade","data":{}}"#, &health,).is_err());
+        assert_eq!(health.last_seq(AccountChannel::Trade), 9);
+    }
+
+    #[test]
+    fn seq_is_monotonic_per_channel_and_allows_gaps() {
+        let health = AccountStreamHealth::new(1);
+        parse_account_event(r#"{"seq":100,"channel":"trade","data":{}}"#, &health).unwrap();
+        let position = r#"{"seq":3,"channel":"position","data":{"symbol":"BTC-USD","qty":"0","entry_price":"0","realized_pnl":"0","status":"closed","updated_at":"now"}}"#;
+        parse_account_event(position, &health).unwrap();
+        parse_account_event(r#"{"seq":900,"channel":"trade","data":{}}"#, &health).unwrap();
+
+        assert_eq!(health.last_seq(AccountChannel::Trade), 900);
+        assert_eq!(health.last_seq(AccountChannel::Position), 3);
+        assert_eq!(health.last_seq(AccountChannel::Order), 0);
+
+        assert!(parse_account_event(position, &health).is_err());
+    }
+
+    #[test]
+    fn auth_and_unknown_channels_do_not_change_seq_state() {
+        let health = AccountStreamHealth::new(1);
+        assert!(parse_account_event(
+            r#"{"seq":99,"channel":"auth","data":{"code":200}}"#,
+            &health,
+        )
+        .unwrap()
+        .is_none());
+        assert!(
+            parse_account_event(r#"{"seq":100,"channel":"balance","data":{}}"#, &health,)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(health.last_seq(AccountChannel::Order), 0);
+        assert_eq!(health.last_seq(AccountChannel::Position), 0);
+        assert_eq!(health.last_seq(AccountChannel::Trade), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Extract maker recovery and runtime state-transition logic into `standx-maker`
- Keep `standx-cli` focused on orchestration, adapters, and effect execution
- Update account stream handling to feed the new reducer-driven flow

## Testing
- Not run (not requested)