### PR TITLE
feat(maker): enforce live accounting invariant between stats and ledger positions

### DIFF
--- a/crates/standx-cli/src/commands/maker/ledger.rs
+++ b/crates/standx-cli/src/commands/maker/ledger.rs
@@ -236,4 +236,29 @@ mod tests {
 
         assert!(error.to_string().contains("non-finite fill_qty"));
     }
+
+    #[test]
+    fn partial_fill_then_cancelled_keeps_ledger_and_stats_positions_aligned() {
+        let mut ledger = MakerLedger::new(0.0);
+        let mut stats = MakerStats::default();
+        let mut fills = Vec::new();
+        let mut update = order_update(OrderSide::Buy, "0.10");
+        update.status = OrderStatus::Canceled;
+
+        apply_order_update(
+            &mut ledger,
+            &update,
+            "BTC-USD",
+            "sxmk-run-",
+            100.0,
+            &mut stats,
+            &mut fills,
+        )
+        .unwrap();
+
+        assert_eq!(fills.len(), 1);
+        assert!((ledger.expected_position - 0.10).abs() < 1e-9);
+        assert!((stats.position() - ledger.expected_position).abs() < 1e-9);
+        assert!(stats.pnl(ledger.expected_position, 100.0).abs() < 1e-9);
+    }
 }

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -279,6 +279,18 @@ mod tests {
     }
 
     #[test]
