### PR TITLE
Narrow standx-maker public API + remove dead code (#260, mostly complete)

### DIFF
--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -741,7 +741,6 @@ mod tests {
             &order_update("0.20", "59.50"),
             "BTC-USD",
             "sxmk-0123456789ab-",
-            59.50,
             &mut stats,
             &mut fills,
         )

--- a/crates/standx-cli/src/commands/maker/feed.rs
+++ b/crates/standx-cli/src/commands/maker/feed.rs
@@ -9,10 +9,10 @@ use tokio::sync::{watch, RwLock};
 /// receipt so cycle reads are lock-and-go.
 #[derive(Default)]
 pub(super) struct FeedState {
-    pub(super) mark: Option<f64>,
+    mark: Option<f64>,
     mark_meta: Option<FeedMeta>,
-    pub(super) best_bid: Option<f64>,
-    pub(super) best_ask: Option<f64>,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
     book_meta: Option<FeedMeta>,
 }
 

--- a/crates/standx-cli/src/commands/maker/ledger.rs
+++ b/crates/standx-cli/src/commands/maker/ledger.rs
@@ -28,7 +28,6 @@ pub(super) fn apply_order_update(
     update: &OrderUpdate,
     symbol: &str,
     run_order_prefix: &str,
-    mark: f64,
     stats: &mut MakerStats,
     fills: &mut Vec<MakerFill>,
 ) -> Result<bool> {
@@ -48,8 +47,7 @@ pub(super) fn apply_order_update(
     fills.extend(buffered);
     // The cumulative fill fields in an order callback are deliberately not
     // booked here. Only a stable-ID TradeUpdate or REST trade may mutate PnL
-    // and expected position.
-    let _ = mark;
+    // and expected position, so the order update needs no mark.
     Ok(saw_exit_fill)
 }
 
@@ -226,7 +224,6 @@ mod tests {
             &order_update(OrderSide::Sell, "-0.20"),
             "BTC-USD",
             "sxmk-run-",
-            100.0,
             &mut stats,
             &mut fills,
         )
@@ -263,7 +260,6 @@ mod tests {
             &order_update(OrderSide::Sell, "NaN"),
             "BTC-USD",
             "sxmk-run-",
-            100.0,
             &mut stats,
             &mut fills,
         )
@@ -294,7 +290,6 @@ mod tests {
             &update,
             "BTC-USD",
             "sxmk-run-",
-            100.0,
             &mut stats,
             &mut fills,
         )

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -32,8 +32,6 @@ use runtime::apply_order_responses;
 
 use cycle::maker_cycle;
 use feed::{fresh_ws_snapshot, market_snapshot, spawn_market_feed};
-#[cfg(test)]
-use model::is_order_rejection;
 use model::{is_maker_order, position_for_symbol, MakerExit};
 pub use model::{FailSafeShutdown, FAIL_SAFE_EXIT_CODE};
 #[cfg(test)]
@@ -51,8 +49,6 @@ use recovery::{
 };
 #[cfg(test)]
 use standx_maker::ProjectionPendingPlace;
-#[cfg(test)]
-use standx_sdk::error::Error as StandxError;
 #[cfg(test)]
 use standx_sdk::models::{Order, OrderSide, Position, Trade};
 #[cfg(test)]
@@ -572,30 +568,6 @@ mod tests {
         assert_eq!(raw["kind"], "loss");
         assert_eq!(raw["firing"], true);
         assert_eq!(raw["symbol"], "BTC-USD");
-    }
-
-    #[test]
-    fn business_rejection_not_fail_safe() {
-        // Post-only would-cross / order-not-found: exchange said no.
-        assert!(is_order_rejection(&StandxError::Api {
-            code: 400,
-            message: "post-only would cross".into(),
-            endpoint: None,
-            retryable: false,
-        }));
-        // 5xx from the venue: transient → counts toward fail-safe.
-        assert!(!is_order_rejection(&StandxError::Api {
-            code: 502,
-            message: "bad gateway".into(),
-            endpoint: None,
-            retryable: true,
-        }));
-        // Network layer: transient → counts toward fail-safe.
-        assert!(!is_order_rejection(&StandxError::Http {
-            code: 0,
-            message: "connection reset".into(),
-            retryable: Some(true),
-        }));
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/model.rs
+++ b/crates/standx-cli/src/commands/maker/model.rs
@@ -1,6 +1,4 @@
 use standx_sdk::account_stream::OrderUpdate;
-#[cfg(test)]
-use standx_sdk::error::Error as StandxError;
 use standx_sdk::models::{Order, OrderSide, OrderStatus, Position};
 
 /// Process exit code emitted when the maker performs an *intentional*
@@ -241,15 +239,4 @@ pub(super) fn signed_position_quantity(
         Some(OrderSide::Buy) => qty.abs(),
         None => qty,
     })
-}
-
-#[cfg(test)]
-pub(super) fn is_order_rejection(error: &StandxError) -> bool {
-    matches!(
-        error,
-        StandxError::Api {
-            retryable: false,
-            ..
-        }
-    )
 }

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -51,7 +51,7 @@ pub(super) struct CycleState<'a> {
     pub(super) live_account_poll: Option<&'a mut LiveAccountPollState>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Default)]
 pub(super) struct CycleResult {
     pub(super) places: u64,
     pub(super) cancels: u64,

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -408,7 +408,6 @@ fn apply_account_event(
                 &update,
                 context.symbol,
                 context.run_order_prefix,
-                context.mark,
                 state.stats,
                 &mut fills,
             )?;

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -1346,7 +1346,7 @@ pub(super) async fn run_maker(
                         }
                     };
                     let Some(connect_attempt) = connect_attempt else {
-                        runtime_state.handle(MakerEvent::CtrlC);
+                        runtime_state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
                         break 'main take_stop_effect(
                             &mut runtime_state,
                             MakerExit::PositionReconciliation,
@@ -1378,7 +1378,7 @@ pub(super) async fn run_maker(
                         tokio::select! {
                             biased;
                             _ = ctrl_c_latched(&mut ctrl_c_rx) => {
-                                runtime_state.handle(MakerEvent::CtrlC);
+                                runtime_state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
                                 break 'main take_stop_effect(
                                     &mut runtime_state,
                                     MakerExit::PositionReconciliation,
@@ -1699,7 +1699,8 @@ pub(super) async fn run_maker(
                         }
                         Err(error) => {
                             if error.downcast_ref::<ReconnectInterrupted>().is_some() {
-                                runtime_state.handle(MakerEvent::CtrlC);
+                                runtime_state
+                                    .handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
                                 break take_stop_effect(
                                     &mut runtime_state,
                                     MakerExit::OrderResponse,
@@ -2026,7 +2027,7 @@ pub(super) async fn run_maker(
                 tokio::select! {
                     biased;
                     _ = ctrl_c_latched(&mut ctrl_c_rx) => {
-                        runtime_state.handle(MakerEvent::CtrlC);
+                        runtime_state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
                         break 'main take_stop_effect(&mut runtime_state, MakerExit::PositionReconciliation);
                     },
                     event = account_during_work => {
@@ -2698,7 +2699,7 @@ pub(super) async fn run_maker(
             };
             tokio::select! {
                 _ = ctrl_c_latched(&mut ctrl_c_rx) => {
-                    runtime_state.handle(MakerEvent::CtrlC);
+                    runtime_state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
                     break 'main take_stop_effect(&mut runtime_state, MakerExit::PositionReconciliation);
                 },
                 _ = tokio::time::sleep_until(deadline) => break,

--- a/crates/standx-maker/src/ledger.rs
+++ b/crates/standx-maker/src/ledger.rs
@@ -165,7 +165,12 @@ impl MakerLedger {
             return false;
         }
         self.maker_order_ids.insert(order_id);
-        if client_order_id.is_some_and(|id| id.starts_with(&format!("{run_order_prefix}x"))) {
+        // Exit orders carry the run prefix followed by an 'x' marker. Match
+        // without allocating a `format!("{run_order_prefix}x")` on every call.
+        if client_order_id.is_some_and(|id| {
+            id.strip_prefix(run_order_prefix)
+                .is_some_and(|rest| rest.starts_with('x'))
+        }) {
             self.exit_order_ids.insert(order_id);
         }
         true

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -37,7 +37,7 @@ pub use ownership::{
 pub use risk::{PositionAlertAnchor, PositionRiskEvent, PositionRiskKind};
 pub use runtime::{
     order_cancel_rejection_reason, MakerEffect, MakerEvent, MakerState, RecoveryTarget,
-    RuntimePhase, RuntimeStopReason, WorkKind, WorkToken,
+    RuntimeStopReason, WorkToken,
 };
 
 /// Static per-run configuration (CLI args + symbol metadata).
@@ -109,7 +109,7 @@ pub struct InventoryExit {
 /// as a percentage of `max_position`; values over 100 are invalid/disabled so
 /// a typo cannot create a surprising late exit. The result is only a plan —
 /// callers must cancel stale quotes and submit a reduce-only order separately.
-pub fn inventory_exit_plan(
+pub(crate) fn inventory_exit_plan(
     position: f64,
     max_position: f64,
     trigger_pct: f64,
@@ -221,7 +221,7 @@ pub fn round_to_decimals(value: f64, decimals: u32) -> f64 {
 }
 
 /// Round DOWN to `decimals` decimal places (used for buy prices).
-pub fn floor_to_decimals(value: f64, decimals: u32) -> f64 {
+pub(crate) fn floor_to_decimals(value: f64, decimals: u32) -> f64 {
     let factor = 10f64.powi(decimals as i32);
     // Nudge by a hair to avoid f64 representation artifacts like
     // 99.90 * 100 = 9989.999999... flooring to 99.89.
@@ -229,7 +229,7 @@ pub fn floor_to_decimals(value: f64, decimals: u32) -> f64 {
 }
 
 /// Round UP to `decimals` decimal places (used for sell prices).
-pub fn ceil_to_decimals(value: f64, decimals: u32) -> f64 {
+pub(crate) fn ceil_to_decimals(value: f64, decimals: u32) -> f64 {
     let factor = 10f64.powi(decimals as i32);
     ((value * factor) - 1e-9).ceil() / factor
 }
@@ -267,7 +267,7 @@ pub fn mark_mid_divergence_bps(mark: f64, best_bid: f64, best_ask: f64) -> f64 {
 /// shift scales linearly with inventory and saturates at `skew_bps` when
 /// `|position| >= max_position`. Returns mark unchanged when skew is off or
 /// `max_position` is non-positive.
-pub fn skew_center(cfg: &MakerConfig, mark: f64, position: f64) -> f64 {
+pub(crate) fn skew_center(cfg: &MakerConfig, mark: f64, position: f64) -> f64 {
     if cfg.max_position <= 0.0 {
         return mark;
     }
@@ -875,7 +875,7 @@ impl AlertMonitor {
 /// min-qty filter, and max-position side suppression. Quotes that fail a guard
 /// are dropped; duplicate prices after clamping/rounding are collapsed (outer
 /// level wins nothing — the inner level is kept).
-pub fn compute_desired_quotes(
+pub(crate) fn compute_desired_quotes(
     cfg: &MakerConfig,
     mark: f64,
     best_bid: Option<f64>,
@@ -997,7 +997,7 @@ pub fn compute_desired_quotes(
 /// directional ladder independently. `reserved_slots` are considered first;
 /// callers use them for submitted-but-not-yet-visible orders, so transport
 /// delay cannot make a later level lose its exposure reservation.
-pub fn cap_desired_exposure(
+pub(crate) fn cap_desired_exposure(
     cfg: &MakerConfig,
     position: f64,
     desired: &[DesiredQuote],
@@ -1064,7 +1064,7 @@ pub fn resting_quotes_would_cross(
 /// Cancels before all Places so the executor frees margin before re-placing;
 /// Holds come last.
 #[allow(clippy::too_many_arguments)]
-pub fn reconcile(
+pub(crate) fn reconcile(
     cfg: &MakerConfig,
     mark: f64,
     position: f64,

--- a/crates/standx-maker/src/runtime.rs
+++ b/crates/standx-maker/src/runtime.rs
@@ -5,7 +5,7 @@ use std::collections::VecDeque;
 const MAX_CONSECUTIVE_CYCLE_ERRORS: u32 = 3;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum RuntimePhase {
+pub(crate) enum RuntimePhase {
     Starting,
     Ready,
     Frozen { reason: String },
@@ -46,7 +46,7 @@ pub enum RuntimeStopReason {
 }
 
 impl RuntimeStopReason {
-    pub fn detail(&self) -> String {
+    fn detail(&self) -> String {
         match self {
             Self::CtrlC => "Ctrl+C".to_string(),
             Self::OrderResponse(reason)
@@ -93,7 +93,6 @@ pub enum MakerEvent {
         message: String,
     },
     StopRequested(RuntimeStopReason),
-    CtrlC,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -136,15 +135,18 @@ impl MakerState {
         }
     }
 
-    pub fn phase(&self) -> &RuntimePhase {
+    #[cfg(test)]
+    pub(crate) fn phase(&self) -> &RuntimePhase {
         &self.phase
     }
 
-    pub fn generation(&self) -> u64 {
+    #[cfg(test)]
+    pub(crate) fn generation(&self) -> u64 {
         self.generation
     }
 
-    pub fn is_frozen(&self) -> bool {
+    #[cfg(test)]
+    pub(crate) fn is_frozen(&self) -> bool {
         matches!(self.phase, RuntimePhase::Frozen { .. })
     }
 
@@ -284,12 +286,14 @@ impl MakerState {
                 RecoveryTarget::OrderResponse,
             ),
             MakerEvent::StopRequested(reason) => self.stop(reason),
-            MakerEvent::CtrlC => self.stop(RuntimeStopReason::CtrlC),
         }
     }
 
     fn matches_in_flight(&self, token: WorkToken, kind: WorkKind) -> bool {
-        token.generation == self.generation && token.kind == kind && self.in_flight == Some(token)
+        // `in_flight` is only ever set with the current generation and is taken
+        // on every generation bump, so `self.in_flight == Some(token)` already
+        // implies the generation matches; only the kind still needs checking.
+        token.kind == kind && self.in_flight == Some(token)
     }
 
     fn request_cycle(&mut self) -> Vec<MakerEffect> {
@@ -528,7 +532,7 @@ mod tests {
         let mut state = MakerState::starting();
         state.handle(MakerEvent::StartupReady);
         let token = next_cycle(&mut state);
-        state.handle(MakerEvent::CtrlC);
+        state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
         assert_eq!(state.next_effect(), Some(MakerEffect::AbortInFlight(token)));
         assert_eq!(
             state.next_effect(),


### PR DESCRIPTION
部分推进 #260。基于最新 `main`。三个 commit,覆盖两个主段(API 收窄 + 死代码/冗余)全部完成,类型一致性段做了最安全的一项、其余延期。

## API 收窄(standx-maker)— 全部完成
- `plan_cycle` 内部件降级 `pub(crate)`:`compute_desired_quotes`、`cap_desired_exposure`、`reconcile`、`skew_center`、`inventory_exit_plan`、`floor_to_decimals`/`ceil_to_decimals`。只留 `plan_cycle`/`preflight_cycle` 作公有入口(测试仍可达),也堵掉了 CLI 绕过敞口上限的诱惑。
- `RuntimePhase` → `pub(crate)` 且移出 re-export;`WorkKind` 移出 re-export(仍 `pub`,因为它是 `WorkToken.kind` 的类型);`MakerState::phase/is_frozen/generation` → `#[cfg(test)] pub(crate)`;`RuntimeStopReason::detail` → 私有(仅 crate 内用)。

## 冗余/死代码 — 全部完成
- 删除 `MakerEvent::CtrlC` 变体(它就是 `StopRequested(RuntimeStopReason::CtrlC)`,两条路都活着);5 处 CLI + 1 处测试改走 `StopRequested`。
- `matches_in_flight` 去掉冗余的 `token.generation == self.generation`(`in_flight == Some(token)` 已隐含),加注释。
- 删除 `model::is_order_rejection` + 其唯一(自测)测试:`#[cfg(test)]` 门控、生产零调用(实际拒单分类走 `OrderResponse.code`)。
- `ledger::apply_order_update` 删掉收进来就丢弃的 `mark: f64` 参数,更新全部调用点。
- `CycleResult` 去掉未用的 `Clone`/`PartialEq` derive。
- `FeedState` 的 `mark`/`best_bid`/`best_ask` 私有化(模块外只经 `fresh_ws_snapshot` 取快照)。

## 类型一致性 — 做了 1 项,其余延期
- ✅ `adopt_order` 的 exit-marker 判定从 `starts_with(&format!("{prefix}x"))` 改 `strip_prefix + starts_with('x')`,去掉每次调用的 String 分配。
- ⏸ 延期(均为 issue 标注的"低优先级",且各自有 API ripple,更适合独立小 PR):`QuoteSlot` 统一裸元组、`CycleInput::active_exit_enabled` → `Option<ExitParams>`、ledger 公有可变字段封装为 getter/方法、`PendingTrade`/`LedgerTrade` 时间戳合并(`LedgerTrade` 目前是借用 `&str` 的 `Copy` 类型,改持有 `String` 会破坏 `Copy` 并波及整个 CLI adapter)、`Alert.kind` 改枚举。

## 验证
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` — **327 tests 全通过** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
