### PR TITLE
Add standard and conservative XAG-USD 100u maker profiles

### DIFF
--- a/examples/maker-xag-100u-conservative.toml
+++ b/examples/maker-xag-100u-conservative.toml
@@ -1,0 +1,63 @@
+# Conservative XAG-USD maker profile for a 100 DUSD account at isolated 2x.
+#
+# Run with (live mode refuses to start without --alert-webhook):
+#   standx --output json maker run XAG-USD \
+#     --maker-config examples/maker-xag-100u-conservative.toml \
+#     --alert-webhook <url> --live --yes
+#
+# Set isolated 2x leverage separately. Quote geometry and the active-exit
+# tuple are unchanged from the production-tested maker-xag-100u.toml profile
+# (max_position=0.8, inventory_exit_pct=25, inventory_exit_qty=0.2); this
+# variant only tightens the financial brakes on top of it. Around a 58.9
+# mark the full inventory is ~47 DUSD notional (~24% of 2x capacity) with
+# ~24 DUSD isolated margin, ~30 including one resting quote per side.
+#
+# Pre-existing XAG inventory up to max_position is adopted automatically at
+# the startup mark, so maker-session PnL starts at zero. Larger inventory is
+# rejected after maker-order cleanup. Account upnl keeps the venue cost basis.
+
+# Quote geometry
+spread_bps = 7.0
+band_bps = 9.0
+size = 0.2
+levels = 1
+level_step_bps = 0.0
+refresh_bps = 2.0
+interval = 3
+
+# Inventory and market-data guards
+max_position = 0.8
+skew_bps = 8.0
+max_divergence_bps = 6.0
+vol_pause_bps = 30.0
+vol_window = 20
+
+# Supervised active inventory exit (production-tested tuple, do not scale
+# without re-validation)
+inventory_exit_pct = 25.0
+inventory_exit_qty = 0.2
+
+# Financial brakes: alert at 2% of the account, hard-stop at 4%. stop_loss
+# is session-scoped mark-to-market PnL and routes through the fail-safe
+# shutdown (freeze, cancel the book, critical webhook, exit). The equity
+# floor is an absolute cross-restart line that catches cumulative drawdown
+# the session-scoped stop cannot see.
+stop_loss = 4.0
+alert_loss = 2.0
+alert_equity_below = 94.0
+alert_margin_below = 30.0
+
+# Remaining alert thresholds (live mode requires at least one non-zero)
+alert_inventory_pct = 70.0
+alert_position_change_pct = 20.0
+alert_uptime = 60.0
+
+# Bounded safe recovery for both authenticated streams. Quoting resumes only
+# after maker cleanup and account/trade reconciliation succeed.
+account_stream_reconnect_attempts = 3
+account_stream_reconnect_backoff = 2
+order_response_reconnect_attempts = 3
+order_response_reconnect_backoff = 2
+
+# Use the WebSocket market feed, with REST fallback handled by the CLI.
+no_ws = false