+    fn accounting_invariant_exit_is_immediate() {
+        let exit = MakerExit::AccountingInvariant(
+            "stats position -0.20000000 differs from ledger expected +0.00000000".to_string(),
+        );
+        let lifecycle = exit.lifecycle_reason();
+        let terminal = exit.terminal_error().unwrap();
+        assert!(lifecycle.contains("accounting invariant failed"));
+        assert!(terminal.contains("stopped immediately"));
+        assert!(terminal.contains("ledger expected"));
+    }
+
+    #[test]
     fn stop_loss_exit_reports_the_breach_and_is_terminal() {
         let exit = MakerExit::StopLoss("session PnL -12.50 <= -10.00".to_string());
         let lifecycle = exit.lifecycle_reason();

--- a/crates/standx-cli/src/commands/maker/model.rs
+++ b/crates/standx-cli/src/commands/maker/model.rs
@@ -3,8 +3,9 @@ use standx_sdk::models::{Order, OrderSide, Position};
 
 /// Process exit code emitted when the maker performs an *intentional*
 /// fail-safe shutdown: the order-response stream was lost, three maker
-/// cycles failed in a row, position reconciliation failed, or residual
-/// maker-owned orders could not be cancelled on the way out.
+/// cycles failed in a row, position reconciliation or an internal accounting
+/// invariant failed, or residual maker-owned orders could not be cancelled on
+/// the way out.
 ///
 /// Supervisors must treat this as "stop, do NOT auto-restart, notify a
 /// human" (systemd `RestartPreventExitStatus=`). It is deliberately
@@ -37,6 +38,7 @@ pub(super) enum MakerExit {
     OrderResponse(String),
     ConsecutiveErrors(String),
     PositionReconciliation(String),
+    AccountingInvariant(String),
     StopLoss(String),
 }
 
@@ -52,6 +54,9 @@ impl MakerExit {
             }
             Self::PositionReconciliation(error) => {
                 format!("fail-safe: position reconciliation failed: {error}")
+            }
+            Self::AccountingInvariant(detail) => {
+                format!("fail-safe: accounting invariant failed: {detail}")
             }
             Self::StopLoss(detail) => {
                 format!("fail-safe: stop-loss breached: {detail}")
@@ -70,6 +75,9 @@ impl MakerExit {
             )),
             Self::PositionReconciliation(error) => Some(format!(
                 "maker stopped immediately (fail-safe): position reconciliation failed: {error}"
+            )),
+            Self::AccountingInvariant(detail) => Some(format!(
+                "maker stopped immediately (fail-safe): accounting invariant failed: {detail}"
             )),
             Self::StopLoss(detail) => Some(format!(
                 "maker stopped immediately (fail-safe): stop-loss breached: {detail}"

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -258,7 +258,11 @@ fn accounting_position_mismatch(
     stats_position: f64,
     qty_tolerance: f64,
 ) -> bool {
-    (stats_position - expected_position).abs() > qty_tolerance
+    let delta = (stats_position - expected_position).abs();
+    // Fail closed: a non-finite delta (NaN from a poisoned position) would make
+    // a bare `>` comparison false and silently pass the invariant, so treat any
+    // non-finite value as a mismatch.
+    !delta.is_finite() || delta > qty_tolerance
 }
 
 async fn accounting_invariant_exit(
@@ -2600,6 +2604,14 @@ mod tests {
         assert!(accounting_position_mismatch(0.2, 0.20051, tolerance));
         assert!(!accounting_position_mismatch(-0.2, -0.20049, tolerance));
         assert!(accounting_position_mismatch(-0.2, -0.20051, tolerance));
+    }
+
+    #[test]
+    fn accounting_position_mismatch_fails_closed_on_non_finite() {
+        let tolerance = 0.0005;
+        assert!(accounting_position_mismatch(f64::NAN, 0.2, tolerance));
+        assert!(accounting_position_mismatch(0.2, f64::NAN, tolerance));
+        assert!(accounting_position_mismatch(f64::INFINITY, 0.2, tolerance));
     }
 
     #[tokio::test]

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -253,6 +253,48 @@ fn emit_stop_loss_triggered(
     }
 }
 
+fn accounting_position_mismatch(
+    expected_position: f64,
+    stats_position: f64,
+    qty_tolerance: f64,
+) -> bool {
+    (stats_position - expected_position).abs() > qty_tolerance
+}
+
+async fn accounting_invariant_exit(
+    notifier: &MakerNotifier,
+    symbol: &str,
+    cycle: u64,
+    expected_position: f64,
+    stats_position: f64,
+    qty_tolerance: f64,
+) -> Option<MakerExit> {
+    if !accounting_position_mismatch(expected_position, stats_position, qty_tolerance) {
+        return None;
+    }
+    let detail = format!(
+        "stats position {stats_position:+.8} differs from ledger expected {expected_position:+.8} beyond tolerance {qty_tolerance:.8}"
+    );
+    notifier
+        .risk(
+            RiskNotice {
+                kind: "accounting_invariant",
+                severity: "critical",
+                event: "mismatch",
+                message: &detail,
+                symbol,
+                cycle,
+                position_before: None,
+                position_after: Some(expected_position),
+                expected: Some(expected_position),
+                observed: Some(stats_position),
+            },
+            true,
+        )
+        .await;
+    Some(MakerExit::AccountingInvariant(detail))
+}
+
 fn emit_reconciliation_snapshot_error(
     output_format: OutputFormat,
     symbol: &str,
@@ -922,6 +964,7 @@ pub(super) async fn run_maker(
     } else {
         MakerStats::default()
     };
+    let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
     let mut breaker = VolBreaker::new(args.vol_window.max(1) as usize, args.vol_pause_bps);
     let mut alerts =
         AlertMonitor::new(args.alert_loss, args.alert_inventory_pct, args.alert_uptime)
@@ -1460,7 +1503,7 @@ pub(super) async fn run_maker(
                                     expected: ledger.expected_position,
                                     max_position: cfg.max_position,
                                     inventory_exit_pct: args.inventory_exit_pct,
-                                    qty_tolerance: 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0,
+                                    qty_tolerance,
                                     symbol: &symbol,
                                     cycle,
                                 },
@@ -1468,8 +1511,7 @@ pub(super) async fn run_maker(
                             .await;
                     }
                     if let Some(position) = position.filter(|position| {
-                        (*position - ledger.expected_position).abs()
-                            > 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0
+                        (*position - ledger.expected_position).abs() > qty_tolerance
                     }) {
                         account_position_mismatch = Some(position);
                     }
@@ -1483,11 +1525,24 @@ pub(super) async fn run_maker(
                 }
             }
         }
-        if account_position_mismatch.is_some_and(|position| {
-            (position - ledger.expected_position).abs()
-                <= 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0
-        }) {
+        if account_position_mismatch
+            .is_some_and(|position| (position - ledger.expected_position).abs() <= qty_tolerance)
+        {
             account_position_mismatch = None;
+        }
+        if args.live {
+            if let Some(exit) = accounting_invariant_exit(
+                &notifier,
+                &symbol,
+                cycle,
+                ledger.expected_position,
+                stats.position(),
+                qty_tolerance,
+            )
+            .await
+            {
+                break 'main exit;
+            }
         }
 
         // Work phase raced against Ctrl+C so a slow API call can be
@@ -1662,15 +1717,13 @@ pub(super) async fn run_maker(
                                     expected: ledger.expected_position,
                                     max_position: cfg.max_position,
                                     inventory_exit_pct: args.inventory_exit_pct,
-                                    qty_tolerance: 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0,
+                                    qty_tolerance,
                                     symbol: &symbol,
                                     cycle,
                                 },
                             )
                             .await;
-                        if (position - ledger.expected_position).abs()
-                            > 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0
-                        {
+                        if (position - ledger.expected_position).abs() > qty_tolerance {
                             runtime_state.reduce(MakerEvent::PositionMismatch);
                             account_position_mismatch = Some(position);
                         }
@@ -1682,6 +1735,20 @@ pub(super) async fn run_maker(
                         health.mark_unhealthy(error.to_string());
                     }
                 }
+            }
+        }
+        if args.live {
+            if let Some(exit) = accounting_invariant_exit(
+                &notifier,
+                &symbol,
+                cycle,
+                ledger.expected_position,
+                stats.position(),
+                qty_tolerance,
+            )
+            .await
+            {
+                break 'main exit;
             }
         }
 
