### PR TITLE
Meter position-mismatch recovery against the recovery circuit breaker (#280)

### DIFF
--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -942,7 +942,12 @@ pub(super) async fn run_maker(
     let mut last_mark: Option<f64> = None;
     let mut last_src: Option<&'static str> = None;
     let recovery_clock_started = std::time::Instant::now();
-    let mut transport_recovery_breaker = maker::RecoveryCircuitBreaker::new(
+    // One rolling budget shared across every automatic recovery — account-stream
+    // reconnect, order-response reconnect, and position-mismatch freeze/recover.
+    // The operator's "N incidents per window" bounds total recovery churn before
+    // a human must step in; letting any one path recover unmetered would defeat
+    // that ceiling.
+    let mut recovery_breaker = maker::RecoveryCircuitBreaker::new(
         args.recovery_incidents_per_window,
         args.recovery_window_secs,
     );
@@ -1100,8 +1105,7 @@ pub(super) async fn run_maker(
                         format!("account stream disconnected ({detail}); reconnect disabled"),
                     );
                 }
-                let admission =
-                    transport_recovery_breaker.admit(recovery_clock_started.elapsed().as_secs());
+                let admission = recovery_breaker.admit(recovery_clock_started.elapsed().as_secs());
                 if !admission.is_admitted() {
                     break recovery_failed_exit(
                         &mut runtime_state,
@@ -1396,8 +1400,8 @@ pub(super) async fn run_maker(
                 } else if args.order_response_reconnect_attempts == 0 {
                     Some("safe reconnect is disabled".to_string())
                 } else {
-                    let admission = transport_recovery_breaker
-                        .admit(recovery_clock_started.elapsed().as_secs());
+                    let admission =
+                        recovery_breaker.admit(recovery_clock_started.elapsed().as_secs());
                     (!admission.is_admitted())
                         .then(|| format!("{}; circuit is open", recovery_circuit_detail(admission)))
                 };
@@ -2242,6 +2246,26 @@ pub(super) async fn run_maker(
                             );
                         }
                     };
+                    // Meter this recovery against the same rolling budget as the
+                    // transport reconnects. An oscillating mismatch source (a
+                    // second actor on the account, settlement jitter around the
+                    // tolerance boundary) would otherwise drive unbounded
+                    // freeze -> cancel-all -> backfill -> resume churn that the
+                    // circuit breaker exists to stop.
+                    let admission =
+                        recovery_breaker.admit(recovery_clock_started.elapsed().as_secs());
+                    if !admission.is_admitted() {
+                        break 'main recovery_failed_exit(
+                            &mut runtime_state,
+                            recovery_token,
+                            format!(
+                                "position mismatch (expected {:+.8}, observed {:+.8}); {}; refusing further live orders",
+                                mismatch.expected,
+                                mismatch.observed,
+                                recovery_circuit_detail(admission)
+                            ),
+                        );
+                    }
                     let mut recovered = false;
                     let mut last_observed = mismatch.observed;
                     for delay in [500_u64, 1_000, 1_500] {

--- a/crates/standx-maker/src/recovery.rs
+++ b/crates/standx-maker/src/recovery.rs
@@ -1,4 +1,5 @@
-//! Deterministic recovery admission policy for live transport incidents.
+//! Deterministic recovery admission policy for live recovery incidents
+//! (transport reconnects and position-mismatch freeze/recover alike).
 
 use std::collections::VecDeque;
 
@@ -38,9 +39,10 @@ impl RecoveryCircuitBreaker {
         }
     }
 
-    /// Admit one transport-recovery incident at monotonic `now_secs`.
-    /// Individual reconnect attempts are deliberately not recorded here; the
-    /// caller owns that bounded retry loop for the admitted incident.
+    /// Admit one recovery incident at monotonic `now_secs`.
+    /// The individual recovery attempts inside an admitted incident (reconnect
+    /// retries, the position-mismatch backfill loop) are deliberately not
+    /// recorded here; the caller owns that bounded work for the admitted incident.
     pub fn admit(&mut self, now_secs: u64) -> RecoveryAdmission {
         while self
             .incidents


### PR DESCRIPTION
Closes #280.

## 问题

滚动恢复熔断器(commit 127f693)只对两条恢复路径做准入检查——账户流重连、订单响应重连——**漏了仓位失配冻结→恢复路径**(`runtime.rs` 的 position-reconciliation 臂)。一个持续振荡的失配源(同账户上另一个 actor、围绕 qty 容差抖动的场内结算)可以驱动**无限** freeze → cancel-all → 3s backfill → resume churn,每轮发 warning/resolved 通知却永不升级、永不停机——而熔断器存在的意义正是收敛这种churn。

## 改动

- 在 position-reconciliation 恢复尝试前加 `admit()` 检查,与两条传输路径同构:熔断打开时走 `recovery_failed_exit` → 干净的 fail-safe 停机(critical webhook 由 shutdown 路径投递),而非继续churn。
- **三类恢复共享一个预算**。operator 的 "N 次恢复/窗口" 是对"人工介入前允许多少自动恢复churn"的总上限;每路径独立预算会让它翻倍。变量 `transport_recovery_breaker` → `recovery_breaker`,并同步更新 standx-maker recovery 模块 doc。

## 语义要点

- 每次失配仍执行**一次** freeze+cancel-all(失配时 book 必须清空);熔断器只 gate 后续的**恢复尝试**,所以churn 被收敛为 N 次撤单循环后一次 fail-safe 停机。
- admit 成功即记一次 incident——**即便恢复成功也记账**——因此"反复恢复成功再破"的振荡源同样会在 N 次后触发熔断。这是本修复能对抗振荡场景的关键。
- 熔断打开退出保持与两条传输路径一致的"安静退出"(仅 exit reason,不额外发 position 专属 `emit_reconciliation_state`/inline RiskNotice)——operator 通知由 shutdown 的 fail-safe critical webhook 覆盖。若评审认为 reconciliation-state JSON 流需要一条 frozen→failed 的收尾,可再补,但那会引入三条熔断退出之间的不对称。

## 验证

- `cargo fmt --check` / `clippy --workspace --all-targets -D warnings` / `cargo test --workspace`(全绿;熔断器语义由 standx-maker/src/recovery.rs 既有单测覆盖)
- Paper 实跑冒烟:报价循环 + Ctrl+C 干净收尾(exit 0)。失配路径为 live-only,无法在 paper 触发,正确性依赖编译期检查 + 与两条已评审传输路径同构 + 上述语义分析——合并前建议照常走一次监督下的 live 冒烟

来源:2026-07-15 maker 全面复审(三路并行,详见 #280)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)