### PR TITLE
Fix maker CLI arg/output consistency (#261, partial)

### DIFF
--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -561,9 +561,11 @@ pub enum MakerCommands {
             env = "STANDX_SUPERVISOR_WEBHOOK_FORMAT"
         )]
         alert_webhook_format: AlertWebhookFormat,
-        /// Disable the WebSocket market feed and poll REST every cycle
-        #[arg(long)]
-        no_ws: bool,
+        /// Disable the WebSocket market feed and poll REST every cycle.
+        /// `--no-ws` enables REST polling; `--no-ws=false` forces the WS feed
+        /// back on even when a config file sets `no_ws = true`.
+        #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
+        no_ws: Option<bool>,
         /// Place real orders (without this flag the bot runs in paper mode:
         /// full loop, prints intended actions, no orders placed)
         #[arg(long)]
@@ -605,12 +607,12 @@ pub enum MakerCommands {
         /// Put the post-only buy this many bps below the mark to avoid taking
         #[arg(long, default_value_t = 100.0)]
         price_offset_bps: f64,
-        /// Bound each response and REST visibility check
-        #[arg(long, default_value_t = 10)]
+        /// Bound each response and REST visibility check (1..=30 seconds)
+        #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..=30))]
         timeout_secs: u64,
         /// Required push channel for start, failure, and completion events
-        #[arg(long, env = "STANDX_SUPERVISOR_WEBHOOK")]
-        alert_webhook: Option<String>,
+        #[arg(long, env = "STANDX_SUPERVISOR_WEBHOOK", required = true)]
+        alert_webhook: String,
         /// Webhook payload format for the target chat platform
         #[arg(
             long,

--- a/crates/standx-cli/src/commands/maker/canary.rs
+++ b/crates/standx-cli/src/commands/maker/canary.rs
@@ -8,7 +8,7 @@ use super::notify::MakerNotifier;
 use super::{FailSafeShutdown, LIVE_MAKER_ENV};
 use crate::cli::{AlertWebhookFormat, OutputFormat};
 use anyhow::Result;
-use standx_maker::round_to_decimals;
+use standx_maker::{format_decimals, round_to_decimals};
 use standx_sdk::auth::Credentials;
 use standx_sdk::client::order::CreateOrderParams;
 use standx_sdk::client::StandXClient;
@@ -226,22 +226,18 @@ pub(super) async fn run_ws_command_canary(
     size: Option<f64>,
     price_offset_bps: f64,
     timeout_secs: u64,
-    alert_webhook: Option<String>,
+    alert_webhook: String,
     alert_webhook_format: AlertWebhookFormat,
     output_format: OutputFormat,
 ) -> Result<()> {
+    // --timeout-secs (1..=30) and the required --alert-webhook are now enforced
+    // by clap, so --help documents them and they cannot reach here invalid.
     if std::env::var(LIVE_MAKER_ENV).ok().as_deref() != Some("1") {
         return Err(anyhow::anyhow!(
             "{}=1 is required for the WS command canary",
             LIVE_MAKER_ENV
         ));
     }
-    if !(1..=30).contains(&timeout_secs) {
-        return Err(anyhow::anyhow!("--timeout-secs must be between 1 and 30"));
-    }
-    let webhook = alert_webhook.ok_or_else(|| {
-        anyhow::anyhow!("WS command canary requires --alert-webhook for fail-safe delivery")
-    })?;
     let credentials = Credentials::load()?;
     if credentials.is_expired() || credentials.private_key.is_empty() {
         return Err(anyhow::anyhow!(
@@ -251,7 +247,7 @@ pub(super) async fn run_ws_command_canary(
 
     let session_id = uuid::Uuid::new_v4().to_string();
     let client = StandXClient::new()?.with_session_id(session_id.clone());
-    let notifier = MakerNotifier::new(output_format, Some(webhook), alert_webhook_format);
+    let notifier = MakerNotifier::new(output_format, Some(alert_webhook), alert_webhook_format);
     let timeout = Duration::from_secs(timeout_secs);
     let infos = client.get_symbol_info().await?;
     let info = infos
@@ -296,14 +292,8 @@ pub(super) async fn run_ws_command_canary(
     let evidence = CanaryEvidence {
         symbol: &symbol,
         client_order_id: &client_order_id,
-        quantity: format!(
-            "{quantity:.precision$}",
-            precision = info.qty_tick_decimals as usize
-        ),
-        price: format!(
-            "{price:.precision$}",
-            precision = info.price_tick_decimals as usize
-        ),
+        quantity: format_decimals(quantity, info.qty_tick_decimals),
+        price: format_decimals(price, info.price_tick_decimals),
     };
     evidence.emit_position(CanaryStage::PreflightVerified, None, 0.0);
     let stream = OrderResponseStream::new(session_id)?;
@@ -391,11 +381,8 @@ async fn run_commands(
             cl_ord_id: Some(client_order_id.to_string()),
             side: OrderSide::Buy,
             order_type: OrderType::Limit,
-            quantity: format!("{quantity:.precision$}", precision = qty_decimals as usize),
-            price: Some(format!(
-                "{price:.precision$}",
-                precision = price_decimals as usize
-            )),
+            quantity: format_decimals(quantity, qty_decimals),
+            price: Some(format_decimals(price, price_decimals)),
             time_in_force: Some(TimeInForce::Alo),
             reduce_only: false,
             stop_price: None,

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -96,6 +96,14 @@ pub async fn handle_maker(
     output_format: OutputFormat,
     verbose: bool,
 ) -> Result<()> {
+    // Maker output is emitted as JSON lines or a human table; there is no CSV
+    // renderer, so `--output csv` would silently fall back to the table. Reject
+    // it up front rather than surprising a pipeline that asked for CSV.
+    if output_format == OutputFormat::Csv {
+        return Err(anyhow::anyhow!(
+            "maker does not support --output csv; use json (machine-readable) or table (human)"
+        ));
+    }
     match command {
         MakerCommands::Run {
             symbol,
@@ -162,7 +170,7 @@ pub async fn handle_maker(
                     alert_margin_below: choose(alert_margin_below, file.alert_margin_below, 0.0),
                     alert_webhook,
                     alert_webhook_format,
-                    no_ws: no_ws || file.no_ws.unwrap_or(false),
+                    no_ws: choose(no_ws, file.no_ws, false),
                     live,
                     order_response_reconnect_attempts: choose(
                         order_response_reconnect_attempts,

--- a/crates/standx-cli/src/main.rs
+++ b/crates/standx-cli/src/main.rs
@@ -180,12 +180,13 @@ fn maker_panic_webhook(command: &Commands) -> Option<(String, AlertWebhookFormat
             alert_webhook: Some(url),
             alert_webhook_format,
             ..
-        }
-        | MakerCommands::WsCommandCanary {
-            alert_webhook: Some(url),
+        } => return Some((url.clone(), *alert_webhook_format)),
+        // The canary's webhook is required by clap, so it is always present.
+        MakerCommands::WsCommandCanary {
+            alert_webhook,
             alert_webhook_format,
             ..
-        } => return Some((url.clone(), *alert_webhook_format)),
+        } => return Some((alert_webhook.clone(), *alert_webhook_format)),
         _ => {}
     }
     None

--- a/crates/standx-maker/src/runtime.rs
+++ b/crates/standx-maker/src/runtime.rs
@@ -407,6 +407,25 @@ mod tests {
     }
 
     #[test]
+    fn frozen_ignores_timer_and_market_changed() {
+        let mut state = MakerState::starting();
+        state.handle(MakerEvent::StartupReady);
+        let token = next_cycle(&mut state);
+        // Freeze on a position mismatch and drain the abort + cleanup it queues.
+        state.handle(MakerEvent::PositionMismatch);
+        assert!(state.is_frozen());
+        while state.next_effect().is_some() {}
+
+        // While frozen, market ticks must not schedule any new cycle work or
+        // arm a replan — the recovery flow owns the state until it completes.
+        state.handle(MakerEvent::Timer);
+        state.handle(MakerEvent::MarketChanged);
+        assert_eq!(state.next_effect(), None);
+        assert!(state.is_frozen());
+        let _ = token;
+    }
+
+    #[test]
     fn coalesced_timer_commits_then_replans() {
         let mut state = MakerState::starting();
         state.handle(MakerEvent::StartupReady);


### PR DESCRIPTION
部分推进 #261(P3)。基于最新 `main`。做完了"配置与 CLI 一致性"里可独立完成、行为可验证的项 + 一个测试缺口;剩下的结构性/测试搬家项延期(见下)。

## 已完成

- **`--no-ws` 不对称修复**:此前唯一用 `no_ws || file.no_ws` 合并的参数,一旦 `maker.toml` 设 `no_ws = true`,命令行无法关掉。改为 tri-state `Option<bool>`(`--no-ws` = true,`--no-ws=false` = 强制把 WS 打开),和其余 26 个参数一样走 `choose(cli, file, default)`。`--help` 显示 `--no-ws[=<NO_WS>] [possible values: true, false]`。
- **`--output csv` 明确拒绝**:maker 没有 CSV 渲染器,此前静默降级为 table。入口直接报错,指向 json/table。
- **canary clap 与运行时对齐**:`--alert-webhook` 改 `required = true`(原为 `Option` + 运行时强制),`--timeout-secs` 用 `value_parser!(u64).range(1..=30)`;`--help` 现在如实说明,运行时校验删除。Usage 行显示 `--alert-webhook <ALERT_WEBHOOK>` 为必填。
- **canary 数字格式化统一**:订单/证据字段改用 `maker::format_decimals`,与 live cycle 路径完全一致(去掉手搓的 `{:.precision$}`)。
- **补测试**:standx-maker runtime 直接测试"Frozen 期间忽略 Timer/MarketChanged"(此前仅间接隐含)。

## 延期(留作后续,均为 P3 里的结构性/测试组织项)

- 策略配置字段清单 4 处平行维护 → `MakerFileConfig::merge()` 收敛:较大结构改动,单独 PR。
- `parse_positive_f64(context, raw)` 收敛 13 处分散解析校验:跨 4 文件,单独 PR。
- canary `run_commands` 10 参 → `CanaryOrderPlan` 请求结构。
- 测试组织:mod.rs 测试归位到被测模块、隐藏 prelude 显式化、跨 crate 重复测试删除、`ProjectionPendingPlace` builder 共享 testutil——都是高 churn 的搬家,单独 PR 更清晰。

## 验证
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` — **330 tests 全通过** ✅
- 跑二进制核对了 `--no-ws`/canary 的 `--help` 与 `--output csv` 拒绝行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