@@ -1774,9 +1841,14 @@ pub(super) async fn run_maker(
                 }
                 // Risk alerts: evaluate over the just-updated stats and
                 // deliver any state changes (stderr always; webhook if set).
+                let session_position = if args.live {
+                    ledger.expected_position
+                } else {
+                    stats.position()
+                };
                 if alerts.enabled() {
                     let fired =
-                        alerts.evaluate(&stats, stats.position(), mark, cfg.max_position, cycle);
+                        alerts.evaluate(&stats, session_position, mark, cfg.max_position, cycle);
                     for alert in fired {
                         // Await firing alerts so a breach raised on the final
                         // cycle before shutdown is not dropped with its task.
@@ -1804,7 +1876,7 @@ pub(super) async fn run_maker(
                 // book, await the critical webhook, exit) — the same path the
                 // other MakerExit variants use.
                 if args.stop_loss > 0.0 {
-                    let pnl = stats.pnl(stats.position(), mark);
+                    let pnl = stats.pnl(session_position, mark);
                     if pnl <= -args.stop_loss {
                         emit_stop_loss_triggered(
                             output_format,
@@ -2163,13 +2235,21 @@ pub(super) async fn run_maker(
     if let Some(handle) = account_stream_handle {
         handle.abort();
     }
+    let final_position = if args.live {
+        ledger.expected_position
+    } else {
+        stats.position()
+    };
     if output_format == OutputFormat::Table {
         println!(
             "\n👋 Stopping maker (ran {} cycles: {} places, {} cancels, {} holds)",
             cycle, total_places, total_cancels, total_holds
         );
         let pnl_note = match last_mark {
-            Some(m) => format!(" | PnL {:+.2} (mark-to-market)", stats.mark_to_market(m)),
+            Some(m) => format!(
+                " | PnL {:+.2} (mark-to-market)",
+                stats.pnl(final_position, m)
+            ),
             None => String::new(),
         };
         println!(
@@ -2207,7 +2287,7 @@ pub(super) async fn run_maker(
     // before the process exits.
     let reason = exit.lifecycle_reason();
     let pnl_str = last_mark
-        .map(|m| format!("{:+.2}", stats.mark_to_market(m)))
+        .map(|m| format!("{:+.2}", stats.pnl(final_position, m)))
         .unwrap_or_else(|| "n/a".to_string());
     let cleanup_note = cleanup_error.as_ref().map_or_else(String::new, |error| {
         format!(" | ⚠️ cleanup failed: {error}")
@@ -2510,6 +2590,35 @@ mod tests {
         assert_eq!(
             latest, None,
             "position updates for other symbols are ignored"
+        );
+    }
+
+    #[test]
+    fn accounting_position_mismatch_respects_half_tick_tolerance() {
+        let tolerance = 0.0005;
+        assert!(!accounting_position_mismatch(0.2, 0.20049, tolerance));
+        assert!(accounting_position_mismatch(0.2, 0.20051, tolerance));
+        assert!(!accounting_position_mismatch(-0.2, -0.20049, tolerance));
+        assert!(accounting_position_mismatch(-0.2, -0.20051, tolerance));
+    }
+
+    #[tokio::test]
+    async fn accounting_invariant_mismatch_becomes_fail_safe_exit() {
+        let notifier = MakerNotifier::new(
+            OutputFormat::Quiet,
+            None,
+            crate::cli::AlertWebhookFormat::Raw,
+        );
+
+        assert!(
+            accounting_invariant_exit(&notifier, "XAG-USD", 1396, 0.0, -0.2, 0.0005,)
+                .await
+                .is_some_and(|exit| matches!(exit, MakerExit::AccountingInvariant(_)))
+        );
+        assert!(
+            accounting_invariant_exit(&notifier, "XAG-USD", 1396, 0.0, 0.00049, 0.0005,)
+                .await
+                .is_none()
         );
     }
 }

--- a/crates/standx-maker/src/ledger.rs
+++ b/crates/standx-maker/src/ledger.rs
@@ -149,6 +149,7 @@ impl MakerLedger {
             OrderSide::Buy => qty,
             OrderSide::Sell => -qty,
         };
+        stats.observe_position(self.expected_position);
         self.accounted.insert(
             fill.order_id,
             FillTotals {
@@ -250,5 +251,130 @@ mod tests {
             .is_none());
         assert_eq!(stats.fills(), 1);
         assert!((ledger.expected_position - 0.2).abs() < 1e-12);
+        assert!((stats.position() - ledger.expected_position).abs() < 1e-12);
+    }
+
+    #[test]
+    fn rest_then_ws_fill_updates_cash_and_position_once() {
+        let mut ledger = MakerLedger::new(0.0);
+        let mut stats = MakerStats::default();
+        assert!(ledger.adopt_order(7, Some("sxmk-run-q00000001b0"), "sxmk-run-"));
+
+        assert!(ledger
+            .record_rest_fill(
+                RestFill {
+                    trade_id: 1,
+                    order_id: 7,
+                    side: OrderSide::Sell,
+                    price: 100.0,
+                    qty: 0.2,
+                    mark: 100.0,
+                    trade_ts: "2026-07-13T00:00:00Z",
+                },
+                &mut stats,
+            )
+            .unwrap()
+            .is_some());
+        assert!(ledger
+            .record_cumulative_fill(
+                CumulativeFill {
+                    order_id: 7,
+                    side: OrderSide::Sell,
+                    qty: 0.2,
+                    notional: 20.0,
+                    mark: 100.0,
+                    origin: "current_run_ws_order",
+                    trade_id: None,
+                    trade_ts: Some("2026-07-13T00:00:00Z"),
+                },
+                &mut stats,
+            )
+            .unwrap()
+            .is_none());
+
+        assert_eq!(stats.fills(), 1);
+        assert!((stats.cash - 20.0).abs() < 1e-12);
+        assert!((ledger.expected_position + 0.2).abs() < 1e-12);
+        assert!((stats.position() - ledger.expected_position).abs() < 1e-12);
+    }
+
+    #[test]
+    fn buffered_inventory_exit_fill_keeps_round_trip_pnl_flat_to_notional() {
+        for (sell_price, buy_price, expected_pnl) in
+            [(57.78, 57.84, -0.012), (58.02, 58.10, -0.016)]
+        {
+            let mut ledger = MakerLedger::new(0.0);
+            let mut stats = MakerStats::default();
+            assert!(ledger.adopt_order(7, Some("sxmk-run-q00000001a0"), "sxmk-run-"));
+            assert!(ledger.adopt_order(8, Some("sxmk-run-x00000002b0"), "sxmk-run-"));
+
+            ledger
+                .record_cumulative_fill(
+                    CumulativeFill {
+                        order_id: 7,
+                        side: OrderSide::Sell,
+                        qty: 0.2,
+                        notional: sell_price * 0.2,
+                        mark: sell_price,
+                        origin: "current_run_ws_order",
+                        trade_id: None,
+                        trade_ts: Some("2026-07-13T14:22:01Z"),
+                    },
+                    &mut stats,
+                )
+                .unwrap();
+            stats.end_cycle(ledger.expected_position, false);
+
+            ledger
+                .record_cumulative_fill(
+                    CumulativeFill {
+                        order_id: 8,
+                        side: OrderSide::Buy,
+                        qty: 0.2,
+                        notional: buy_price * 0.2,
+                        mark: buy_price,
+                        origin: "current_run_ws_order",
+                        trade_id: None,
+                        trade_ts: Some("2026-07-13T14:22:05Z"),
+                    },
+                    &mut stats,
+                )
+                .unwrap();
+
+            assert!(ledger.expected_position.abs() < 1e-12);
+            assert!(stats.position().abs() < 1e-12);
+            assert!((stats.pnl(ledger.expected_position, buy_price) - expected_pnl).abs() < 1e-12);
+            assert!(stats.pnl(ledger.expected_position, buy_price) > -4.0);
+        }
+    }
+
+    #[test]
+    fn partial_cumulative_fills_update_position_once_per_delta() {
+        let mut ledger = MakerLedger::new(0.0);
+        let mut stats = MakerStats::default();
+        assert!(ledger.adopt_order(7, Some("sxmk-run-q00000001b0"), "sxmk-run-"));
+
+        for (qty, notional) in [(0.1, 10.0), (0.2, 20.0), (0.2, 20.0)] {
+            ledger
+                .record_cumulative_fill(
+                    CumulativeFill {
+                        order_id: 7,
+                        side: OrderSide::Buy,
+                        qty,
+                        notional,
+                        mark: 100.0,
+                        origin: "current_run_ws_order",
+                        trade_id: None,
+                        trade_ts: Some("2026-07-13T00:00:00Z"),
+                    },
+                    &mut stats,
+                )
+                .unwrap();
+        }
+
+        assert_eq!(stats.fills(), 2);
+        assert!((stats.cash + 20.0).abs() < 1e-12);
+        assert!((ledger.expected_position - 0.2).abs() < 1e-12);
+        assert!((stats.position() - ledger.expected_position).abs() < 1e-12);
     }
 }

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -338,11 +338,17 @@ impl MakerStats {
         }
     }
 
+    /// Synchronize the cached telemetry position with the authoritative
+    /// current-run ledger without closing another maker cycle.
+    pub(crate) fn observe_position(&mut self, position: f64) {
+        self.last_position = position;
+        self.max_abs_position = self.max_abs_position.max(position.abs());
+    }
+
     /// Close out a cycle after the caller has recorded exact venue fills.
     /// `two_sided` is whether both a bid and an ask were resting this cycle.
     pub fn end_cycle(&mut self, position: f64, two_sided: bool) {
-        self.last_position = position;
-        self.max_abs_position = self.max_abs_position.max(position.abs());
+        self.observe_position(position);
         self.cycles += 1;
         if two_sided {
             self.two_sided_cycles += 1;

--- a/docs/13-maker.md
+++ b/docs/13-maker.md
@@ -183,9 +183,11 @@ center = mark × (1 − skew_bps × clamp(position / max_position, ±1) / 1e4)
 三种输出格式：
 
 - **表格（默认）**：每轮一行 `[时间] #轮次 mark= bid= ask= pos= pnl= | hold= place= cancel=`，其下缩进列出 PLACE / CANCEL / HOLD / FILL 明细。Live 模式还会打印 `ACCOUNT balance= equity= available= upnl=`，数据来自该轮交易所账户快照；这里的账户 `upnl` 与机器人本次会话的 `pnl` 是两个不同口径。
-- **JSON（`--output json` 或 `--openclaw`）**：每个动作一行 JSON；每轮末尾一条 `cycle_summary`，含 `position`、`starting_position`、`pnl`、`fills_total`、`uptime_pct`、`avg_capture_bps`、`halted`、`vol_bps`，以及 live 模式下的 `account`（`balance`、`equity`、`available`、`upnl`；paper 模式为 `null`）。`pnl` 和 `fills_total` 只属于当前 maker session：已有仓位按启动 mark 自动接管并把 session PnL 归零，历史交易所盈亏仍看 `account.upnl`。live fill 还包含 `trade_id`、`order_id`、`trade_ts` 与 `origin=current_run`。
+- **JSON（`--output json` 或 `--openclaw`）**：每个动作一行 JSON；每轮末尾一条 `cycle_summary`，含 `position`、`starting_position`、`pnl`、`fills_total`、`uptime_pct`、`avg_capture_bps`、`halted`、`vol_bps`，以及 live 模式下的 `account`（`balance`、`equity`、`available`、`upnl`；paper 模式为 `null`）。`pnl` 和 `fills_total` 只属于当前 maker session：已有仓位按启动 mark 自动接管并把 session PnL 归零，历史交易所盈亏仍看 `account.upnl`。live session PnL 使用 current-run ledger 的权威仓位；每个去重后的增量成交会原子更新现金流与统计仓位。live fill 还包含 `trade_id`、`order_id`、`trade_ts` 与 `origin=current_run`。
 
 live 启动时会先清理旧 `sxmk-` 订单并同步账本，再认证 `order + position + trade-shadow` account stream 和 Order Response Stream。绝对仓位不超过 `max_position` 时自动接管，输出 `ledger_sync` / `inventory_adopted`；超过上限（允许半个数量 tick 误差）则输出 `startup_rejected` 并退出。order 回调和 REST trade 以订单累计成交量双向去重。account stream 断开或仓位不一致时立即冻结 placements、撤净 maker 订单，并在约 0.5s、1.5s、3.0s 结合 WS 与 REST 核对；恢复后从空 maker book 继续，3 秒仍不一致则 fail-safe 停机。
+
+内部统计仓位与 current-run ledger 仓位也必须保持在半个数量 tick 的容差内；超出容差会输出 `risk_notification(kind=accounting_invariant, severity=critical)`，立即进入 fail-safe 清理并以退出码 75 停机，避免使用不一致的仓位计算告警或 stop-loss。
 
 运行时使用单一事件循环同时等待周期任务、account/order-response 回调、行情刷新和 Ctrl+C。关键账户事件会取消当前 REST/下单 future、递增 generation 并进入冻结清理；旧 generation 的工作结果不会重新开启挂单。普通行情刷新在已有工作执行时会合并为一次后续 replan，避免并发 cycle。
 

--- a/docs/14-maker-live-gate.md
+++ b/docs/14-maker-live-gate.md
@@ -21,6 +21,7 @@ maker by itself.
 - Existing inventory at or below `max_position` is adopted at the startup mark with maker-session PnL zeroed; inventory above the limit rejects startup after maker-order cleanup.
 - A venue position change that cannot yet be explained by current-run order callbacks freezes placements immediately. WS order updates and REST snapshots are reconciled for at most three seconds; persistent mismatch triggers fail-safe cleanup and shutdown.
 - Account-order cumulative fills and REST trades are tested in both arrival orders and never double-count fills, expected position, or maker-session PnL.
+- Every accepted current-run fill atomically synchronizes ledger position and session telemetry position; an internal mismatch beyond half a quantity tick fails closed before further live placement or risk evaluation.
 - Position jumps, account-stream state changes, reconciliation, volatility breaker, inventory exit, residual cleanup, and final fail-safe emit `risk_notification` telemetry; critical shutdown/cleanup delivery is awaited with a timeout.
 - Inventory-exit configuration remains disabled unless a supervised test has approved its exact threshold and chunk; the recorded XAG-USD test approves only `max_position=0.8`, trigger `25%`, and chunk `0.2`.
 


### PR DESCRIPTION
## Summary
- Live mode now fails closed when the internal telemetry position (`MakerStats`) drifts from the authoritative current-run ledger position beyond half a quantity tick: emits `risk_notification(kind=accounting_invariant, severity=critical)` and exits fail-safe (exit code 75) via the same cleanup path as other `MakerExit` variants.
- `MakerStats::observe_position` synchronizes `last_position`/`max_abs_position` on every accepted deduplicated fill, not only at cycle end.
- Live alerts, stop-loss evaluation, and final PnL reporting now use the ledger's authoritative position (`ledger.expected_position`) instead of the cached stats position; paper mode behavior unchanged.
- Hoists the repeated half-tick `qty_tolerance` computation to one binding.
- Docs: 13-maker.md and 14-maker-live-gate.md updated with the new invariant.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green)
- New tests: mismatch tolerance boundaries, fail-safe exit wiring, REST→WS fill ordering, partial cumulative fills, partial-fill-then-cancel alignment, round-trip PnL flatness

🤖 Generated with [Claude Code](https://claude.com/claude-code)