### PR TITLE
Dedupe maker silent-drift hotspots + cycle-skip/crossed-touch/qty_tolerance (#259, partial)

### DIFF
--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -2,10 +2,11 @@ use super::ledger::{adopt_order, apply_rest_trade};
 #[cfg(test)]
 use super::ledger::{apply_account_trade, apply_order_update, maker_trade_fill};
 use super::model::{position_for_symbol, rest_order_observation};
-use super::output::{emit_maker_cycle, log_maker_event, CycleOutput, MakerLogEvent};
+use super::output::{
+    emit_cycle_skip, emit_maker_cycle, log_maker_event, CycleOutput, MakerLogEvent,
+};
 use super::pipeline::{fetch_account_audit, CycleRequest, CycleResult, CycleState};
 use super::recovery::PositionReconciliationError;
-use crate::cli::*;
 use anyhow::Result;
 use standx_maker::{
     self as maker, AccountProjectionEvent, MakerAccountProjection, MakerFill, MakerLedger,
@@ -140,9 +141,7 @@ pub(super) async fn maker_cycle(
         breaker,
         live_account_poll,
     } = state;
-    use maker::{
-        format_decimals, paper_quote_filled, Action, CycleInput, CycleSkip, MarketSnapshot,
-    };
+    use maker::{format_decimals, paper_quote_filled, Action, CycleInput, MarketSnapshot};
 
     // 0. Run all market-only guards before any account/order I/O. The pure
     // planner owns breaker observation and data-consistency policy; this
@@ -154,57 +153,17 @@ pub(super) async fn maker_cycle(
     };
     let preflight = maker::preflight_cycle(breaker, market, max_divergence_bps, live);
     let halted = match preflight.skip {
-        Some(CycleSkip::CrossedBook) => {
-            let live_str = if live { "live" } else { "paper" };
-            match output_format {
-                OutputFormat::Json => {
-                    println!(
-                        "{}",
-                        serde_json::json!({
-                            "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-                            "cycle": cycle, "mode": live_str, "symbol": symbol,
-                            "action": "skip", "reason": "crossed_book",
-                            "mark": format_decimals(mark, cfg.price_decimals),
-                        })
-                    );
-                }
-                _ => {
-                    eprintln!(
-                        "⚠️  #{} crossed order book on {}; skipping cycle (no actions)",
-                        cycle, symbol
-                    );
-                }
-            }
-            return Ok(CycleResult::default());
-        }
-        Some(CycleSkip::MarkMidDivergence { divergence_bps }) => {
-            let live_str = if live { "live" } else { "paper" };
-            match output_format {
-                OutputFormat::Json => {
-                    println!(
-                        "{}",
-                        serde_json::json!({
-                            "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-                            "cycle": cycle, "mode": live_str, "symbol": symbol,
-                            "action": "skip", "reason": "mark_mid_divergence",
-                            "mark": format_decimals(mark, cfg.price_decimals),
-                            "divergence_bps": (divergence_bps * 100.0).round() / 100.0,
-                            "max_divergence_bps": max_divergence_bps,
-                        })
-                    );
-                }
-                _ => {
-                    eprintln!(
-                        "⚠️  #{} mark/mid divergence {:.1}bps > {}bps — skipping cycle (no actions)",
-                        cycle, divergence_bps, max_divergence_bps
-                    );
-                }
-            }
-            return Ok(CycleResult::default());
-        }
-        Some(CycleSkip::MissingTouch) => {
-            // Fail-safe: without a touch we cannot guarantee no-cross pricing.
-            eprintln!("⚠️  empty order book on {}; skipping this cycle", symbol);
+        Some(skip) => {
+            emit_cycle_skip(
+                output_format,
+                cycle,
+                symbol,
+                live,
+                mark,
+                cfg.price_decimals,
+                max_divergence_bps,
+                skip,
+            );
             return Ok(CycleResult::default());
         }
         None => preflight.halted,

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -79,6 +79,15 @@ pub fn panic_webhook_body(format: AlertWebhookFormat, text: &str) -> serde_json:
 /// locked until it has been supervised-tested against production.
 const LIVE_MAKER_ENV: &str = "STANDX_ENABLE_LIVE_MAKER";
 
+/// REST history depth for ledger sync and reconciliation snapshots. Shared by
+/// every account-audit fan-out and the ledger-sync telemetry so the reported
+/// limits cannot drift from the ones actually queried.
+const ORDER_HISTORY_LIMIT: u32 = 100;
+const TRADE_LOOKBACK_LIMIT: u32 = 500;
+/// Look-back window for the startup ledger baseline (adopts existing inventory
+/// at the session boundary).
+const LEDGER_HISTORY_WINDOW_SECS: i64 = 24 * 60 * 60;
+
 /// Warn when the JWT has under 2h of life left; escalate under 15m. Token
 /// lifetime caps run duration (there is no renewal endpoint), so an operator
 /// needs lead time to re-authenticate before the bot halts.

--- a/crates/standx-cli/src/commands/maker/output.rs
+++ b/crates/standx-cli/src/commands/maker/output.rs
@@ -475,9 +475,9 @@ pub(super) fn emit_ledger_sync(
                 "pnl_baseline": 0.0,
                 "historical_maker_orders": historical_orders,
                 "historical_maker_trades_ignored": historical_trades,
-                "history_window_seconds": 24 * 60 * 60,
-                "history_order_limit": 100,
-                "history_trade_limit": 500,
+                "history_window_seconds": LEDGER_HISTORY_WINDOW_SECS,
+                "history_order_limit": ORDER_HISTORY_LIMIT,
+                "history_trade_limit": TRADE_LOOKBACK_LIMIT,
                 "current_run_fills": 0,
             })
         );

--- a/crates/standx-cli/src/commands/maker/output.rs
+++ b/crates/standx-cli/src/commands/maker/output.rs
@@ -529,6 +529,69 @@ pub(super) fn emit_startup_rejected(
     }
 }
 
+/// The current instant as an RFC3339 string, truncated to whole seconds — the
+/// timestamp format every maker telemetry line uses.
+pub(super) fn ts_now() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Emit a skipped-cycle event. Unlike the previous inline handling, all three
+/// reasons — including `MissingTouch` — now produce a JSON event, so an ingest
+/// pipeline sees every skip rather than silently missing empty-book cycles.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit_cycle_skip(
+    output_format: OutputFormat,
+    cycle: u64,
+    symbol: &str,
+    live: bool,
+    mark: f64,
+    price_decimals: u32,
+    max_divergence_bps: f64,
+    skip: maker::CycleSkip,
+) {
+    if output_format == OutputFormat::Json {
+        let mut event = serde_json::json!({
+            "ts": ts_now(),
+            "cycle": cycle,
+            "mode": if live { "live" } else { "paper" },
+            "symbol": symbol,
+            "action": "skip",
+            "mark": maker::format_decimals(mark, price_decimals),
+        });
+        let fields = event.as_object_mut().expect("json object");
+        match skip {
+            maker::CycleSkip::CrossedBook => {
+                fields.insert("reason".into(), "crossed_book".into());
+            }
+            maker::CycleSkip::MarkMidDivergence { divergence_bps } => {
+                fields.insert("reason".into(), "mark_mid_divergence".into());
+                fields.insert(
+                    "divergence_bps".into(),
+                    ((divergence_bps * 100.0).round() / 100.0).into(),
+                );
+                fields.insert("max_divergence_bps".into(), max_divergence_bps.into());
+            }
+            maker::CycleSkip::MissingTouch => {
+                fields.insert("reason".into(), "missing_touch".into());
+            }
+        }
+        println!("{event}");
+        return;
+    }
+    match skip {
+        maker::CycleSkip::CrossedBook => eprintln!(
+            "⚠️  #{cycle} crossed order book on {symbol}; skipping cycle (no actions)"
+        ),
+        maker::CycleSkip::MarkMidDivergence { divergence_bps } => eprintln!(
+            "⚠️  #{cycle} mark/mid divergence {divergence_bps:.1}bps > {max_divergence_bps}bps — skipping cycle (no actions)"
+        ),
+        maker::CycleSkip::MissingTouch => {
+            // Fail-safe: without a touch we cannot guarantee no-cross pricing.
+            eprintln!("⚠️  #{cycle} empty order book on {symbol}; skipping this cycle")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -1,3 +1,4 @@
+use super::{ORDER_HISTORY_LIMIT, TRADE_LOOKBACK_LIMIT};
 use crate::cli::OutputFormat;
 use anyhow::Result;
 use standx_maker::{
@@ -138,8 +139,8 @@ pub(super) async fn fetch_account_audit(
     let (open_orders, positions, filled_orders, trades) = tokio::join!(
         client.get_open_orders(Some(symbol)),
         client.get_positions(Some(symbol)),
-        client.get_order_history(Some(symbol), Some(100)),
-        client.get_user_trades(symbol, session_started_at, now, Some(500)),
+        client.get_order_history(Some(symbol), Some(ORDER_HISTORY_LIMIT)),
+        client.get_user_trades(symbol, session_started_at, now, Some(TRADE_LOOKBACK_LIMIT)),
     );
     Ok(AccountAudit {
         open_orders: open_orders?,

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -1,7 +1,6 @@
 use super::ledger::{adopt_order, apply_rest_trade};
-use super::model::{
-    is_current_run_order, is_maker_order, position_for_symbol, signed_position_quantity,
-};
+use super::model::{is_current_run_order, is_maker_order, position_for_symbol};
+use super::pipeline::{fetch_account_audit, AccountAudit};
 use crate::cli::OutputFormat;
 use anyhow::Result;
 use standx_maker::{MakerFill, MakerLedger, MakerStats};
@@ -134,19 +133,18 @@ pub(super) async fn reconcile_ledger_snapshot(
     stats: &mut MakerStats,
 ) -> Result<(f64, Vec<MakerFill>)> {
     let now = chrono::Utc::now().timestamp();
-    let (orders, filled_orders, trades, positions) = tokio::join!(
-        client.get_open_orders(Some(request.symbol)),
-        client.get_order_history(Some(request.symbol), Some(100)),
-        client.get_user_trades(request.symbol, request.session_started_at, now, Some(500)),
-        client.get_positions(Some(request.symbol)),
-    );
-    let orders = orders?;
-    let filled_orders = filled_orders?;
-    for order in orders.iter().chain(filled_orders.iter()) {
+    let audit =
+        fetch_account_audit(client, request.symbol, request.session_started_at, now).await?;
+    let AccountAudit {
+        open_orders,
+        positions,
+        filled_orders,
+        trades,
+    } = audit;
+    for order in open_orders.iter().chain(filled_orders.iter()) {
         adopt_order(ledger, order, request.run_order_prefix)?;
     }
-    let trades = trades?;
-    let observed = position_for_symbol(&positions?, request.symbol)?;
+    let observed = position_for_symbol(&positions, request.symbol)?;
     recover_current_run_order_ids_for_reconciliation(
         client,
         &trades,
@@ -356,17 +354,9 @@ pub(super) fn validate_reconnect_snapshot(
         ));
     }
 
-    let mut position = 0.0;
-    for item in positions
-        .iter()
-        .filter(|position| position.symbol.eq_ignore_ascii_case(symbol))
-    {
-        position += signed_position_quantity(&item.qty, item.side).map_err(|error| {
-            anyhow::anyhow!(
-                "reconnect reconciliation found invalid position qty on {symbol}: {error}"
-            )
-        })?;
-    }
+    let position = position_for_symbol(positions, symbol).map_err(|error| {
+        anyhow::anyhow!("reconnect reconciliation found invalid position on {symbol}: {error}")
+    })?;
 
     let maker_filled_order_ids = filled_orders
         .iter()
@@ -413,19 +403,14 @@ async fn query_reconnect_snapshot(
     run_order_prefix: &str,
 ) -> Result<ReconnectSnapshot> {
     let now = chrono::Utc::now().timestamp();
-    let (open_orders, positions, filled_orders, trades) = tokio::join!(
-        client.get_open_orders(Some(symbol)),
-        client.get_positions(Some(symbol)),
-        client.get_order_history(Some(symbol), Some(100)),
-        client.get_user_trades(symbol, session_started_at, now, Some(500)),
-    );
+    let audit = fetch_account_audit(client, symbol, session_started_at, now).await?;
     validate_reconnect_snapshot(
         symbol,
         run_order_prefix,
-        &open_orders?,
-        &positions?,
-        &filled_orders?,
-        &trades?,
+        &audit.open_orders,
+        &audit.positions,
+        &audit.filled_orders,
+        &audit.trades,
     )
 }
 

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -354,20 +354,12 @@ fn market_update_requires_replan(
     refresh_bps: f64,
     max_divergence_bps: f64,
 ) -> bool {
-    if maker::bps_diff(mark, previous_mark) > refresh_bps {
-        return true;
-    }
-    if matches!((best_bid, best_ask), (Some(bid), Some(ask)) if bid >= ask) {
-        return true;
-    }
-    if maker::resting_quotes_would_cross(resting, best_bid, best_ask) {
-        return true;
-    }
-    matches!(
-        (best_bid, best_ask),
-        (Some(bid), Some(ask))
-            if maker::mark_mid_divergence_bps(mark, bid, ask) > max_divergence_bps
-    )
+    // Crossed book and mark/mid divergence share the exact skip rules the
+    // strategy applies in preflight_cycle; route through the same predicate so
+    // the replan trigger cannot drift from it.
+    maker::bps_diff(mark, previous_mark) > refresh_bps
+        || maker::touch_skip(mark, best_bid, best_ask, max_divergence_bps).is_some()
+        || maker::resting_quotes_would_cross(resting, best_bid, best_ask)
 }
 
 fn apply_account_event(
@@ -789,12 +781,17 @@ pub(super) async fn run_maker(
         // submitted. Existing inventory is adopted at the current mark, so
         // maker-session PnL starts at zero while account upnl remains intact.
         let history_to = chrono::Utc::now().timestamp();
-        let history_from = history_to.saturating_sub(24 * 60 * 60);
+        let history_from = history_to.saturating_sub(LEDGER_HISTORY_WINDOW_SECS);
         let (positions, startup_market, filled_orders, historical_trades, balance) = tokio::join!(
             client.get_positions(Some(&symbol)),
             market_snapshot(&client, &symbol, None),
-            client.get_order_history(Some(&symbol), Some(100)),
-            client.get_user_trades(&symbol, history_from, history_to, Some(500)),
+            client.get_order_history(Some(&symbol), Some(ORDER_HISTORY_LIMIT)),
+            client.get_user_trades(
+                &symbol,
+                history_from,
+                history_to,
+                Some(TRADE_LOOKBACK_LIMIT)
+            ),
             client.get_balance(),
         );
         let positions = positions?;

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -712,6 +712,9 @@ pub(super) async fn run_maker(
         args.alert_webhook_format,
     );
 
+    // Half a qty tick: the adoption/mismatch tolerance used throughout the run.
+    let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
+
     // ---- Live gating & clean start ----
     let mut order_responses = None;
     let mut order_commands = None;
@@ -874,7 +877,6 @@ pub(super) async fn run_maker(
             .await?;
         let post_auth_positions = client.get_positions(Some(&symbol)).await?;
         let post_auth_position = position_for_symbol(&post_auth_positions, &symbol)?;
-        let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
         if (post_auth_position - starting_position).abs() > qty_tolerance {
             handle.abort();
             notifier
@@ -937,7 +939,7 @@ pub(super) async fn run_maker(
             historical_maker_orders,
             historical_maker_trades,
         );
-        if starting_position.abs() > 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0 {
+        if starting_position.abs() > qty_tolerance {
             let message = format!("adopted non-zero starting inventory {starting_position:+.8}");
             notifier
                 .risk(
@@ -1121,7 +1123,6 @@ pub(super) async fn run_maker(
     } else {
         MakerStats::default()
     };
-    let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
     let mut breaker = VolBreaker::new(args.vol_window.max(1) as usize, args.vol_pause_bps);
     let mut alerts =
         AlertMonitor::new(args.alert_loss, args.alert_inventory_pct, args.alert_uptime)
@@ -1277,7 +1278,6 @@ pub(super) async fn run_maker(
                         }
                     };
 
-                let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
                 if account_stream_reconnect_attempts_used >= args.account_stream_reconnect_attempts
                 {
                     break recovery_failed_exit(
@@ -1625,7 +1625,7 @@ pub(super) async fn run_maker(
                         session_started_at,
                         run_order_prefix: &run_order_prefix,
                         expected_position: ledger.expected_position,
-                        qty_tolerance: 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0,
+                        qty_tolerance,
                         output_format,
                         attempts_used: order_response_reconnect_attempts_used,
                         max_attempts: args.order_response_reconnect_attempts,
@@ -2441,7 +2441,6 @@ pub(super) async fn run_maker(
                             );
                         }
                     };
-                    let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
                     let mut recovered = false;
                     let mut last_observed = mismatch.observed;
                     for delay in [500_u64, 1_000, 1_500] {

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -501,6 +501,29 @@ pub struct CyclePreflight {
     pub skip: Option<CycleSkip>,
 }
 
+/// The touch-level reason a two-sided book cannot be quoted, if any: a crossed
+/// book (`best_bid >= best_ask`) or mark/mid divergence beyond the limit.
+///
+/// Returns `None` for a healthy book or a one-sided/missing touch — the caller
+/// decides how to treat a missing side. Shared by [`preflight_cycle`] (which
+/// maps it to a skip) and the CLI's replan trigger so the two cannot drift.
+pub fn touch_skip(
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    max_divergence_bps: f64,
+) -> Option<CycleSkip> {
+    let (best_bid, best_ask) = (best_bid?, best_ask?);
+    if best_bid >= best_ask {
+        return Some(CycleSkip::CrossedBook);
+    }
+    let divergence_bps = mark_mid_divergence_bps(mark, best_bid, best_ask);
+    if divergence_bps > max_divergence_bps {
+        return Some(CycleSkip::MarkMidDivergence { divergence_bps });
+    }
+    None
+}
+
 /// Observe volatility and validate a snapshot before account/order I/O.
 ///
 /// A skipped cycle deliberately leaves resting quotes untouched. This mirrors
@@ -513,20 +536,16 @@ pub fn preflight_cycle(
     require_full_touch: bool,
 ) -> CyclePreflight {
     let halted = breaker.observe(market.mark);
-    if let (Some(best_bid), Some(best_ask)) = (market.best_bid, market.best_ask) {
-        if best_bid >= best_ask {
-            return CyclePreflight {
-                halted,
-                skip: Some(CycleSkip::CrossedBook),
-            };
-        }
-        let divergence_bps = mark_mid_divergence_bps(market.mark, best_bid, best_ask);
-        if divergence_bps > max_divergence_bps {
-            return CyclePreflight {
-                halted,
-                skip: Some(CycleSkip::MarkMidDivergence { divergence_bps }),
-            };
-        }
+    if let Some(skip) = touch_skip(
+        market.mark,
+        market.best_bid,
+        market.best_ask,
+        max_divergence_bps,
+    ) {
+        return CyclePreflight {
+            halted,
+            skip: Some(skip),
+        };
     }
     if require_full_touch && (market.best_bid.is_none() || market.best_ask.is_none()) {
         return CyclePreflight {

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -272,16 +272,28 @@ pub fn skew_center(cfg: &MakerConfig, mark: f64, position: f64) -> f64 {
 ///
 /// This is a discrete-time "crossed → filled" proxy used only to simulate
 /// inventory in paper mode; a real venue matches on the trade stream.
-pub fn paper_quote_filled(
+/// Whether a quote at `price` on `side` crosses the current touch: a buy at or
+/// above the best ask, or a sell at or below the best bid. This single event is
+/// both "a paper quote would fill" and "a resting quote would cross the book".
+pub fn quote_crosses_touch(
     side: OrderSide,
     price: f64,
     best_bid: Option<f64>,
     best_ask: Option<f64>,
 ) -> bool {
     match side {
-        OrderSide::Buy => best_ask.is_some_and(|a| a <= price),
-        OrderSide::Sell => best_bid.is_some_and(|b| b >= price),
+        OrderSide::Buy => best_ask.is_some_and(|ask| price >= ask),
+        OrderSide::Sell => best_bid.is_some_and(|bid| price <= bid),
     }
+}
+
+pub fn paper_quote_filled(
+    side: OrderSide,
+    price: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+) -> bool {
+    quote_crosses_touch(side, price, best_bid, best_ask)
 }
 
 /// Running telemetry for a maker session: fills, mark-to-market PnL, spread
@@ -1015,10 +1027,9 @@ pub fn resting_quotes_would_cross(
     best_bid: Option<f64>,
     best_ask: Option<f64>,
 ) -> bool {
-    resting.iter().any(|quote| match quote.side {
-        OrderSide::Buy => best_ask.is_some_and(|ask| quote.price >= ask),
-        OrderSide::Sell => best_bid.is_some_and(|bid| quote.price <= bid),
-    })
+    resting
+        .iter()
+        .any(|quote| quote_crosses_touch(quote.side, quote.price, best_bid, best_ask))
 }
 
 /// Diff desired vs resting quotes, applying the anti-flicker hold rule.


### PR DESCRIPTION
部分推进 #259。基于最新 `main`。两个 commit,聚焦**会静默漂移的重复**(issue 的优先项)+ 若干安全的样板去重。较高 churn / 纯装饰性的项留作后续,见下方"未做"。

## 已完成

### 会静默漂移的重复(优先项,全部完成)
- **replan 谓词下沉**:`market_update_requires_replan` 曾逐字重实现 `preflight_cycle` 的 crossed-book + mark/mid 偏离规则。提取共享纯谓词 `standx_maker::touch_skip`,`preflight_cycle` 用它映射成 `CycleSkip`,CLI replan 触发器用 `.is_some()` 消费,二者无法再漂移。
- **REST fan-out 统一**:4 端点账户快照 fan-out 曾复制在 `reconcile_ledger_snapshot` / `query_reconnect_snapshot` / 启动块;前两者改走 `fetch_account_audit`。魔数 100/500/24h(含 `emit_ledger_sync` telemetry 里第三份)提为命名常量 `ORDER_HISTORY_LIMIT` / `TRADE_LOOKBACK_LIMIT` / `LEDGER_HISTORY_WINDOW_SECS`。
- **`validate_reconnect_snapshot`** 内联重实现的 signed-qty 求和改调 `position_for_symbol`。

### 样板去重
- **cycle-skip 发射统一为 `emit_cycle_skip`**——顺带修一个真实可观测性缺口:`MissingTouch` 此前只 eprintln、JSON 模式不可见,现在和另两种 skip 一样发 JSON 事件(`reason: "missing_touch"`),采集端不再漏掉空簿跳过。新增 `output::ts_now()`。
- **crossed-touch 谓词**:`paper_quote_filled` 与 `resting_quotes_would_cross` 是同一条件(`bid>=ask` 与 `price>=ask` 等价),都改为委托共享的 `standx_maker::quote_crosses_touch`。
- **`qty_tolerance`**(半个 qty tick)公式在 `run_maker` 里 6 处重复(2 处 `let` shadow + 内联),收敛为 live-gating 前的单一绑定复用。

## 未做(留作后续,故意)
- **`RiskNotice` builder(22 处)**:尝试过脚本化转换,但字段组合/多行 message 使机械转换脆弱,且这是 live 交易通知路径上的纯装饰改动——一处字段回归即静默丢 telemetry。值得单独一个 PR 谨慎做 + 逐条核对,不塞进这个已验证的批次。
- **`AlertMonitor` EdgeTrigger 坍缩(~130 行、4 个滞回常数)**:金融风险代码,建议单独 PR 带针对性测试。
- **`ts_now()` / JSON envelope 的全量 26 处收敛**:helper 已就位,批量替换留作后续机械跟进。
- `unhealthy_*` 已由 main 上的 `ensure_live_streams_healthy` 部分整合,收益不大。

## 验证
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` — **323 tests 全通过** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
