### PR TITLE
Split run_maker: shutdown_report + symmetric account-stream reconnect (#255)

### DIFF
--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -40,8 +40,9 @@ use notify::{token_expiry_level, MakerNotifier, PositionChange, RiskNotice, Toke
 use pipeline::{CycleRequest, CycleState, LiveAccountPollState};
 use recovery::{
     cancel_maker_orders_with_retry, ctrl_c_latched, order_response_reconnect_available,
-    reconcile_ledger_snapshot, reconnect_order_response, PositionReconciliationError,
-    ReconcileRequest, ReconnectInterrupted, ReconnectRequest,
+    reconcile_ledger_snapshot, reconnect_account_stream, reconnect_order_response,
+    AccountStreamReconnect, PositionReconciliationError, ReconcileRequest, ReconnectInterrupted,
+    ReconnectRequest,
 };
 #[cfg(test)]
 use recovery::{

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -4,6 +4,9 @@ use super::pipeline::{fetch_account_audit, AccountAudit};
 use crate::cli::OutputFormat;
 use anyhow::Result;
 use standx_maker::{MakerFill, MakerLedger, MakerStats};
+use standx_sdk::account_stream::{
+    AccountChannel, AccountEvent, AccountStream, AccountStreamHealth,
+};
 use standx_sdk::client::StandXClient;
 use standx_sdk::models::{Order, Position, Trade};
 use standx_sdk::order_response::{
@@ -411,6 +414,88 @@ async fn query_reconnect_snapshot(
         &audit.positions,
         &audit.filled_orders,
         &audit.trades,
+    )
+}
+
+/// The live halves of a freshly authenticated account stream.
+pub(super) type AccountStreamConnection = (
+    tokio::sync::mpsc::Receiver<AccountEvent>,
+    AccountStreamHealth,
+    tokio::task::JoinHandle<()>,
+);
+
+/// Terminal outcome of the account-stream reconnect loop, mirroring the
+/// order-response reconnect: either a live connection, an operator Ctrl+C, or
+/// the attempt budget exhausted.
+pub(super) enum AccountStreamReconnect {
+    Connected(AccountStreamConnection),
+    Interrupted,
+    Exhausted(String),
+}
+
+/// Reconnect the authenticated account stream with bounded attempts and
+/// exponential backoff, both interruptible by Ctrl+C. Bumps `epoch` and
+/// `attempts_used` in place so the caller's projection reset and budget stay in
+/// sync. The maker book is already cancelled by the completed cleanup, so
+/// aborting the waits on Ctrl+C is safe. Symmetric with
+/// [`reconnect_order_response`]; the caller owns the post-connect event
+/// application and REST reconciliation (account-stream-specific).
+pub(super) async fn reconnect_account_stream(
+    epoch: &mut u64,
+    attempts_used: &mut u32,
+    max_attempts: u32,
+    backoff_secs: u64,
+    ctrl_c: &mut tokio::sync::watch::Receiver<bool>,
+) -> AccountStreamReconnect {
+    let mut last_connect_error: Option<String> = None;
+    while *attempts_used < max_attempts {
+        *attempts_used += 1;
+        let attempt = *attempts_used;
+        *epoch = epoch.saturating_add(1);
+        let connect_epoch = *epoch;
+        let reconnect = async {
+            let stream = AccountStream::new(connect_epoch)?;
+            stream
+                .connect(&[
+                    AccountChannel::Order,
+                    AccountChannel::Position,
+                    AccountChannel::Trade,
+                    AccountChannel::Balance,
+                ])
+                .await
+                .map_err(anyhow::Error::from)
+        };
+        let connect_attempt = tokio::select! {
+            biased;
+            _ = ctrl_c_latched(ctrl_c) => None,
+            result = tokio::time::timeout(Duration::from_secs(15), reconnect) => Some(result),
+        };
+        let Some(connect_attempt) = connect_attempt else {
+            return AccountStreamReconnect::Interrupted;
+        };
+        match connect_attempt {
+            Ok(Ok(triple)) => return AccountStreamReconnect::Connected(triple),
+            Ok(Err(error)) => last_connect_error = Some(format!("connect failed: {error}")),
+            Err(_) => last_connect_error = Some("connect timed out after 15 seconds".to_string()),
+        }
+        eprintln!(
+            "⚠️  account stream reconnect attempt {}/{} failed: {}",
+            attempt,
+            max_attempts,
+            last_connect_error.as_deref().unwrap_or("unknown error")
+        );
+        if attempt < max_attempts {
+            let multiplier = 1_u32 << attempt.saturating_sub(1).min(4);
+            let backoff = Duration::from_secs(backoff_secs).saturating_mul(multiplier);
+            tokio::select! {
+                biased;
+                _ = ctrl_c_latched(ctrl_c) => return AccountStreamReconnect::Interrupted,
+                _ = tokio::time::sleep(backoff) => {}
+            }
+        }
+    }
+    AccountStreamReconnect::Exhausted(
+        last_connect_error.unwrap_or_else(|| "no attempts available".to_string()),
     )
 }
 

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -588,6 +588,193 @@ pub(super) fn validate_alert_thresholds(
     Ok(())
 }
 
+struct ShutdownReport<'a> {
+    live: bool,
+    output_format: OutputFormat,
+    symbol: &'a str,
+    cfg: &'a MakerConfig,
+    client: &'a StandXClient,
+    notifier: &'a MakerNotifier,
+    ledger: &'a MakerLedger,
+    stats: &'a MakerStats,
+    breaker: &'a VolBreaker,
+    exit: MakerExit,
+    cycle: u64,
+    total_places: u64,
+    total_cancels: u64,
+    total_holds: u64,
+    total_fills: u64,
+    total_halted: u64,
+    sim_position: f64,
+    last_mark: Option<f64>,
+    feed_handle: Option<tokio::task::JoinHandle<()>>,
+    account_stream_handle: Option<tokio::task::JoinHandle<()>>,
+    order_response_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+/// Abort feed/stream tasks, cancel any residual maker orders, print the human
+/// summary, and deliver the stopped-lifecycle notifications. Runs on every
+/// exit path; returns the process result (fail-safe error or clean Ok).
+async fn shutdown_report(report: ShutdownReport<'_>) -> Result<()> {
+    let ShutdownReport {
+        live,
+        output_format,
+        symbol,
+        cfg,
+        client,
+        notifier,
+        ledger,
+        stats,
+        breaker,
+        exit,
+        cycle,
+        total_places,
+        total_cancels,
+        total_holds,
+        total_fills,
+        total_halted,
+        sim_position,
+        last_mark,
+        feed_handle,
+        account_stream_handle,
+        order_response_handle,
+    } = report;
+    if let Some(handle) = feed_handle {
+        handle.abort();
+    }
+    if let Some(handle) = account_stream_handle {
+        handle.abort();
+    }
+    let final_position = if live {
+        ledger.expected_position
+    } else {
+        stats.position()
+    };
+    if output_format == OutputFormat::Table {
+        println!(
+            "\n👋 Stopping maker (ran {} cycles: {} places, {} cancels, {} holds)",
+            cycle, total_places, total_cancels, total_holds
+        );
+        let pnl_note = match last_mark {
+            Some(m) => format!(
+                " | PnL {:+.2} (mark-to-market)",
+                stats.pnl(final_position, m)
+            ),
+            None => String::new(),
+        };
+        println!(
+            "   {} fills | uptime {:.0}% | max pos {} | avg capture {:.1}bps{}",
+            total_fills,
+            stats.uptime_pct(),
+            maker::format_decimals(stats.max_abs_position, cfg.qty_decimals),
+            stats.avg_spread_capture_bps(),
+            pnl_note
+        );
+        if breaker.enabled() {
+            println!("   vol breaker: {} cycles halted", total_halted);
+        }
+        if !live {
+            println!(
+                "   paper sim: ending position {}",
+                maker::format_decimals(sim_position, cfg.qty_decimals)
+            );
+        }
+    }
+    if let Some(handle) = order_response_handle {
+        handle.abort();
+    }
+    // Do not return early on cleanup failure: operators need the stopped
+    // lifecycle alert most when residual maker orders may still be live.
+    let cleanup_error = if live {
+        cancel_maker_orders_with_retry(client, symbol, 3, output_format)
+            .await
+            .err()
+    } else {
+        None
+    };
+
+    // Notify stop on every exit path. Await delivery so the message lands
+    // before the process exits.
+    let reason = exit.lifecycle_reason();
+    let pnl_str = last_mark
+        .map(|m| format!("{:+.2}", stats.pnl(final_position, m)))
+        .unwrap_or_else(|| "n/a".to_string());
+    let cleanup_note = cleanup_error.as_ref().map_or_else(String::new, |error| {
+        format!(" | ⚠️ cleanup failed: {error}")
+    });
+    if let Some(error) = cleanup_error.as_ref() {
+        let message = format!("maker cleanup failed or left residual orders: {error}");
+        notifier
+            .risk(
+                RiskNotice {
+                    kind: "maker_cleanup",
+                    severity: "critical",
+                    event: "residual_orders",
+                    message: &message,
+                    symbol,
+                    cycle,
+                    position_before: None,
+                    position_after: None,
+                    expected: Some(ledger.expected_position),
+                    observed: None,
+                },
+                true,
+            )
+            .await;
+    }
+    if !matches!(&exit, MakerExit::CtrlC) {
+        notifier
+            .risk(
+                RiskNotice {
+                    kind: "fail_safe",
+                    severity: "critical",
+                    event: "stopped",
+                    message: &reason,
+                    symbol,
+                    cycle,
+                    position_before: None,
+                    position_after: None,
+                    expected: Some(ledger.expected_position),
+                    observed: None,
+                },
+                true,
+            )
+            .await;
+    }
+    notifier
+        .lifecycle(
+            "stopped",
+            &format!(
+                "🔴 maker stopped ({}) — {} | {} cycles, {} fills, uptime {:.0}%, PnL {}{}",
+                reason,
+                symbol,
+                cycle,
+                total_fills,
+                stats.uptime_pct(),
+                pnl_str,
+                cleanup_note,
+            ),
+            symbol,
+            true,
+        )
+        .await;
+
+    if let Some(error) = cleanup_error {
+        // A residual-order cleanup failure is an intentional fail-safe stop
+        // that needs a human, not an automatic restart.
+        return Err(anyhow::Error::new(FailSafeShutdown {
+            message: format!(
+                "maker stopped (fail-safe) but maker-owned order cleanup failed: {error}"
+            ),
+        }));
+    }
+
+    match exit.terminal_error() {
+        Some(message) => Err(anyhow::Error::new(FailSafeShutdown { message })),
+        None => Ok(()),
+    }
+}
+
 pub(super) async fn run_maker(
     symbol: String,
     args: MakerRunArgs,
@@ -2814,140 +3001,30 @@ pub(super) async fn run_maker(
     };
 
     // ---- Cleanup on ALL exit paths ----
-    if let Some(handle) = feed_handle {
-        handle.abort();
-    }
-    if let Some(handle) = account_stream_handle {
-        handle.abort();
-    }
-    let final_position = if args.live {
-        ledger.expected_position
-    } else {
-        stats.position()
-    };
-    if output_format == OutputFormat::Table {
-        println!(
-            "\n👋 Stopping maker (ran {} cycles: {} places, {} cancels, {} holds)",
-            cycle, total_places, total_cancels, total_holds
-        );
-        let pnl_note = match last_mark {
-            Some(m) => format!(
-                " | PnL {:+.2} (mark-to-market)",
-                stats.pnl(final_position, m)
-            ),
-            None => String::new(),
-        };
-        println!(
-            "   {} fills | uptime {:.0}% | max pos {} | avg capture {:.1}bps{}",
-            total_fills,
-            stats.uptime_pct(),
-            maker::format_decimals(stats.max_abs_position, cfg.qty_decimals),
-            stats.avg_spread_capture_bps(),
-            pnl_note
-        );
-        if breaker.enabled() {
-            println!("   vol breaker: {} cycles halted", total_halted);
-        }
-        if !args.live {
-            println!(
-                "   paper sim: ending position {}",
-                maker::format_decimals(sim_position, cfg.qty_decimals)
-            );
-        }
-    }
-    if let Some(handle) = order_response_handle {
-        handle.abort();
-    }
-    // Do not return early on cleanup failure: operators need the stopped
-    // lifecycle alert most when residual maker orders may still be live.
-    let cleanup_error = if args.live {
-        cancel_maker_orders_with_retry(&client, &symbol, 3, output_format)
-            .await
-            .err()
-    } else {
-        None
-    };
-
-    // Notify stop on every exit path. Await delivery so the message lands
-    // before the process exits.
-    let reason = exit.lifecycle_reason();
-    let pnl_str = last_mark
-        .map(|m| format!("{:+.2}", stats.pnl(final_position, m)))
-        .unwrap_or_else(|| "n/a".to_string());
-    let cleanup_note = cleanup_error.as_ref().map_or_else(String::new, |error| {
-        format!(" | ⚠️ cleanup failed: {error}")
-    });
-    if let Some(error) = cleanup_error.as_ref() {
-        let message = format!("maker cleanup failed or left residual orders: {error}");
-        notifier
-            .risk(
-                RiskNotice {
-                    kind: "maker_cleanup",
-                    severity: "critical",
-                    event: "residual_orders",
-                    message: &message,
-                    symbol: &symbol,
-                    cycle,
-                    position_before: None,
-                    position_after: None,
-                    expected: Some(ledger.expected_position),
-                    observed: None,
-                },
-                true,
-            )
-            .await;
-    }
-    if !matches!(&exit, MakerExit::CtrlC) {
-        notifier
-            .risk(
-                RiskNotice {
-                    kind: "fail_safe",
-                    severity: "critical",
-                    event: "stopped",
-                    message: &reason,
-                    symbol: &symbol,
-                    cycle,
-                    position_before: None,
-                    position_after: None,
-                    expected: Some(ledger.expected_position),
-                    observed: None,
-                },
-                true,
-            )
-            .await;
-    }
-    notifier
-        .lifecycle(
-            "stopped",
-            &format!(
-                "🔴 maker stopped ({}) — {} | {} cycles, {} fills, uptime {:.0}%, PnL {}{}",
-                reason,
-                symbol,
-                cycle,
-                total_fills,
-                stats.uptime_pct(),
-                pnl_str,
-                cleanup_note,
-            ),
-            &symbol,
-            true,
-        )
-        .await;
-
-    if let Some(error) = cleanup_error {
-        // A residual-order cleanup failure is an intentional fail-safe stop
-        // that needs a human, not an automatic restart.
-        return Err(anyhow::Error::new(FailSafeShutdown {
-            message: format!(
-                "maker stopped (fail-safe) but maker-owned order cleanup failed: {error}"
-            ),
-        }));
-    }
-
-    match exit.terminal_error() {
-        Some(message) => Err(anyhow::Error::new(FailSafeShutdown { message })),
-        None => Ok(()),
-    }
+    shutdown_report(ShutdownReport {
+        live: args.live,
+        output_format,
+        symbol: &symbol,
+        cfg: &cfg,
+        client: &client,
+        notifier: &notifier,
+        ledger: &ledger,
+        stats: &stats,
+        breaker: &breaker,
+        exit,
+        cycle,
+        total_places,
+        total_cancels,
+        total_holds,
+        total_fills,
+        total_halted,
+        sim_position,
+        last_mark,
+        feed_handle,
+        account_stream_handle,
+        order_response_handle,
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -1513,89 +1513,35 @@ pub(super) async fn run_maker(
                     );
                 }
 
-                let mut last_connect_error: Option<String> = None;
-                let mut reconnected = None;
-                while account_stream_reconnect_attempts_used
-                    < args.account_stream_reconnect_attempts
+                let (mut events, health, handle) = match reconnect_account_stream(
+                    &mut account_stream_epoch,
+                    &mut account_stream_reconnect_attempts_used,
+                    args.account_stream_reconnect_attempts,
+                    args.account_stream_reconnect_backoff,
+                    &mut ctrl_c_rx,
+                )
+                .await
                 {
-                    account_stream_reconnect_attempts_used += 1;
-                    let attempt = account_stream_reconnect_attempts_used;
-                    account_stream_epoch = account_stream_epoch.saturating_add(1);
-                    let reconnect = async {
-                        let stream = AccountStream::new(account_stream_epoch)?;
-                        stream
-                            .connect(&[
-                                AccountChannel::Order,
-                                AccountChannel::Position,
-                                AccountChannel::Trade,
-                                AccountChannel::Balance,
-                            ])
-                            .await
-                            .map_err(anyhow::Error::from)
-                    };
-                    // The maker book is already cancelled (cleanup completed),
-                    // so aborting the reconnect wait on Ctrl+C is safe.
-                    let connect_attempt = tokio::select! {
-                        biased;
-                        _ = ctrl_c_latched(&mut ctrl_c_rx) => None,
-                        result = tokio::time::timeout(Duration::from_secs(15), reconnect) => {
-                            Some(result)
-                        }
-                    };
-                    let Some(connect_attempt) = connect_attempt else {
+                    AccountStreamReconnect::Connected(triple) => triple,
+                    AccountStreamReconnect::Interrupted => {
                         runtime_state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
                         break 'main take_stop_effect(
                             &mut runtime_state,
                             MakerExit::PositionReconciliation,
                         );
-                    };
-                    match connect_attempt {
-                        Ok(Ok(triple)) => {
-                            reconnected = Some(triple);
-                            break;
-                        }
-                        Ok(Err(error)) => {
-                            last_connect_error = Some(format!("connect failed: {error}"));
-                        }
-                        Err(_) => {
-                            last_connect_error =
-                                Some("connect timed out after 15 seconds".to_string());
-                        }
                     }
-                    eprintln!(
-                        "⚠️  account stream reconnect attempt {}/{} failed: {}",
-                        attempt,
-                        args.account_stream_reconnect_attempts,
-                        last_connect_error.as_deref().unwrap_or("unknown error")
-                    );
-                    if attempt < args.account_stream_reconnect_attempts {
-                        let multiplier = 1_u32 << attempt.saturating_sub(1).min(4);
-                        let backoff = Duration::from_secs(args.account_stream_reconnect_backoff)
-                            .saturating_mul(multiplier);
-                        tokio::select! {
-                            biased;
-                            _ = ctrl_c_latched(&mut ctrl_c_rx) => {
-                                runtime_state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
-                                break 'main take_stop_effect(
-                                    &mut runtime_state,
-                                    MakerExit::PositionReconciliation,
-                                );
-                            }
-                            _ = tokio::time::sleep(backoff) => {}
-                        }
+                    AccountStreamReconnect::Exhausted(reason) => {
+                        runtime_state.handle(MakerEvent::RecoveryFailed {
+                            token: recovery_token,
+                            reason: format!(
+                                "account stream disconnected ({detail}); reconnect exhausted: {reason}"
+                            ),
+                        });
+                        break take_stop_effect(
+                            &mut runtime_state,
+                            MakerExit::PositionReconciliation,
+                        );
                     }
-                }
-
-                let Some((mut events, health, handle)) = reconnected else {
-                    runtime_state.handle(MakerEvent::RecoveryFailed {
-                        token: recovery_token,
-                        reason: format!(
-                            "account stream disconnected ({detail}); reconnect exhausted: {}",
-                            last_connect_error
-                                .unwrap_or_else(|| "no attempts available".to_string())
-                        ),
-                    });
-                    break take_stop_effect(&mut runtime_state, MakerExit::PositionReconciliation);
                 };
 
                 let projection = account_projection


### PR DESCRIPTION
推进 #255 剩余的 run_maker 拆分。基于最新 `main`。两个 commit,均为行为保持的机械提取,测试保驾。

## 已完成

### Phase A — `shutdown_report()`
run_maker 末尾 ~135 行、在所有退出路径上运行的清理+通知块(abort feed/stream 任务、撤残留挂单、打印人类摘要、投递 stopped 生命周期通知、映射进程结果)是线性的函数尾部代码、无循环控制流。原样搬进 `async fn shutdown_report(ShutdownReport<'_>)`,run_maker 的主干在 `'main` 循环处收尾。

### Phase B — 账户流重连抽到 `recovery::reconnect_account_stream`
issue 明确指出的不对称:订单响应重连早已在 `recovery::reconnect_order_response`,而等价的账户流 connect/backoff 循环仍内联在 run_maker。把 ~85 行的尝试/退避循环抽出,与订单响应版对称。它就地更新 `epoch`/`attempts_used`,返回 `AccountStreamReconnect { Connected | Interrupted | Exhausted }`,让调用方保留原本的 `break 'main`(Ctrl+C→stop)和 RecoveryFailed(预算耗尽→stop)控制流。账户流特有的连接后事件应用 + REST 对账**刻意留在** run_maker(它不是"重连"原语的一部分)。

## Phase C(共享 freeze_and_cleanup)—— 经评估后决定不做(deliberate)

计划里的 Phase C 假设三段 freeze→cleanup→recover 流程"完全一致"。**但审查之后的改动(#270/#273 的 preserve-pending-acks 工作)已经刻意让它们分叉了:**

- **projection 清理方法不同**:账户流 / 仓位失配用 `clear_orders_preserving_pending_acks`;订单响应用 `clear_orders_and_pending`。
- **流拆卸不同**:账户流 abort 自己的 handle + take `account_events`;订单响应 take 自己的三个 halves;仓位失配不拆任何流。
- **风险通知不同**(kind/event/message/severity)。

在 live 交易的 freeze/恢复路径上,强行抽一个要参数化这 3 处真实差异(清理策略、拆卸、通知)的共享骨架,**收益低于风险**——正是容易埋下细微 bug 的地方,且 issue 的"完全一致"前提已部分过时。**决定:保持三段显式,不抽共享骨架。** 这是基于当前代码(而非审查快照)的有意取舍——DRY 在这里会掩盖有意的分叉并抬高 live 路径的 bug 风险。#255 以本 PR(A+B)交付,C 项作为已评估的取舍关闭。

## 验证
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` — **338 tests 全通过**(含 ~730 行行为级 effect 排序/缓冲/fail-closed 测试)✅

## 范围说明
- 本次按约定**不含 startup→LiveSession(Phase D)**,故 **#256 仍开着**,留作后续。
- run_maker 仍约 2200 行;A/B 拆走了尾部与账户流重连循环。进一步瘦身(cycle select/commit/stop-loss/reconciliation 主体外移)超出本 issue 清单,属更大的独立重构。

Refs #255(A+B 交付;C 经评估后有意不做)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
