### PR TITLE
Fix maker Ctrl+C interruptibility & fail-open validations; drop dead code

### DIFF
--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -41,8 +41,9 @@ use notify::webhook_body;
 use notify::{token_expiry_level, MakerNotifier, PositionChange, RiskNotice, TokenExpiryLevel};
 use pipeline::{CycleRequest, CycleState, LiveAccountPollState};
 use recovery::{
-    cancel_maker_orders_with_retry, order_response_reconnect_available, reconcile_ledger_snapshot,
-    reconnect_order_response, PositionReconciliationError, ReconcileRequest, ReconnectRequest,
+    cancel_maker_orders_with_retry, ctrl_c_latched, order_response_reconnect_available,
+    reconcile_ledger_snapshot, reconnect_order_response, PositionReconciliationError,
+    ReconcileRequest, ReconnectInterrupted, ReconnectRequest,
 };
 #[cfg(test)]
 use recovery::{

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -35,6 +35,27 @@ impl fmt::Display for PositionReconciliationError {
 
 impl std::error::Error for PositionReconciliationError {}
 
+/// Marker error: the operator pressed Ctrl+C while a reconnect wait was in
+/// progress. The caller routes this to shutdown instead of RecoveryFailed.
+#[derive(Debug)]
+pub(super) struct ReconnectInterrupted;
+
+impl fmt::Display for ReconnectInterrupted {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "order-response reconnect interrupted by Ctrl+C")
+    }
+}
+
+impl std::error::Error for ReconnectInterrupted {}
+
+/// Resolves once the runtime's Ctrl+C latch has been set (see runtime.rs);
+/// pends forever if the listener is gone so callers' selects don't spin.
+pub(super) async fn ctrl_c_latched(ctrl_c: &mut tokio::sync::watch::Receiver<bool>) {
+    if ctrl_c.wait_for(|pressed| *pressed).await.is_err() {
+        std::future::pending::<()>().await;
+    }
+}
+
 pub(super) async fn recover_current_run_order_ids_for_reconciliation(
     client: &StandXClient,
     trades: &[Trade],
@@ -420,6 +441,7 @@ pub(super) struct ReconnectRequest<'a> {
     pub(super) max_attempts: u32,
     pub(super) base_backoff: Duration,
     pub(super) original_failure: &'a str,
+    pub(super) ctrl_c: tokio::sync::watch::Receiver<bool>,
 }
 
 pub(super) async fn reconnect_order_response(
@@ -437,8 +459,10 @@ pub(super) async fn reconnect_order_response(
         max_attempts,
         base_backoff,
         original_failure,
+        ctrl_c,
     } = request;
     let mut cleanup_client = cleanup_client;
+    let mut ctrl_c = ctrl_c;
     let first_attempt = attempts_used.saturating_add(1);
     let mut last_error = None;
     // The runtime Cleanup effect has already emptied and verified the maker
@@ -470,11 +494,26 @@ pub(super) async fn reconnect_order_response(
         if cleanup_ok {
             // Give just-submitted HTTP orders time to become visible, then
             // require a second authoritative snapshot after authentication.
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            // The maker book is verified empty at this point, so aborting the
+            // reconnect waits on Ctrl+C is safe.
+            tokio::select! {
+                biased;
+                _ = ctrl_c_latched(&mut ctrl_c) => {
+                    return Err(anyhow::Error::new(ReconnectInterrupted));
+                }
+                _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+            }
             let session_id = uuid::Uuid::new_v4().to_string();
             let candidate_client = StandXClient::new()?.with_session_id(&session_id);
             let stream = OrderResponseStream::new(&session_id)?;
-            match tokio::time::timeout(Duration::from_secs(15), stream.connect()).await {
+            let connect_attempt = tokio::select! {
+                biased;
+                _ = ctrl_c_latched(&mut ctrl_c) => {
+                    return Err(anyhow::Error::new(ReconnectInterrupted));
+                }
+                result = tokio::time::timeout(Duration::from_secs(15), stream.connect()) => result,
+            };
+            match connect_attempt {
                 Ok(Ok((commands, responses, health, handle))) => {
                     match query_reconnect_snapshot(
                         &candidate_client,
@@ -568,7 +607,13 @@ pub(super) async fn reconnect_order_response(
         if attempt < max_attempts {
             let local_attempt = attempt.saturating_sub(first_attempt).min(4);
             let multiplier = 1_u32 << local_attempt;
-            tokio::time::sleep(base_backoff.saturating_mul(multiplier)).await;
+            tokio::select! {
+                biased;
+                _ = ctrl_c_latched(&mut ctrl_c) => {
+                    return Err(anyhow::Error::new(ReconnectInterrupted));
+                }
+                _ = tokio::time::sleep(base_backoff.saturating_mul(multiplier)) => {}
+            }
         }
     }
 

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -1,23 +1,12 @@
 use super::*;
 use standx_sdk::order_response::OrderResponse;
 
-fn next_runtime_effect(runtime_state: &mut MakerState) -> Option<MakerEffect> {
-    runtime_state.next_effect().map(|effect| match effect {
-        MakerEffect::RunCycle(token) => MakerEffect::RunCycle(token),
-        MakerEffect::AbortInFlight(token) => MakerEffect::AbortInFlight(token),
-        MakerEffect::CommitCycle(token) => MakerEffect::CommitCycle(token),
-        MakerEffect::Cleanup { token, target } => MakerEffect::Cleanup { token, target },
-        MakerEffect::Recover { token, target } => MakerEffect::Recover { token, target },
-        MakerEffect::Stop(reason) => MakerEffect::Stop(reason),
-    })
-}
-
 fn take_cleanup_effect(
     runtime_state: &mut MakerState,
     expected_target: RecoveryTarget,
 ) -> Result<WorkToken> {
     loop {
-        match next_runtime_effect(runtime_state) {
+        match runtime_state.next_effect() {
             Some(MakerEffect::AbortInFlight(_)) => {}
             Some(MakerEffect::Cleanup { token, target }) if target == expected_target => {
                 return Ok(token);
@@ -40,7 +29,7 @@ fn take_recovery_effect(
     runtime_state: &mut MakerState,
     expected_target: RecoveryTarget,
 ) -> Result<WorkToken> {
-    match next_runtime_effect(runtime_state) {
+    match runtime_state.next_effect() {
         Some(MakerEffect::Recover { token, target }) if target == expected_target => Ok(token),
         Some(effect) => Err(anyhow::anyhow!(
             "runtime expected {expected_target:?} recovery, got {effect:?}"
@@ -53,7 +42,7 @@ fn take_recovery_effect(
 
 fn take_stop_effect(runtime_state: &mut MakerState) -> Result<MakerExit> {
     loop {
-        match next_runtime_effect(runtime_state) {
+        match runtime_state.next_effect() {
             Some(MakerEffect::AbortInFlight(_)) => {}
             Some(MakerEffect::Stop(reason)) => return Ok(reason.into()),
             Some(effect) => {
@@ -748,7 +737,13 @@ pub(super) async fn run_maker(
     }
     let symbol = info.symbol.clone(); // canonical casing
 
-    let min_order_qty: f64 = info.min_order_qty.parse().unwrap_or(0.0);
+    let min_order_qty: f64 = info.min_order_qty.parse().map_err(|_| {
+        anyhow::anyhow!(
+            "unparseable min_order_qty '{}' for {} from venue symbol info",
+            info.min_order_qty,
+            info.symbol
+        )
+    })?;
     let cfg = MakerConfig {
         spread_bps: args.spread_bps,
         band_bps: args.band_bps,
@@ -1237,8 +1232,21 @@ pub(super) async fn run_maker(
     // credentials are only reloaded from disk/env periodically.
     let mut token_expiry_alerted = TokenExpiryLevel::Ok;
     let mut last_token_expiry_check: Option<std::time::Instant> = None;
+    let mut balance_floor_parse_warned = false;
     let mut runtime_state = MakerState::starting();
     runtime_state.handle(MakerEvent::StartupReady);
+
+    // Long-lived Ctrl+C listener. Tokio's first ctrl_c() call permanently
+    // replaces the process SIGINT handler, so a per-select future silently
+    // drops presses that arrive between selects (and the process no longer
+    // dies on SIGINT either). Latch presses into a watch channel every wait
+    // point can observe.
+    let (ctrl_c_tx, mut ctrl_c_rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        while signal::ctrl_c().await.is_ok() {
+            let _ = ctrl_c_tx.send(true);
+        }
+    });
 
     let exit = 'main: loop {
         if args.live {
@@ -1399,7 +1407,23 @@ pub(super) async fn run_maker(
                             .await
                             .map_err(anyhow::Error::from)
                     };
-                    match tokio::time::timeout(Duration::from_secs(15), reconnect).await {
+                    // The maker book is already cancelled (cleanup completed),
+                    // so aborting the reconnect wait on Ctrl+C is safe.
+                    let connect_attempt = tokio::select! {
+                        biased;
+                        _ = ctrl_c_latched(&mut ctrl_c_rx) => None,
+                        result = tokio::time::timeout(Duration::from_secs(15), reconnect) => {
+                            Some(result)
+                        }
+                    };
+                    let Some(connect_attempt) = connect_attempt else {
+                        runtime_state.handle(MakerEvent::CtrlC);
+                        break 'main match take_stop_effect(&mut runtime_state) {
+                            Ok(exit) => exit,
+                            Err(error) => MakerExit::PositionReconciliation(error.to_string()),
+                        };
+                    };
+                    match connect_attempt {
                         Ok(Ok(triple)) => {
                             reconnected = Some(triple);
                             break;
@@ -1420,11 +1444,21 @@ pub(super) async fn run_maker(
                     );
                     if attempt < args.account_stream_reconnect_attempts {
                         let multiplier = 1_u32 << attempt.saturating_sub(1).min(4);
-                        tokio::time::sleep(
-                            Duration::from_secs(args.account_stream_reconnect_backoff)
-                                .saturating_mul(multiplier),
-                        )
-                        .await;
+                        let backoff = Duration::from_secs(args.account_stream_reconnect_backoff)
+                            .saturating_mul(multiplier);
+                        tokio::select! {
+                            biased;
+                            _ = ctrl_c_latched(&mut ctrl_c_rx) => {
+                                runtime_state.handle(MakerEvent::CtrlC);
+                                break 'main match take_stop_effect(&mut runtime_state) {
+                                    Ok(exit) => exit,
+                                    Err(error) => {
+                                        MakerExit::PositionReconciliation(error.to_string())
+                                    }
+                                };
+                            }
+                            _ = tokio::time::sleep(backoff) => {}
+                        }
                     }
                 }
 
@@ -1696,6 +1730,7 @@ pub(super) async fn run_maker(
                         max_attempts: args.order_response_reconnect_attempts,
                         base_backoff: Duration::from_secs(args.order_response_reconnect_backoff),
                         original_failure: &detail,
+                        ctrl_c: ctrl_c_rx.clone(),
                     })
                     .await
                     {
@@ -1734,6 +1769,13 @@ pub(super) async fn run_maker(
                             continue;
                         }
                         Err(error) => {
+                            if error.downcast_ref::<ReconnectInterrupted>().is_some() {
+                                runtime_state.handle(MakerEvent::CtrlC);
+                                break match take_stop_effect(&mut runtime_state) {
+                                    Ok(exit) => exit,
+                                    Err(error) => MakerExit::OrderResponse(error.to_string()),
+                                };
+                            }
                             if let Some(reconciliation) =
                                 error.downcast_ref::<PositionReconciliationError>()
                             {
@@ -1962,7 +2004,7 @@ pub(super) async fn run_maker(
         if runtime_state.pending_effect().is_none() {
             runtime_state.handle(MakerEvent::Timer);
         }
-        let cycle_work_token = match next_runtime_effect(&mut runtime_state) {
+        let cycle_work_token = match runtime_state.next_effect() {
             Some(MakerEffect::RunCycle(token)) => token,
             Some(MakerEffect::Stop(reason)) => break reason.into(),
             Some(effect) => {
@@ -2057,7 +2099,7 @@ pub(super) async fn run_maker(
                 };
                 tokio::select! {
                     biased;
-                    _ = signal::ctrl_c() => {
+                    _ = ctrl_c_latched(&mut ctrl_c_rx) => {
                         runtime_state.handle(MakerEvent::CtrlC);
                         break 'main match take_stop_effect(&mut runtime_state) {
                             Ok(exit) => exit,
@@ -2223,7 +2265,7 @@ pub(super) async fn run_maker(
             Ok((places, cancels, holds, fills, mark, src, halted, exit_pending_after, balance)) => {
                 runtime_state.handle(MakerEvent::CycleCompleted(cycle_work_token));
                 if !matches!(
-                    next_runtime_effect(&mut runtime_state),
+                    runtime_state.next_effect(),
                     Some(MakerEffect::CommitCycle(token)) if token == cycle_work_token
                 ) {
                     continue 'main;
@@ -2337,11 +2379,20 @@ pub(super) async fn run_maker(
                         let equity = balance.equity.parse::<f64>().ok();
                         let available = balance.cross_available.parse::<f64>().ok();
                         if let (Some(equity), Some(available)) = (equity, available) {
+                            balance_floor_parse_warned = false;
                             let fired = alerts.evaluate_account(equity, available);
                             for alert in fired {
                                 let await_delivery = alert.firing;
                                 notifier.alert(&alert, &symbol, await_delivery).await;
                             }
+                        } else if !balance_floor_parse_warned {
+                            // An armed --alert-equity-below / --alert-margin-below
+                            // must not go silently dark on unparseable balances.
+                            balance_floor_parse_warned = true;
+                            eprintln!(
+                                "⚠️  equity/margin floor alerts skipped: unparseable balance fields (equity='{}', cross_available='{}')",
+                                balance.equity, balance.cross_available
+                            );
                         }
                     }
                 }
@@ -2704,7 +2755,7 @@ pub(super) async fn run_maker(
                 }
             };
             tokio::select! {
-                _ = signal::ctrl_c() => {
+                _ = ctrl_c_latched(&mut ctrl_c_rx) => {
                     runtime_state.handle(MakerEvent::CtrlC);
                     break 'main match take_stop_effect(&mut runtime_state) {
                         Ok(exit) => exit,
@@ -3013,7 +3064,7 @@ mod tests {
     fn runtime_effect_executor_orders_abort_cleanup_and_recovery() {
         let mut runtime_state = MakerState::starting();
         runtime_state.handle(MakerEvent::StartupReady);
-        let cycle_token = match next_runtime_effect(&mut runtime_state) {
+        let cycle_token = match runtime_state.next_effect() {
             Some(MakerEffect::RunCycle(token)) => token,
             effect => panic!("expected cycle effect, got {effect:?}"),
         };
@@ -3031,7 +3082,7 @@ mod tests {
                 .expect("cleanup completion must schedule recovery");
         runtime_state.handle(MakerEvent::RecoverySucceeded(recovery));
         assert!(matches!(
-            next_runtime_effect(&mut runtime_state),
+            runtime_state.next_effect(),
             Some(MakerEffect::RunCycle(_))
         ));
     }
@@ -3040,7 +3091,7 @@ mod tests {
     fn runtime_recovery_failure_is_the_stop_source_of_truth() {
         let mut runtime_state = MakerState::starting();
         runtime_state.handle(MakerEvent::StartupReady);
-        let _ = next_runtime_effect(&mut runtime_state);
+        let _ = runtime_state.next_effect();
         runtime_state.handle(MakerEvent::OrderResponseDisconnected("closed".to_string()));
         let cleanup = take_cleanup_effect(&mut runtime_state, RecoveryTarget::OrderResponse)
             .expect("cleanup effect");
@@ -3100,7 +3151,7 @@ mod tests {
 
         let mut runtime_state = MakerState::starting();
         runtime_state.handle(MakerEvent::StartupReady);
-        let cycle_token = match next_runtime_effect(&mut runtime_state) {
+        let cycle_token = match runtime_state.next_effect() {
             Some(MakerEffect::RunCycle(token)) => token,
             effect => panic!("expected cycle effect, got {effect:?}"),
         };
@@ -3156,7 +3207,7 @@ mod tests {
         // target and fail closed into a stop.
         let mut runtime_state = MakerState::starting();
         runtime_state.handle(MakerEvent::StartupReady);
-        let _ = next_runtime_effect(&mut runtime_state);
+        let _ = runtime_state.next_effect();
         runtime_state.handle(MakerEvent::CycleInvalidated {
             reason: "account state changed during maker cycle".to_string(),
         });
@@ -3306,7 +3357,7 @@ mod tests {
         let mut runtime_state = MakerState::starting();
         runtime_state.handle(MakerEvent::StartupReady);
         assert!(matches!(
-            next_runtime_effect(&mut runtime_state),
+            runtime_state.next_effect(),
             Some(MakerEffect::RunCycle(_))
         ));
 
@@ -3338,7 +3389,7 @@ mod tests {
         let mut runtime_state = MakerState::starting();
         runtime_state.handle(MakerEvent::StartupReady);
         assert!(matches!(
-            next_runtime_effect(&mut runtime_state),
+            runtime_state.next_effect(),
             Some(MakerEffect::RunCycle(_))
         ));
 

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -375,11 +375,6 @@ impl MakerStats {
         self.cash + position * mark
     }
 
-    /// Mark-to-market equity using the last observed position.
-    pub fn mark_to_market(&self, mark: f64) -> f64 {
-        self.cash + self.last_position * mark
-    }
-
     /// The last observed position.
     pub fn position(&self) -> f64 {
         self.last_position
@@ -995,6 +990,19 @@ pub fn cap_desired_exposure(
         .collect()
 }
 
+/// Whether any resting quote crosses the current touch (buy at/above the ask,
+/// sell at/below the bid).
+pub fn resting_quotes_would_cross(
+    resting: &[RestingQuote],
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+) -> bool {
+    resting.iter().any(|quote| match quote.side {
+        OrderSide::Buy => best_ask.is_some_and(|ask| quote.price >= ask),
+        OrderSide::Sell => best_bid.is_some_and(|bid| quote.price <= bid),
+    })
+}
+
 /// Diff desired vs resting quotes, applying the anti-flicker hold rule.
 ///
 /// Decision table per resting quote (checked in order):
@@ -1014,17 +1022,6 @@ pub fn cap_desired_exposure(
 /// surviving resting counterpart yields a `Place`. The returned Vec orders all
 /// Cancels before all Places so the executor frees margin before re-placing;
 /// Holds come last.
-pub fn resting_quotes_would_cross(
-    resting: &[RestingQuote],
-    best_bid: Option<f64>,
-    best_ask: Option<f64>,
-) -> bool {
-    resting.iter().any(|quote| match quote.side {
-        OrderSide::Buy => best_ask.is_some_and(|ask| quote.price >= ask),
-        OrderSide::Sell => best_bid.is_some_and(|bid| quote.price <= bid),
-    })
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn reconcile(
     cfg: &MakerConfig,
@@ -1103,74 +1100,6 @@ pub fn reconcile(
     actions
 }
 
-/// One deterministic market/position observation for offline strategy replay.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ReplaySnapshot {
-    pub mark: f64,
-    pub best_bid: Option<f64>,
-    pub best_ask: Option<f64>,
-    pub position: f64,
-}
-
-/// Decisions generated for one replay observation.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ReplayCycle {
-    pub cycle: u64,
-    pub actions: Vec<Action>,
-}
-
-/// Replay quote/reconcile decisions without network, credentials, or order I/O.
-///
-/// This simulator deliberately does not invent fills. Callers provide the
-/// observed position at every step, which makes it suitable for validating
-/// risk guards against recorded market/position sequences before canary use.
-pub fn replay_actions(cfg: &MakerConfig, snapshots: &[ReplaySnapshot]) -> Vec<ReplayCycle> {
-    let mut resting = Vec::<RestingQuote>::new();
-    let mut cycles = Vec::with_capacity(snapshots.len());
-
-    for (index, snapshot) in snapshots.iter().enumerate() {
-        let cycle = index as u64;
-        let raw = compute_desired_quotes(
-            cfg,
-            snapshot.mark,
-            snapshot.best_bid,
-            snapshot.best_ask,
-            snapshot.position,
-        );
-        let desired = cap_desired_exposure(cfg, snapshot.position, &raw, &[]);
-        let actions = reconcile(
-            cfg,
-            snapshot.mark,
-            snapshot.position,
-            snapshot.best_bid,
-            snapshot.best_ask,
-            &desired,
-            &resting,
-            cycle,
-        );
-
-        for action in &actions {
-            match action {
-                Action::Cancel { side, level, .. } => {
-                    resting.retain(|quote| !(quote.side == *side && quote.level == *level));
-                }
-                Action::Place(quote) => resting.push(RestingQuote {
-                    order_id: None,
-                    side: quote.side,
-                    level: quote.level,
-                    price: quote.price,
-                    qty: quote.qty,
-                    ref_center: skew_center(cfg, snapshot.mark, snapshot.position),
-                    placed_at_cycle: cycle,
-                }),
-                Action::Hold { .. } => {}
-            }
-        }
-        cycles.push(ReplayCycle { cycle, actions });
-    }
-    cycles
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1233,38 +1162,64 @@ mod tests {
     }
 
     #[test]
-    fn replay_requotes_on_touch_move_without_creating_crossed_quote() {
-        let snapshots = [
-            ReplaySnapshot {
-                mark: 100.0,
-                best_bid: Some(99.99),
-                best_ask: Some(100.01),
-                position: 0.0,
-            },
-            ReplaySnapshot {
-                mark: 100.0,
-                best_bid: Some(99.88),
-                best_ask: Some(99.90),
-                position: 0.0,
-            },
-        ];
-        let replay = replay_actions(&cfg(), &snapshots);
-        assert!(replay[0]
-            .actions
+    fn requotes_on_touch_move_without_creating_crossed_quote() {
+        // Cycle 0: quote a calm book and let the places rest.
+        let desired = compute_desired_quotes(&cfg(), 100.0, Some(99.99), Some(100.01), 0.0);
+        let actions = reconcile(
+            &cfg(),
+            100.0,
+            0.0,
+            Some(99.99),
+            Some(100.01),
+            &desired,
+            &[],
+            0,
+        );
+        assert!(actions
             .iter()
             .any(|action| matches!(action, Action::Place(_))));
-        assert!(replay[1].actions.iter().any(|action| matches!(
+        let resting: Vec<RestingQuote> = actions
+            .iter()
+            .filter_map(|action| match action {
+                Action::Place(quote) => Some(RestingQuote {
+                    order_id: None,
+                    side: quote.side,
+                    level: quote.level,
+                    price: quote.price,
+                    qty: quote.qty,
+                    ref_center: skew_center(&cfg(), 100.0, 0.0),
+                    placed_at_cycle: 0,
+                }),
+                _ => None,
+            })
+            .collect();
+
+        // Cycle 1: the touch drops below the resting sell; the stale quote is
+        // cancelled as WouldCross and no replacement crosses the new touch.
+        let (bid, ask) = (99.88, 99.90);
+        let desired = compute_desired_quotes(&cfg(), 100.0, Some(bid), Some(ask), 0.0);
+        let actions = reconcile(
+            &cfg(),
+            100.0,
+            0.0,
+            Some(bid),
+            Some(ask),
+            &desired,
+            &resting,
+            1,
+        );
+        assert!(actions.iter().any(|action| matches!(
             action,
             Action::Cancel {
                 reason: CancelReason::WouldCross,
                 ..
             }
         )));
-        for action in &replay[1].actions {
+        for action in &actions {
             if let Action::Place(quote) = action {
                 match quote.side {
-                    OrderSide::Buy => assert!(quote.price < snapshots[1].best_ask.unwrap()),
-                    OrderSide::Sell => assert!(quote.price > snapshots[1].best_bid.unwrap()),
+                    OrderSide::Buy => assert!(quote.price < ask),
+                    OrderSide::Sell => assert!(quote.price > bid),
                 }
             }
         }


### PR DESCRIPTION
## 背景

对 maker 全部代码(~12.7k 行)做了一次全面代码质量审查。结论:架构健康(纯策略核心 + fail-safe CLI),问题是堆积而非过度设计。本 PR 只落地**正确性四件套 + 三处死代码删除**;其余结构性/重复/清理债务已拆成 issues #255–#261,不在此 PR 范围。

## 改动内容

### 正确性修复

- **Ctrl+C 恢复期间不可中断**(本 PR 主体)。此前 `ctrl_c()` 只在两个 cycle `select!` 循环里逐次创建;由于 tokio 首次调用 `ctrl_c()` 会永久替换进程 SIGINT 处理器,当运行时处于恢复流程之外(账户流重连的连接超时/指数退避、冻结窗口、等待 webhook 投递)时按下的 Ctrl+C 会被静默吞掉,且进程也不再响应 SIGINT。改为:启动时安装一个长期存活的监听任务,把按键**锁存**进 `watch` channel;所有 select、账户流重连的连接/退避等待、以及 `reconnect_order_response` 内的三个等待点(通过新增的 `ReconnectInterrupted` 标记错误)都能观察到它。锁存不重置,任意时刻的按键都不会丢。清理阶段(撤单重试)刻意保持不可中断——冻结后先撤净挂单是安全前提。
- **`min_order_qty` fail-open**:此前 `parse().unwrap_or(0.0)`,交易所返回畸形字符串时会静默把启动期最小下单量校验变成恒真。改为解析失败直接报错。
- **权益/保证金告警静默失效**:余额字段解析失败且 `--alert-equity-below`/`--alert-margin-below` 已启用时,守护会静默停摆而操作者以为它在生效。改为打警告(去重一次,解析恢复后重置)。
- **`reconcile` 决策表文档归位**:6 行决策表文档此前挂在单行辅助函数 `resting_quotes_would_cross` 头上(rustdoc 渲染错位),移回 `reconcile`,并给辅助函数补一行自己的文档。

### 死代码删除

- replay 模拟器(`replay_actions` / `ReplaySnapshot` / `ReplayCycle`,workspace 内零调用)——其中有价值的 crossed-quote 行为断言改写为直接驱动 `reconcile` 的测试保留
- `next_runtime_effect` 恒等包装(13 个调用点改为直调 `next_effect()`)
- `MakerStats::mark_to_market`(零调用者,含测试)

## 验证

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` — 312 tests 全部通过 ✅

## Reviewer 须知

- 行为改动仅限 Ctrl+C 可中断性与两处 fail-closed;其余为文档/死代码。
- 后续债务见 #255(P1,`run_maker` ~2300 行拆分 + 三段恢复流程合并)、#256–#261。
- #255 正文指出 #226(reducer 影子状态机)的前提在 #247 合并后已部分过时,可考虑关闭/更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
