### PR TITLE
Add rolling transport recovery circuit breaker for maker reconnects

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,8 +418,10 @@ ID prefix: manual/API orders are preserved. It cleans up maker-owned orders on
 exit (with retries and verification), stops quoting after 3 consecutive API
 errors, and safely pauses on an asynchronous order-response disconnect. It
 then cleans and verifies the maker book, authenticates a new response session,
-and reconciles orders, position, and fills before quoting can resume; a disabled
-or exhausted reconnect budget still fails closed.
+and reconciles orders, position, and fills before quoting can resume. Reconnect
+attempts are bounded per incident, while account-stream and order-response
+incidents share a rolling-window circuit breaker; a disabled or exhausted
+budget still fails closed.
 Live fill telemetry is sourced from authenticated, maker-order-correlated trade
 history rather than inferred from position changes. Paper mode simulates fills
 when the touch crosses a quote, so position, inventory skew, and PnL telemetry

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -570,8 +570,8 @@ pub enum MakerCommands {
         /// full loop, prints intended actions, no orders placed)
         #[arg(long)]
         live: bool,
-        /// Maximum authenticated order-response reconnect attempts across one
-        /// live maker run. Each attempt first cleans maker orders and must
+        /// Maximum authenticated order-response reconnect attempts for one
+        /// recovery incident. Each attempt first cleans maker orders and must
         /// reconcile an empty maker book before quoting resumes. 0 disables.
         #[arg(long)]
         order_response_reconnect_attempts: Option<u32>,
@@ -579,8 +579,8 @@ pub enum MakerCommands {
         /// Later attempts use bounded exponential backoff.
         #[arg(long)]
         order_response_reconnect_backoff: Option<u64>,
-        /// Maximum account-stream reconnect attempts after an unhealthy
-        /// disconnect during a live maker run. Each attempt reconnects the
+        /// Maximum account-stream reconnect attempts for one unhealthy-stream
+        /// recovery incident. Each attempt reconnects the
         /// authenticated account stream, replays buffered events, and backs
         /// fill gaps with REST trades before reconciling the venue position.
         /// 0 disables reconnect entirely (fail closed immediately).
@@ -590,6 +590,13 @@ pub enum MakerCommands {
         /// Later attempts use bounded exponential backoff.
         #[arg(long)]
         account_stream_reconnect_backoff: Option<u64>,
+        /// Maximum transport recovery incidents admitted inside one rolling
+        /// window, shared by account-stream and order-response recovery.
+        #[arg(long)]
+        recovery_incidents_per_window: Option<u32>,
+        /// Rolling transport recovery circuit-breaker window in seconds.
+        #[arg(long)]
+        recovery_window_secs: Option<u64>,
         /// Supervised fault injection: close the local order-response stream
         /// after this many seconds. Hidden because it is only for live-gate
         /// validation and is limited by the maker command to 60 seconds.

--- a/crates/standx-cli/src/commands/maker/config.rs
+++ b/crates/standx-cli/src/commands/maker/config.rs
@@ -36,6 +36,8 @@ pub(super) struct MakerFileConfig {
     pub order_response_reconnect_backoff: Option<u64>,
     pub account_stream_reconnect_attempts: Option<u32>,
     pub account_stream_reconnect_backoff: Option<u64>,
+    pub recovery_incidents_per_window: Option<u32>,
+    pub recovery_window_secs: Option<u64>,
 }
 
 pub(super) fn load(path: Option<&Path>) -> Result<MakerFileConfig> {
@@ -63,7 +65,7 @@ mod tests {
     #[test]
     fn parses_partial_non_sensitive_strategy_file() {
         let config: MakerFileConfig = toml::from_str(
-            "spread_bps = 8\nmax_position = 0.02\nalert_position_change_pct = 20\nno_ws = true\norder_response_reconnect_attempts = 3\norder_response_reconnect_backoff = 2\naccount_stream_reconnect_attempts = 3\naccount_stream_reconnect_backoff = 2\n",
+            "spread_bps = 8\nmax_position = 0.02\nalert_position_change_pct = 20\nno_ws = true\norder_response_reconnect_attempts = 3\norder_response_reconnect_backoff = 2\naccount_stream_reconnect_attempts = 3\naccount_stream_reconnect_backoff = 2\nrecovery_incidents_per_window = 3\nrecovery_window_secs = 3600\n",
         )
         .unwrap();
         assert_eq!(config.spread_bps, Some(8.0));
@@ -74,6 +76,8 @@ mod tests {
         assert_eq!(config.order_response_reconnect_backoff, Some(2));
         assert_eq!(config.account_stream_reconnect_attempts, Some(3));
         assert_eq!(config.account_stream_reconnect_backoff, Some(2));
+        assert_eq!(config.recovery_incidents_per_window, Some(3));
+        assert_eq!(config.recovery_window_secs, Some(3600));
         assert_eq!(config.size, None);
     }
 
@@ -101,6 +105,8 @@ mod tests {
         assert_eq!(config.order_response_reconnect_backoff, Some(2));
         assert_eq!(config.account_stream_reconnect_attempts, Some(3));
         assert_eq!(config.account_stream_reconnect_backoff, Some(2));
+        assert_eq!(config.recovery_incidents_per_window, Some(3));
+        assert_eq!(config.recovery_window_secs, Some(3600));
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -39,10 +39,9 @@ use notify::webhook_body;
 use notify::{token_expiry_level, MakerNotifier, PositionChange, RiskNotice, TokenExpiryLevel};
 use pipeline::{CycleRequest, CycleState, LiveAccountPollState};
 use recovery::{
-    cancel_maker_orders_with_retry, ctrl_c_latched, order_response_reconnect_available,
-    reconcile_ledger_snapshot, reconnect_account_stream, reconnect_order_response,
-    AccountStreamReconnect, PositionReconciliationError, ReconcileRequest, ReconnectInterrupted,
-    ReconnectRequest,
+    cancel_maker_orders_with_retry, ctrl_c_latched, reconcile_ledger_snapshot,
+    reconnect_account_stream, reconnect_order_response, AccountStreamReconnect,
+    PositionReconciliationError, ReconcileRequest, ReconnectInterrupted, ReconnectRequest,
 };
 #[cfg(test)]
 use recovery::{
@@ -138,6 +137,8 @@ pub async fn handle_maker(
             order_response_reconnect_backoff,
             account_stream_reconnect_attempts,
             account_stream_reconnect_backoff,
+            recovery_incidents_per_window,
+            recovery_window_secs,
             controlled_disconnect_after,
         } => {
             let file = config::load(maker_config.as_deref())?;
@@ -192,6 +193,16 @@ pub async fn handle_maker(
                         account_stream_reconnect_backoff,
                         file.account_stream_reconnect_backoff,
                         2,
+                    ),
+                    recovery_incidents_per_window: choose(
+                        recovery_incidents_per_window,
+                        file.recovery_incidents_per_window,
+                        3,
+                    ),
+                    recovery_window_secs: choose(
+                        recovery_window_secs,
+                        file.recovery_window_secs,
+                        3600,
                     ),
                     controlled_disconnect_after,
                     verbose,
@@ -256,6 +267,8 @@ struct MakerRunArgs {
     order_response_reconnect_backoff: u64,
     account_stream_reconnect_attempts: u32,
     account_stream_reconnect_backoff: u64,
+    recovery_incidents_per_window: u32,
+    recovery_window_secs: u64,
     controlled_disconnect_after: Option<u64>,
     verbose: bool,
 }
@@ -370,30 +383,6 @@ mod tests {
             model::signed_position_quantity("0.13", Some(OrderSide::Sell)).unwrap(),
             -0.13
         );
-    }
-
-    #[test]
-    fn reconnect_policy_is_bounded_and_preserves_controlled_fail_safe() {
-        assert!(order_response_reconnect_available(
-            "order-response WebSocket error: reset",
-            0,
-            3
-        ));
-        assert!(!order_response_reconnect_available(
-            "order-response WebSocket error: reset",
-            3,
-            3
-        ));
-        assert!(!order_response_reconnect_available(
-            "controlled fault injection closed the order-response stream after 15s",
-            0,
-            3
-        ));
-        assert!(!order_response_reconnect_available(
-            "order-response WebSocket error: reset",
-            0,
-            0
-        ));
     }
 
     struct EnvGuard {

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -294,7 +294,6 @@ pub(super) struct ReconnectSnapshot {
 }
 
 pub(super) struct ReconnectedOrderResponse {
-    pub(super) client: StandXClient,
     pub(super) commands: OrderCommandSender,
     pub(super) responses: tokio::sync::mpsc::Receiver<OrderResponse>,
     pub(super) health: OrderResponseHealth,
@@ -327,14 +326,6 @@ fn emit_order_response_reconnect(
             "⚠️  order-response reconnect {event} ({attempt}/{max_attempts}) on {symbol}: {message}"
         );
     }
-}
-
-pub(super) fn order_response_reconnect_available(
-    failure: &str,
-    attempts_used: u32,
-    max: u32,
-) -> bool {
-    !failure.starts_with("controlled fault injection") && attempts_used < max
 }
 
 pub(super) fn validate_reconnect_snapshot(
@@ -434,23 +425,20 @@ pub(super) enum AccountStreamReconnect {
 }
 
 /// Reconnect the authenticated account stream with bounded attempts and
-/// exponential backoff, both interruptible by Ctrl+C. Bumps `epoch` and
-/// `attempts_used` in place so the caller's projection reset and budget stay in
-/// sync. The maker book is already cancelled by the completed cleanup, so
+/// exponential backoff, both interruptible by Ctrl+C. Bumps `epoch` per
+/// attempt so the caller's projection reset follows the connected stream. The
+/// maker book is already cancelled by the completed cleanup, so
 /// aborting the waits on Ctrl+C is safe. Symmetric with
 /// [`reconnect_order_response`]; the caller owns the post-connect event
 /// application and REST reconciliation (account-stream-specific).
 pub(super) async fn reconnect_account_stream(
     epoch: &mut u64,
-    attempts_used: &mut u32,
     max_attempts: u32,
     backoff_secs: u64,
     ctrl_c: &mut tokio::sync::watch::Receiver<bool>,
 ) -> AccountStreamReconnect {
     let mut last_connect_error: Option<String> = None;
-    while *attempts_used < max_attempts {
-        *attempts_used += 1;
-        let attempt = *attempts_used;
+    for attempt in 1..=max_attempts {
         *epoch = epoch.saturating_add(1);
         let connect_epoch = *epoch;
         let reconnect = async {
@@ -507,7 +495,6 @@ pub(super) struct ReconnectRequest<'a> {
     pub(super) expected_position: f64,
     pub(super) qty_tolerance: f64,
     pub(super) output_format: OutputFormat,
-    pub(super) attempts_used: u32,
     pub(super) max_attempts: u32,
     pub(super) base_backoff: Duration,
     pub(super) original_failure: &'a str,
@@ -516,7 +503,7 @@ pub(super) struct ReconnectRequest<'a> {
 
 pub(super) async fn reconnect_order_response(
     request: ReconnectRequest<'_>,
-) -> Result<(ReconnectedOrderResponse, u32)> {
+) -> Result<ReconnectedOrderResponse> {
     let ReconnectRequest {
         cleanup_client,
         symbol,
@@ -525,22 +512,19 @@ pub(super) async fn reconnect_order_response(
         expected_position,
         qty_tolerance,
         output_format,
-        attempts_used,
         max_attempts,
         base_backoff,
         original_failure,
         ctrl_c,
     } = request;
-    let mut cleanup_client = cleanup_client;
     let mut ctrl_c = ctrl_c;
-    let first_attempt = attempts_used.saturating_add(1);
     let mut last_error = None;
     // The runtime Cleanup effect has already emptied and verified the maker
     // book before it emits Recover. Only repeat cleanup between failed
     // reconnect attempts, when a late venue-side request may have surfaced.
     let mut cleanup_needed = false;
 
-    for attempt in first_attempt..=max_attempts {
+    for attempt in 1..=max_attempts {
         emit_order_response_reconnect(
             output_format,
             symbol,
@@ -574,7 +558,6 @@ pub(super) async fn reconnect_order_response(
                 _ = tokio::time::sleep(Duration::from_secs(1)) => {}
             }
             let session_id = uuid::Uuid::new_v4().to_string();
-            let candidate_client = StandXClient::new()?.with_session_id(&session_id);
             let stream = OrderResponseStream::new(&session_id)?;
             let connect_attempt = tokio::select! {
                 biased;
@@ -586,7 +569,7 @@ pub(super) async fn reconnect_order_response(
             match connect_attempt {
                 Ok(Ok((commands, responses, health, handle))) => {
                     match query_reconnect_snapshot(
-                        &candidate_client,
+                        &cleanup_client,
                         symbol,
                         session_started_at,
                         run_order_prefix,
@@ -606,7 +589,6 @@ pub(super) async fn reconnect_order_response(
                                     "new order-response session became unhealthy during reconciliation without a recorded reason".to_string()
                                 });
                                 handle.abort();
-                                cleanup_client = candidate_client;
                                 last_error = Some(anyhow::anyhow!(
                                     "new order-response session failed during reconciliation: {reason}"
                                 ));
@@ -626,34 +608,27 @@ pub(super) async fn reconnect_order_response(
                                     max_attempts,
                                     &message,
                                 );
-                                return Ok((
-                                    ReconnectedOrderResponse {
-                                        client: candidate_client,
-                                        commands,
-                                        responses,
-                                        health,
-                                        handle,
-                                    },
-                                    attempt,
-                                ));
+                                return Ok(ReconnectedOrderResponse {
+                                    commands,
+                                    responses,
+                                    health,
+                                    handle,
+                                });
                             }
                         }
                         Err(error) => {
                             handle.abort();
-                            cleanup_client = candidate_client;
                             last_error =
                                 Some(anyhow::anyhow!("post-auth reconciliation failed: {error}"));
                         }
                     }
                 }
                 Ok(Err(error)) => {
-                    cleanup_client = candidate_client;
                     last_error = Some(anyhow::anyhow!(
                         "order-response authentication failed: {error}"
                     ));
                 }
                 Err(_) => {
-                    cleanup_client = candidate_client;
                     last_error = Some(anyhow::anyhow!(
                         "order-response reconnect timed out after 15 seconds"
                     ));
@@ -675,7 +650,7 @@ pub(super) async fn reconnect_order_response(
             &error_text,
         );
         if attempt < max_attempts {
-            let local_attempt = attempt.saturating_sub(first_attempt).min(4);
+            let local_attempt = attempt.saturating_sub(1).min(4);
             let multiplier = 1_u32 << local_attempt;
             tokio::select! {
                 biased;

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -249,6 +249,7 @@ struct AccountEventOutcome {
     latest_position: Option<f64>,
     exit_fill_observed: bool,
     balance_changed: bool,
+    requires_order_reconciliation: bool,
 }
 
 impl AccountEventOutcome {
@@ -259,6 +260,7 @@ impl AccountEventOutcome {
         }
         self.exit_fill_observed |= other.exit_fill_observed;
         self.balance_changed |= other.balance_changed;
+        self.requires_order_reconciliation |= other.requires_order_reconciliation;
     }
 }
 
@@ -420,18 +422,7 @@ fn apply_account_event(
                 generation,
                 AccountProjectionEvent::OrderObserved(observation),
             );
-            if projection_outcome.unknown_current_run_order {
-                return Err(anyhow::anyhow!(
-                    "account stream reported an unknown current-run maker order: order_id={} client_order_id={:?} status={:?} side={:?} price={} qty={} fill_qty={}",
-                    update.order_id,
-                    update.cl_ord_id,
-                    update.status,
-                    update.side,
-                    update.price,
-                    update.qty,
-                    update.fill_qty,
-                ));
-            }
+            let requires_order_reconciliation = projection_outcome.unknown_current_run_order;
             for fill in &fills {
                 if let Some(order_id) = fill.order_id {
                     state.projection.apply(
@@ -449,6 +440,7 @@ fn apply_account_event(
                 latest_position: None,
                 exit_fill_observed,
                 balance_changed: false,
+                requires_order_reconciliation,
             })
         }
         AccountEvent::Position(update) => {
@@ -469,6 +461,7 @@ fn apply_account_event(
                 latest_position: Some(qty),
                 exit_fill_observed: false,
                 balance_changed: false,
+                requires_order_reconciliation: false,
             })
         }
         AccountEvent::Trade(trade) => {
@@ -499,6 +492,7 @@ fn apply_account_event(
                 latest_position: None,
                 exit_fill_observed,
                 balance_changed: false,
+                requires_order_reconciliation: false,
             })
         }
         // A balance update only signals that the REST-backed margin snapshot
@@ -524,6 +518,22 @@ fn accounting_position_mismatch(
     // a bare `>` comparison false and silently pass the invariant, so treat any
     // non-finite value as a mismatch.
     !delta.is_finite() || delta > qty_tolerance
+}
+
+fn recovery_circuit_detail(admission: maker::RecoveryAdmission) -> String {
+    let (incidents, limit, window_secs) = match admission {
+        maker::RecoveryAdmission::Admitted {
+            incidents,
+            limit,
+            window_secs,
+        }
+        | maker::RecoveryAdmission::CircuitOpen {
+            incidents,
+            limit,
+            window_secs,
+        } => (incidents, limit, window_secs),
+    };
+    format!("rolling recovery circuit {incidents}/{limit} incident(s) in {window_secs}s")
 }
 
 async fn accounting_invariant_exit(
@@ -775,6 +785,12 @@ async fn shutdown_report(report: ShutdownReport<'_>) -> Result<()> {
     }
 }
 
+fn new_maker_rest_client() -> Result<StandXClient> {
+    let client = StandXClient::new()?;
+    debug_assert!(client.session_id().is_none());
+    Ok(client)
+}
+
 pub(super) async fn run_maker(
     symbol: String,
     args: MakerRunArgs,
@@ -823,10 +839,21 @@ pub(super) async fn run_maker(
             "--account-stream-reconnect-backoff must be between 1 and 60 seconds when reconnect is enabled"
         ));
     }
-    let mut client = match order_session_id.as_deref() {
-        Some(session_id) => StandXClient::new()?.with_session_id(session_id),
-        None => StandXClient::new()?,
-    };
+    if !(1..=100).contains(&args.recovery_incidents_per_window) {
+        return Err(anyhow::anyhow!(
+            "--recovery-incidents-per-window must be between 1 and 100"
+        ));
+    }
+    if !(60..=86_400).contains(&args.recovery_window_secs) {
+        return Err(anyhow::anyhow!(
+            "--recovery-window-secs must be between 60 and 86400"
+        ));
+    }
+    // REST reads, audits, and fail-safe cleanup must stay outside the
+    // order-response session. Attaching x-session-id to REST cancellation
+    // would route its asynchronous response into the command response stream,
+    // where it has no projection request entry and would look uncorrelated.
+    let client = new_maker_rest_client()?;
 
     // ---- Startup: symbol metadata + invariants (fail fast) ----
     let infos = client.get_symbol_info().await?;
@@ -1226,6 +1253,10 @@ pub(super) async fn run_maker(
                 "│ account-stream recovery: {} attempt(s), {}s base backoff",
                 args.account_stream_reconnect_attempts, args.account_stream_reconnect_backoff
             );
+            println!(
+                "│ transport recovery circuit: {} incident(s) / {}s rolling window",
+                args.recovery_incidents_per_window, args.recovery_window_secs
+            );
         }
         if args.no_ws {
             println!("│ feed: REST polling (--no-ws)");
@@ -1351,9 +1382,13 @@ pub(super) async fn run_maker(
             .with_account_floors(args.alert_equity_below, args.alert_margin_below);
     let mut last_mark: Option<f64> = None;
     let mut last_src: Option<&'static str> = None;
-    let mut order_response_reconnect_attempts_used = 0_u32;
-    let mut account_stream_reconnect_attempts_used = 0_u32;
+    let recovery_clock_started = std::time::Instant::now();
+    let mut transport_recovery_breaker = maker::RecoveryCircuitBreaker::new(
+        args.recovery_incidents_per_window,
+        args.recovery_window_secs,
+    );
     let mut account_position_mismatch: Option<f64> = None;
+    let mut account_order_reconciliation_required = false;
     // A wallet-level WS balance update cannot be substituted for the unified
     // REST equity/margin model. Coalesce updates into one immediate
     // authoritative refresh on the next cycle when account floors are active.
@@ -1500,22 +1535,28 @@ pub(super) async fn run_maker(
                         }
                     };
 
-                if account_stream_reconnect_attempts_used >= args.account_stream_reconnect_attempts
-                {
+                if args.account_stream_reconnect_attempts == 0 {
+                    break recovery_failed_exit(
+                        &mut runtime_state,
+                        recovery_token,
+                        format!("account stream disconnected ({detail}); reconnect disabled"),
+                    );
+                }
+                let admission =
+                    transport_recovery_breaker.admit(recovery_clock_started.elapsed().as_secs());
+                if !admission.is_admitted() {
                     break recovery_failed_exit(
                         &mut runtime_state,
                         recovery_token,
                         format!(
-                            "account stream disconnected ({detail}); reconnect disabled or budget exhausted ({}/{})",
-                            account_stream_reconnect_attempts_used,
-                            args.account_stream_reconnect_attempts
+                            "account stream disconnected ({detail}); {}; refusing further live orders",
+                            recovery_circuit_detail(admission)
                         ),
                     );
                 }
 
                 let (mut events, health, handle) = match reconnect_account_stream(
                     &mut account_stream_epoch,
-                    &mut account_stream_reconnect_attempts_used,
                     args.account_stream_reconnect_attempts,
                     args.account_stream_reconnect_backoff,
                     &mut ctrl_c_rx,
@@ -1683,6 +1724,24 @@ pub(super) async fn run_maker(
                     }
                 }
 
+                // A current-run order may surface after the first freeze
+                // cleanup while the account stream is authenticating. Require
+                // one final authoritative empty-book verification before the
+                // recovered stream can resume quoting.
+                if let Err(error) =
+                    cancel_maker_orders_with_retry(&client, &symbol, 3, output_format).await
+                {
+                    handle.abort();
+                    break recovery_failed_exit(
+                        &mut runtime_state,
+                        recovery_token,
+                        format!(
+                            "account stream reconnect final maker-book verification failed: {error}"
+                        ),
+                    );
+                }
+                projection.clear_orders_preserving_pending_acks();
+
                 account_events = Some(events);
                 account_stream_health = Some(health);
                 account_stream_handle = Some(handle);
@@ -1733,11 +1792,6 @@ pub(super) async fn run_maker(
                         }
                     };
                 let controlled_fault = detail.starts_with("controlled fault injection");
-                let reconnect_available = order_response_reconnect_available(
-                    &detail,
-                    order_response_reconnect_attempts_used,
-                    args.order_response_reconnect_attempts,
-                );
                 // Mirror the account-stream path: the order-response stream was
                 // previously silent on the webhook across disconnect/reconnect.
                 let disconnect_message =
@@ -1784,7 +1838,17 @@ pub(super) async fn run_maker(
                             );
                         }
                     };
-                if reconnect_available {
+                let reconnect_unavailable = if controlled_fault {
+                    Some("controlled fault injection requires fail-safe shutdown".to_string())
+                } else if args.order_response_reconnect_attempts == 0 {
+                    Some("safe reconnect is disabled".to_string())
+                } else {
+                    let admission = transport_recovery_breaker
+                        .admit(recovery_clock_started.elapsed().as_secs());
+                    (!admission.is_admitted())
+                        .then(|| format!("{}; circuit is open", recovery_circuit_detail(admission)))
+                };
+                if reconnect_unavailable.is_none() {
                     if let Some(handle) = order_response_handle.take() {
                         handle.abort();
                     }
@@ -1798,7 +1862,6 @@ pub(super) async fn run_maker(
                         expected_position: ledger.expected_position,
                         qty_tolerance,
                         output_format,
-                        attempts_used: order_response_reconnect_attempts_used,
                         max_attempts: args.order_response_reconnect_attempts,
                         base_backoff: Duration::from_secs(args.order_response_reconnect_backoff),
                         original_failure: &detail,
@@ -1806,13 +1869,11 @@ pub(super) async fn run_maker(
                     })
                     .await
                     {
-                        Ok((reconnected, attempts_used)) => {
-                            client = reconnected.client;
+                        Ok(reconnected) => {
                             order_commands = Some(reconnected.commands);
                             order_responses = Some(reconnected.responses);
                             order_response_health = Some(reconnected.health);
                             order_response_handle = Some(reconnected.handle);
-                            order_response_reconnect_attempts_used = attempts_used;
                             // Cleanup verified an empty maker book. The next
                             // cycle rebuilds exchange state before it may place.
                             resting.clear();
@@ -1923,17 +1984,8 @@ pub(super) async fn run_maker(
                         }
                     }
                 }
-                let reconnect_note = if controlled_fault {
-                    "controlled fault injection requires fail-safe shutdown".to_string()
-                } else if args.order_response_reconnect_attempts == 0 {
-                    "safe reconnect is disabled".to_string()
-                } else {
-                    format!(
-                        "safe reconnect budget exhausted ({}/{})",
-                        order_response_reconnect_attempts_used,
-                        args.order_response_reconnect_attempts
-                    )
-                };
+                let reconnect_note = reconnect_unavailable
+                    .expect("unavailable reconnect must carry a fail-safe reason");
                 let refuse_message =
                     format!("{detail}; {reconnect_note}; refusing further live orders");
                 notifier
@@ -2002,6 +2054,7 @@ pub(super) async fn run_maker(
                 },
             ) {
                 Ok(outcome) => {
+                    account_order_reconciliation_required |= outcome.requires_order_reconciliation;
                     let position = absorb_account_outcome(
                         outcome,
                         OutcomeSink {
@@ -2066,6 +2119,8 @@ pub(super) async fn run_maker(
         // Work phase raced against Ctrl+C so a slow API call can be
         // interrupted (mirrors run_watch_loop).
         let mismatch = account_position_mismatch.take();
+        let order_reconciliation_required =
+            std::mem::take(&mut account_order_reconciliation_required);
         let exit_pending_before = inventory_exit_pending;
         let breaker_halted_before = breaker.halted();
         if runtime_state.pending_effect().is_none() {
@@ -2089,6 +2144,12 @@ pub(super) async fn run_maker(
                 return Err(anyhow::Error::new(PositionReconciliationError {
                     expected: ledger.expected_position,
                     observed,
+                }));
+            }
+            if order_reconciliation_required {
+                return Err(anyhow::Error::new(PositionReconciliationError {
+                    expected: ledger.expected_position,
+                    observed: ledger.expected_position,
                 }));
             }
             let (mark, best_bid, best_ask, src, market_fallback_reason) =
@@ -2255,6 +2316,9 @@ pub(super) async fn run_maker(
                 },
             ) {
                 Ok(outcome) => {
+                    if outcome.requires_order_reconciliation {
+                        cycle_invalidated_by_account = true;
+                    }
                     let position = absorb_account_outcome(
                         outcome,
                         OutcomeSink {
@@ -2698,6 +2762,25 @@ pub(super) async fn run_maker(
                         }
                     }
                     if recovered {
+                        // Requests already accepted by the venue can become
+                        // visible after the initial freeze cleanup. Verify the
+                        // maker book again at the end of the bounded recovery
+                        // window before unfreezing placements.
+                        if let Err(error) =
+                            cancel_maker_orders_with_retry(&client, &symbol, 3, output_format).await
+                        {
+                            break 'main recovery_failed_exit(
+                                &mut runtime_state,
+                                recovery_token,
+                                format!(
+                                    "position reconciliation final maker-book verification failed: {error}"
+                                ),
+                            );
+                        }
+                        if let Some(projection) = account_projection.as_mut() {
+                            projection.clear_orders_preserving_pending_acks();
+                        }
+                        account_order_reconciliation_required = false;
                         if let Some(projection) = account_projection.as_mut() {
                             let generation = projection.generation();
                             projection.apply(
@@ -2871,6 +2954,8 @@ pub(super) async fn run_maker(
                         },
                     ) {
                         Ok(outcome) => {
+                            account_order_reconciliation_required |=
+                                outcome.requires_order_reconciliation;
                             let position = absorb_account_outcome(
                                 outcome,
                                 OutcomeSink {
@@ -3027,6 +3112,12 @@ mod tests {
             message: String::new(),
             request_id: request_id.map(str::to_string),
         }
+    }
+
+    #[test]
+    fn maker_rest_client_is_isolated_from_order_response_session() {
+        let client = new_maker_rest_client().expect("maker REST client is constructible");
+        assert_eq!(client.session_id(), None);
     }
 
     fn position_update(symbol: &str, side: Option<OrderSide>, qty: &str) -> PositionUpdate {
@@ -3860,6 +3951,45 @@ mod tests {
         // projection (raw wallet fields are not projected).
         assert!(outcome.balance_changed);
         assert_eq!(stats.fills(), 0);
+    }
+
+    #[test]
+    fn uncorrelated_current_run_order_requires_reconciliation_without_stream_failure() {
+        let mut ledger = MakerLedger::new(0.0);
+        let mut stats = MakerStats::default();
+        let mut projection = MakerAccountProjection::new(1, "sxmk-test-", 0.0, 0.005, 0.00005);
+        let mut state = AccountEventState {
+            ledger: &mut ledger,
+            stats: &mut stats,
+            projection: &mut projection,
+        };
+        let context = AccountEventContext {
+            symbol: "BTC-USD",
+            run_order_prefix: "sxmk-test-",
+            mark: 100.0,
+            cycle: 2,
+            output_format: OutputFormat::Quiet,
+        };
+        let update = OrderUpdate {
+            seq: 1,
+            order_id: 7,
+            cl_ord_id: Some("sxmk-test-q00000001b0".to_string()),
+            symbol: "BTC-USD".to_string(),
+            side: OrderSide::Buy,
+            qty: "0.2".to_string(),
+            fill_qty: "0".to_string(),
+            fill_avg_price: "0".to_string(),
+            price: "100".to_string(),
+            status: standx_sdk::models::OrderStatus::Open,
+            reduce_only: false,
+            updated_at: "2026-07-15T00:00:00Z".to_string(),
+        };
+
+        let outcome = apply_account_event(AccountEvent::Order(update), &mut state, &context)
+            .expect("a late current-run order is a reconciliation trigger, not stream failure");
+
+        assert!(outcome.requires_order_reconciliation);
+        assert_eq!(outcome.fills, 0);
     }
 
     #[test]

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -20,6 +20,7 @@ use standx_sdk::models::OrderSide;
 pub mod account_projection;
 pub mod ledger;
 pub mod ownership;
+pub mod recovery;
 pub mod risk;
 pub mod runtime;
 
@@ -35,6 +36,7 @@ pub use ownership::{
     open_qty_adopts, pending_covers_slot, position_within_limit, quote_client_order_id, QuoteSlot,
     MAKER_CL_ORD_ID_PREFIX,
 };
+pub use recovery::{RecoveryAdmission, RecoveryCircuitBreaker};
 pub use risk::{PositionAlertAnchor, PositionRiskEvent, PositionRiskKind};
 pub use runtime::{
     order_cancel_rejection_reason, MakerEffect, MakerEvent, MakerState, RecoveryTarget,

--- a/crates/standx-maker/src/recovery.rs
+++ b/crates/standx-maker/src/recovery.rs
@@ -1,0 +1,106 @@
+//! Deterministic recovery admission policy for live transport incidents.
+
+use std::collections::VecDeque;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoveryAdmission {
+    Admitted {
+        incidents: u32,
+        limit: u32,
+        window_secs: u64,
+    },
+    CircuitOpen {
+        incidents: u32,
+        limit: u32,
+        window_secs: u64,
+    },
+}
+
+impl RecoveryAdmission {
+    pub fn is_admitted(self) -> bool {
+        matches!(self, Self::Admitted { .. })
+    }
+}
+
+#[derive(Debug)]
+pub struct RecoveryCircuitBreaker {
+    limit: u32,
+    window_secs: u64,
+    incidents: VecDeque<u64>,
+}
+
+impl RecoveryCircuitBreaker {
+    pub fn new(limit: u32, window_secs: u64) -> Self {
+        Self {
+            limit,
+            window_secs,
+            incidents: VecDeque::new(),
+        }
+    }
+
+    /// Admit one transport-recovery incident at monotonic `now_secs`.
+    /// Individual reconnect attempts are deliberately not recorded here; the
+    /// caller owns that bounded retry loop for the admitted incident.
+    pub fn admit(&mut self, now_secs: u64) -> RecoveryAdmission {
+        while self
+            .incidents
+            .front()
+            .is_some_and(|started| now_secs.saturating_sub(*started) >= self.window_secs)
+        {
+            self.incidents.pop_front();
+        }
+        let incidents = self.incidents.len() as u32;
+        if incidents >= self.limit {
+            return RecoveryAdmission::CircuitOpen {
+                incidents,
+                limit: self.limit,
+                window_secs: self.window_secs,
+            };
+        }
+        self.incidents.push_back(now_secs);
+        RecoveryAdmission::Admitted {
+            incidents: incidents + 1,
+            limit: self.limit,
+            window_secs: self.window_secs,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn incidents_are_bounded_inside_one_window() {
+        let mut breaker = RecoveryCircuitBreaker::new(2, 60);
+        assert!(breaker.admit(10).is_admitted());
+        assert_eq!(breaker.incidents.len(), 1);
+        assert!(breaker.admit(20).is_admitted());
+        assert_eq!(breaker.incidents.len(), 2);
+        assert!(matches!(
+            breaker.admit(30),
+            RecoveryAdmission::CircuitOpen { incidents: 2, .. }
+        ));
+    }
+
+    #[test]
+    fn incidents_expire_at_the_rolling_window_boundary() {
+        let mut breaker = RecoveryCircuitBreaker::new(1, 60);
+        assert!(breaker.admit(10).is_admitted());
+        assert!(!breaker.admit(69).is_admitted());
+        assert!(breaker.admit(70).is_admitted());
+    }
+
+    #[test]
+    fn zero_limit_is_fail_closed() {
+        let mut breaker = RecoveryCircuitBreaker::new(0, 60);
+        assert!(matches!(
+            breaker.admit(0),
+            RecoveryAdmission::CircuitOpen {
+                incidents: 0,
+                limit: 0,
+                ..
+            }
+        ));
+    }
+}

--- a/docs/13-maker.md
+++ b/docs/13-maker.md
@@ -83,8 +83,12 @@ standx maker run <SYMBOL> [OPTIONS]
 | `--alert-webhook-format` | `slack` | webhook 报文格式：`slack` / `feishu` / `telegram` / `raw` |
 | `--no-ws` | 关 | 禁用 WebSocket 行情，改为每轮 REST 轮询 |
 | `--live` | 关 | 下真实单（不带此标志即 paper 模式） |
-| `--order-response-reconnect-attempts` | `3` | 单次 maker run 内订单回报流的安全重连总预算；每次先清理、换 session 并对账，`0` 禁用 |
+| `--order-response-reconnect-attempts` | `3` | 单次订单回报流事故内的安全重连次数；每次先清理、换 session 并对账，`0` 禁用 |
 | `--order-response-reconnect-backoff` | `2` | 安全重连基础退避秒数，后续失败按上限递增 |
+| `--account-stream-reconnect-attempts` | `3` | 单次账户流事故内的安全重连次数；重连后回放、REST 回补并对账，`0` 禁用 |
+| `--account-stream-reconnect-backoff` | `2` | 账户流重连基础退避秒数，后续失败按上限递增 |
+| `--recovery-incidents-per-window` | `3` | 账户流与订单回报流共用的滚动窗口事故熔断上限 |
+| `--recovery-window-secs` | `3600` | 运输层恢复事故熔断的滚动时间窗（秒） |
 
 启动时会做快速校验（fail fast）：交易对存在且在交易中、`spread-bps > 0`、`band-bps > spread-bps`、`size` 取整后 ≥ 最小下单量、`skew-bps ≥ 0`；主动退出必须同时设置百分比与数量。
 

--- a/examples/maker-xag-100u-conservative.toml
+++ b/examples/maker-xag-100u-conservative.toml
@@ -58,6 +58,8 @@ account_stream_reconnect_attempts = 3
 account_stream_reconnect_backoff = 2
 order_response_reconnect_attempts = 3
 order_response_reconnect_backoff = 2
+recovery_incidents_per_window = 3
+recovery_window_secs = 3600
 
 # Use the WebSocket market feed, with REST fallback handled by the CLI.
 no_ws = false

--- a/examples/maker-xag-100u-standard.toml
+++ b/examples/maker-xag-100u-standard.toml
@@ -63,6 +63,8 @@ account_stream_reconnect_attempts = 3
 account_stream_reconnect_backoff = 2
 order_response_reconnect_attempts = 3
 order_response_reconnect_backoff = 2
+recovery_incidents_per_window = 3
+recovery_window_secs = 3600
 
 # Use the WebSocket market feed, with REST fallback handled by the CLI.
 no_ws = false

--- a/examples/maker-xag-100u.toml
+++ b/examples/maker-xag-100u.toml
@@ -47,6 +47,8 @@ inventory_exit_qty = 0.2
 # resumes only after maker cleanup and account/trade reconciliation succeed.
 order_response_reconnect_attempts = 3
 order_response_reconnect_backoff = 2
+recovery_incidents_per_window = 3
+recovery_window_secs = 3600
 
 # Use the WebSocket market feed, with REST fallback handled by the CLI.
 no_ws = false

--- a/examples/maker.toml
+++ b/examples/maker.toml
@@ -51,5 +51,10 @@ order_response_reconnect_backoff = 2
 account_stream_reconnect_attempts = 3
 account_stream_reconnect_backoff = 2
 
+# Shared rolling circuit breaker across account-stream and order-response
+# recovery incidents. Attempt counts above reset for every admitted incident.
+recovery_incidents_per_window = 3
+recovery_window_secs = 3600
+
 # Use REST market polling instead of the WebSocket feed (normally false)
 no_ws = false


### PR DESCRIPTION
**Summary**
- Introduce a shared rolling-window circuit breaker for account-stream and order-response recovery incidents.
- Scope reconnect budgets to a single recovery incident and keep cleanup/reconciliation on the CLI side.
- Reopen quoting only after an extra maker-book verification, and ensure REST reads/cancels use a separate client session.
- Update CLI/config help and README language to match the new recovery semantics.

**Testing**
- Added/updated config parsing coverage for the new recovery window settings.
- Adjusted maker runtime logic to preserve fail-closed behavior across reconnect and reconciliation paths.
- Not run (not requested).