### PR TITLE
test: unify process-env lock across all env-touching tests

### DIFF
--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -364,11 +364,9 @@ mod tests {
         _lock: std::sync::MutexGuard<'static, ()>,
     }
 
-    static MAKER_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
-            let lock = MAKER_ENV_LOCK
+            let lock = crate::TEST_ENV_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             let original = std::env::var(key).ok();

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -152,9 +152,6 @@ pub(super) async fn fetch_history_trade_audit(
 mod tests {
     use super::*;
     use mockito::{Matcher, Server};
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct JwtGuard {
         original: Option<String>,
@@ -163,7 +160,11 @@ mod tests {
 
     impl JwtGuard {
         fn set() -> Self {
-            let lock = ENV_LOCK
+            // Share the crate-wide env lock so this STANDX_JWT mutation cannot
+            // run concurrently with env reads in other modules' tests (e.g. the
+            // maker cleanup test's Credentials::load). A per-module lock would
+            // not exclude those cross-module races. See crate::TEST_ENV_LOCK.
+            let lock = crate::TEST_ENV_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             let original = std::env::var("STANDX_JWT").ok();

--- a/crates/standx-cli/src/config.rs
+++ b/crates/standx-cli/src/config.rs
@@ -141,17 +141,13 @@ impl Config {
 mod tests {
     use super::*;
     use std::io::Write;
-    use std::sync::Mutex;
     use tempfile::TempDir;
-
-    /// Serializes tests that mutate process environment variables.
-    /// Tests run in parallel threads within one binary, so concurrent
-    /// EnvGuards on the same variable race without this lock.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     /// Helper struct to temporarily set environment variables
     /// Restores original value (or removes if not set) when dropped.
-    /// Holds the ENV_LOCK for its lifetime so env tests never overlap.
+    /// Holds the crate-wide [`crate::TEST_ENV_LOCK`] for its lifetime so env
+    /// tests never overlap — including across modules (telemetry, maker,
+    /// pipeline).
     struct EnvGuard {
         key: String,
         original_value: Option<String>,
@@ -160,7 +156,7 @@ mod tests {
 
     impl EnvGuard {
         fn set(key: &str, value: &str) -> Self {
-            let lock = ENV_LOCK
+            let lock = crate::TEST_ENV_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             let original_value = std::env::var(key).ok();
@@ -336,19 +332,29 @@ mod tests {
 
     #[test]
     fn test_config_env_isolation() {
-        // Test that EnvGuard properly restores original values
-        // Set an initial value
+        // Verify the temporary-set-then-restore semantics EnvGuard relies on.
+        // Done inline under TEST_ENV_LOCK rather than via EnvGuard: EnvGuard
+        // holds that same (non-reentrant) lock for its lifetime, so nesting it
+        // under an already-held lock would deadlock. Holding the lock keeps
+        // every mutation here from racing the process-global environ against
+        // env reads in other tests. EnvGuard's own set/restore is covered by
+        // the env-override tests above.
+        let _lock = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
         std::env::set_var("TEST_ISOLATION_VAR", "original");
+        let saved = std::env::var("TEST_ISOLATION_VAR").ok();
 
-        {
-            let _guard = EnvGuard::set("TEST_ISOLATION_VAR", "modified");
-            assert_eq!(std::env::var("TEST_ISOLATION_VAR").unwrap(), "modified");
+        std::env::set_var("TEST_ISOLATION_VAR", "modified");
+        assert_eq!(std::env::var("TEST_ISOLATION_VAR").unwrap(), "modified");
+
+        match saved {
+            Some(value) => std::env::set_var("TEST_ISOLATION_VAR", value),
+            None => std::env::remove_var("TEST_ISOLATION_VAR"),
         }
-
-        // After guard is dropped, should be restored
         assert_eq!(std::env::var("TEST_ISOLATION_VAR").unwrap(), "original");
 
-        // Cleanup
         std::env::remove_var("TEST_ISOLATION_VAR");
     }
 

--- a/crates/standx-cli/src/lib.rs
+++ b/crates/standx-cli/src/lib.rs
@@ -15,3 +15,17 @@ pub mod telemetry;
 // `crate::{models, error}` (used by output.rs/config.rs) keep resolving.
 pub use standx_sdk::{auth, client, error, models, websocket};
 pub use standx_sdk::{Error, Result};
+
+/// Process-global lock serializing every test that reads or mutates process
+/// environment variables.
+///
+/// `std::env::set_var`/`remove_var` mutate a process-global table that is not
+/// synchronized against concurrent `std::env::var` reads (the reason
+/// `set_var` becomes `unsafe` in edition 2024). On glibc a concurrent
+/// mutation can realloc `environ` mid-read, so an *unrelated* `var()` lookup
+/// spuriously returns "unset". Every env-touching test across all modules must
+/// hold THIS single lock for the duration it depends on the environment —
+/// per-module locks do not exclude cross-module races (e.g. a pipeline test
+/// mutating `STANDX_JWT` while the maker cleanup test reads it).
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/crates/standx-cli/src/telemetry.rs
+++ b/crates/standx-cli/src/telemetry.rs
@@ -263,6 +263,12 @@ mod tests {
 
     #[test]
     fn test_telemetry_disabled() {
+        // Serialize with every other env-touching test across the crate; a bare
+        // set_var here otherwise races the process-global environ against reads
+        // like Credentials::load() elsewhere. See crate::TEST_ENV_LOCK.
+        let _env = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         // Save original value
         let original = env::var(TELEMETRY_ENV_VAR).ok();
 
@@ -279,6 +285,9 @@ mod tests {
 
     #[test]
     fn test_telemetry_enabled_by_default() {
+        let _env = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         env::remove_var(TELEMETRY_ENV_VAR);
         let _telemetry = Telemetry::new();
         // Note: This might fail if user has env var set


### PR DESCRIPTION
## What & why

**Scope changed:** the cancel-confirmation feature this branch originally carried was implemented and merged independently as #245, so that work is dropped. What remains is the test-infrastructure fix surfaced along the way — still needed on current `main`.

The CLI test binary guards the process-global environment with **four independent locks**: `config` (`ENV_LOCK`), `maker` (`MAKER_ENV_LOCK`), `pipeline` (`ENV_LOCK`), and `telemetry` (none at all). `std::env::set_var`/`remove_var` mutate a table that is **not** synchronized against concurrent `std::env::var` reads — the reason `set_var` becomes `unsafe` in edition 2024. On glibc a concurrent mutation can realloc `environ` mid-read, so an *unrelated* lookup spuriously returns "unset".

Independent per-module locks cannot exclude **cross-module** races: a pipeline or telemetry test mutating an env var can run concurrently with the maker cleanup test's `Credentials::load()` read of `STANDX_JWT`, corrupting it and surfacing as a flaky `Authentication required` failure under load (observed deterministically on CI's Linux runner).

## Change

- Add one crate-wide `#[cfg(test)] TEST_ENV_LOCK` in `lib.rs`.
- Route every env guard (config, maker, pipeline) and the previously-unlocked telemetry tests through it.
- Rewrite `test_config_env_isolation` to hold the shared lock for its whole body (inline, without `EnvGuard`, which re-locks the non-reentrant mutex and would deadlock).

## Verification

Full CLI lib suite at `RUST_TEST_THREADS=16`: **8/8 clean**. Before the fix the maker cleanup test failed ~2/3 of runs under the same load. `fmt`/`clippy -D warnings`/`test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)