--- a/examples/maker-xag-100u-standard.toml
+++ b/examples/maker-xag-100u-standard.toml
@@ -1,0 +1,68 @@
+# Standard XAG-USD maker profile for a 100 DUSD account at isolated 2x.
+#
+# Run with (live mode refuses to start without --alert-webhook):
+#   standx --output json maker run XAG-USD \
+#     --maker-config examples/maker-xag-100u-standard.toml \
+#     --alert-webhook <url> --live --yes
+#
+# Set isolated 2x leverage separately. Compared to the conservative profile
+# this quotes a two-level ladder with 1.5x the inventory cap for higher
+# capital utilization: around a 58.9 mark the full inventory is ~71 DUSD
+# notional (~35% of 2x capacity), ~35 DUSD isolated margin plus ~18 for the
+# resting ladder (worst case ~53 committed).
+#
+# ⚠️ The active-exit tuple below (max_position=1.2, inventory_exit_pct=25,
+# inventory_exit_qty=0.3) is scaled proportionally from the production-tested
+# (0.8 / 25 / 0.2) tuple. The code path is identical but this exact tuple has
+# NOT been validated live — run it in paper mode first (stop_loss also fires
+# in paper, so the brake can be verified in the same run).
+#
+# Pre-existing XAG inventory up to max_position is adopted automatically at
+# the startup mark, so maker-session PnL starts at zero. Larger inventory is
+# rejected after maker-order cleanup. Account upnl keeps the venue cost basis.
+
+# Quote geometry: slightly tighter spread and a two-level ladder trade more
+# volume for more adverse-selection exposure.
+spread_bps = 6.0
+band_bps = 8.0
+size = 0.3
+levels = 2
+level_step_bps = 4.0
+refresh_bps = 2.0
+interval = 3
+
+# Inventory and market-data guards
+max_position = 1.2
+skew_bps = 8.0
+max_divergence_bps = 6.0
+vol_pause_bps = 30.0
+vol_window = 20
+
+# Supervised active inventory exit (see the scaling caveat above)
+inventory_exit_pct = 25.0
+inventory_exit_qty = 0.3
+
+# Financial brakes: alert at 3% of the account, hard-stop at 6%. stop_loss
+# is session-scoped mark-to-market PnL and routes through the fail-safe
+# shutdown (freeze, cancel the book, critical webhook, exit). The equity
+# floor is an absolute cross-restart line that catches cumulative drawdown
+# the session-scoped stop cannot see.
+stop_loss = 6.0
+alert_loss = 3.0
+alert_equity_below = 90.0
+alert_margin_below = 25.0
+
+# Remaining alert thresholds (live mode requires at least one non-zero)
+alert_inventory_pct = 70.0
+alert_position_change_pct = 20.0
+alert_uptime = 60.0
+
+# Bounded safe recovery for both authenticated streams. Quoting resumes only
+# after maker cleanup and account/trade reconciliation succeed.
+account_stream_reconnect_attempts = 3
+account_stream_reconnect_backoff = 2
+order_response_reconnect_attempts = 3
+order_response_reconnect_backoff = 2
+
+# Use the WebSocket market feed, with REST fallback handled by the CLI.
+no_ws = false

--- a/examples/maker-xag-100u.toml
+++ b/examples/maker-xag-100u.toml
@@ -1,5 +1,10 @@
 # Conservative XAG-USD maker profile for a 100 DUSD account.
 #
+# NOTE: superseded by maker-xag-100u-conservative.toml (same production-tested
+# geometry plus the stop-loss/equity/margin brakes) and, for higher capital
+# utilization, maker-xag-100u-standard.toml. Kept for reference; live mode now
+# additionally requires --alert-webhook on the command line.
+#
 # Run with:
 #   standx --output json maker run XAG-USD \
 #     --maker-config examples/maker-xag-100u.toml --live --yes


### PR DESCRIPTION
## Summary
Two example maker profiles for a **100 DUSD account at isolated 2x** on XAG-USD, both updated for the risk controls merged this week (#216 account-stream safe reconnect, #219 `stop_loss` + equity/margin floors, #220 live webhook requirement, #221 `deny_unknown_fields`):

| | conservative | standard |
|---|---|---|
| Full-inventory notional (@58.9) | ~47 DUSD (24% of 2x capacity) | ~71 DUSD (35%) |
| Quotes per side | 1 × 0.2 | 2 × 0.3 (4 bps ladder) |
| Alert → hard stop | 2 → 4 DUSD | 3 → 6 DUSD |
| Equity / margin floors | 94 / 30 | 90 / 25 |
| Active-exit tuple | (0.8 / 25 / 0.2) — production-tested | (1.2 / 25 / 0.3) — **scaled, not validated; paper-first warning in header** |

The legacy `maker-xag-100u.toml` gets a header note pointing to the new profiles and the `--alert-webhook` live requirement. No code changes.

## Test plan
- [x] All keys verified against `MakerFileConfig` (with `deny_unknown_fields` an unknown key refuses to start) — none unknown
- [x] `cargo fmt --check` / `clippy -D warnings` / `cargo test -p standx-cli` (config parse tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)