### PR TITLE
Add baseline manifests for observed maker runs

### DIFF
--- a/docs/13-maker.md
+++ b/docs/13-maker.md
@@ -76,9 +76,13 @@ standx maker run <SYMBOL> [OPTIONS]
 | `--max-divergence-bps` | `25` | 当 mark 价与盘口中价背离超过此值时跳过该轮（不动挂单） |
 | `--vol-pause-bps` | `0` | 波动率熔断：mark 在 `--vol-window` 轮内的极差达到此值（bps）即撤掉全部报价暂停，回落到一半以下才恢复。0 关闭。见 [13.3](#波动率熔断) |
 | `--vol-window` | `12` | 波动率熔断测量极差的窗口（最近 N 轮） |
+| `--stop-loss` | `0` | 会话 PnL 跌到负阈值时 fail-safe：冻结、撤销 maker 单、等待 critical webhook 后停机；不会自动平仓。0 关闭 |
 | `--alert-loss` | `0` | 风险告警：mark-to-market PnL 跌到 −此值（计价单位）时告警。0 关闭 |
 | `--alert-inventory-pct` | `0` | 风险告警：\|仓位\| 达到 `--max-position` 的此百分比时告警。0 关闭 |
+| `--alert-position-change-pct` | `0` | 实际仓位相对通知锚点累计变化达到 `--max-position` 的此百分比时告警。0 关闭 |
 | `--alert-uptime` | `0` | 风险告警：双边 uptime 跌破此百分比时告警（过预热期后）。0 关闭 |
+| `--alert-equity-below` | `0` | 账户 equity 低于此绝对值时告警；仅 live、需要账户快照。0 关闭 |
+| `--alert-margin-below` | `0` | cross available margin 低于此绝对值时告警；仅 live。0 关闭 |
 | `--alert-webhook` | 无 | 除 stderr/JSON 外，把告警 POST 到此 URL |
 | `--alert-webhook-format` | `slack` | webhook 报文格式：`slack` / `feishu` / `telegram` / `raw` |
 | `--no-ws` | 关 | 禁用 WebSocket 行情，改为每轮 REST 轮询 |
@@ -221,13 +225,20 @@ live 启动时会先清理旧 `sxmk-` 订单并同步账本，再认证 `order +
 
 ### 风险告警
 
-遥测默认只**展示**指标；风险告警把它变成**主动通知**。三个阈值各自 opt-in（0 关闭）：
+遥测默认只**展示**指标；`alert_*` 把它变成**主动通知**。所有阈值各自 opt-in（0 关闭）：
 
 - `--alert-loss <X>`：mark-to-market PnL 跌到 −X 时告警（回升到 −X/2 以上解除）。
 - `--alert-inventory-pct <P>`：\|仓位\| 达到 `--max-position` 的 P% 时告警（跌回 0.9×P% 以下解除）——趋势市里最先亮的灯。
+- `--alert-position-change-pct <P>`：实际仓位相对上次通知锚点累计变化达到 `--max-position` 的 P% 时告警。
 - `--alert-uptime <U>`：双边 uptime 跌破 U% 时告警（前 20 轮预热期不判）。
+- `--alert-equity-below <X>`：live 账户 equity 低于 X 时告警，恢复到 1.1×X 以上解除。
+- `--alert-margin-below <X>`：live 账户 cross available margin 低于 X 时告警，恢复到 1.1×X 以上解除。
 
 告警是**边沿触发**的：进入异常态时响一次、恢复时响一次，不会每轮刷屏。输出到 stderr（`🚨 ALERT` / `✅ RESOLVED`）与 JSON（`action:"alert"`）；若设了 `--alert-webhook <url>`，还会 POST 一条 JSON（fire-and-forget，慢/坏的端点不会拖住报价循环）。
+
+`--stop-loss` 不是告警阈值，也不是止盈/自动平仓：它在会话 PnL 触线后执行 fail-safe
+停机，撤销 maker 自有挂单并交接残余仓位。`--inventory-exit-pct/qty` 才是正常运行中的
+reduce-only 主动库存退出，而且只在 live 生效；两者不能互相替代。
 
 `--alert-webhook-format` 按目标平台组织报文:
 

--- a/docs/15-openobserve.md
+++ b/docs/15-openobserve.md
@@ -49,9 +49,37 @@ scripts/run_maker_observed.sh \
 1. 为每次运行生成唯一 `run_id`。
 2. 将 stdout 写入 `var/standx/<run_id>.ndjson`。
 3. 将 stderr 写入 `var/standx/<run_id>.stderr.log`，同时保留终端显示。
-4. 转发 Ctrl+C/TERM 给 maker，并等待 lifecycle/cleanup 日志写完。
-5. 若 `OPENOBSERVE_AUTO_UPLOAD=1`，启动时验证 OpenObserve 连接，运行期间持续增量上传。
-6. maker 退出后等待 lifecycle/cleanup 落盘，再做最终补传。
+4. 将基线身份和结束完整性写入 `var/standx/<run_id>.manifest.json`，不修改 maker JSON。
+5. 转发 Ctrl+C/TERM 给 maker，并等待 lifecycle/cleanup 日志写完。
+6. 若 `OPENOBSERVE_AUTO_UPLOAD=1`，启动时验证 OpenObserve 连接，运行期间持续增量上传。
+7. maker 退出后等待 lifecycle/cleanup 落盘，再做最终补传。
+
+sidecar manifest 包含完整 `git_sha`、整仓 dirty paths、策略/运行时 source dirty paths、实际
+执行程序 SHA-256、采集脚本 SHA-256、配置内容哈希、非敏感 CLI 策略覆盖、symbol、UTC
+时间窗、日志 SHA-256、cycle 缺口、lifecycle 完整性和统一 regime 摘要。摘要包括首末/
+极值 mark、净移动/range bps、directionality、halt/fallback、最大 `vol_bps`、fills 和
+平均 uptime；包装器不会记录 webhook、凭据或完整原始命令。若要把 run 晋级为阶段 0
+baseline，还需在启动前从权威 symbol metadata 填入：
+
+```bash
+export STANDX_BASELINE_PRICE_TICK_DECIMALS=2
+export STANDX_BASELINE_QTY_TICK_DECIMALS=4
+export STANDX_BASELINE_MIN_ORDER_QTY=0.0001
+```
+
+`standx-maker/standx-sdk/standx-cli`、Cargo 锁定文件和本次使用的通用 maker 配置必须相对
+`git_sha` clean；文档或采集脚本本身可以处于待提交状态，但完整 dirty paths 会保留，实际
+参与采集的脚本还会记录 collector SHA-256。策略源码不 clean、缺少身份字段、存在非法 JSON/缺 cycle、缺
+`started/stopped` lifecycle 或进程非零退出时，manifest 会令
+`validation.baseline_eligible=false`，不会静默纳入比较基线。
+
+采集后重新核对 manifest 判定和原始日志哈希：
+
+```bash
+python3 scripts/maker_run_manifest.py validate \
+  --manifest var/standx/<run_id>.manifest.json \
+  --repo-root .
+```
 
 终端看到以下信息表示启动检查和实时上传正常：
 

--- a/docs/18-maker-strategy-roadmap.md
+++ b/docs/18-maker-strategy-roadmap.md
@@ -60,6 +60,9 @@ python3 -m py_compile scripts/openobserve_dashboard.py
 
 ## 阶段 0：基线与证据校准
 
+当前执行记录：
+[maker-strategy-stage-0-baseline-2026-07-15.md](evidence/maker-strategy-stage-0-baseline-2026-07-15.md)。
+
 ### 目标
 
 在不改变交易行为的前提下，建立后续 A/B 比较的唯一基线，消除配置、注释和 live 证据之间
@@ -73,14 +76,27 @@ python3 -m py_compile scripts/openobserve_dashboard.py
 - 盘点已有 paper/live 日志，登记可用于回放的数据字段和缺口。
 - 保持通用 `examples/maker.toml` 的主动库存退出默认关闭。
 
+### Trace 分类口径
+
+阶段 0 的市场分类只用于组织数据集，不改变策略阈值。可比较窗口至少包含 300 个连续
+`cycle_summary` 且覆盖 600 秒；不足时只能作为身份/采集校准 run。分类按以下优先级执行：
+
+1. 快速波动/压力：`max_vol_bps >= 50`，或存在 halted cycle 且窗口 range ≥ 50bps；
+2. 趋势：`|net_move_bps| >= 75`、`|net_move_bps| / range_bps >= 0.7` 且无 halted cycle；
+3. 平静：range ≤ 10bps 且 `|net_move_bps| <= 5`；
+4. 其余或必需字段缺失：`unclassified`。
+
+其中 range 使用 `(max_mark - min_mark) / min_mark`，net move 使用
+`(end_mark / start_mark - 1)`。分类结果必须连同原始值记录，不能只保存标签。
+
 ### 验收标准
 
-- [ ] 每个用于比较的基线 run 都能追溯到 `git_sha + config_hash + symbol + time range`。
-- [ ] 同一配置值在 TOML 注释、maker 文档和 live-gate evidence 中不存在冲突。
-- [ ] 已生产验证与未验证的 inventory-exit tuple 分开标注；未验证 tuple 不宣称可用于 live。
-- [ ] 文档明确说明 `alert_*` 只通知，`stop_loss` 会 fail-safe 停机但不会自动平仓。
-- [ ] 形成至少一份平静、一份趋势和一份快速波动 trace 清单；缺失字段有显式记录。
-- [ ] 不改变报价、退出、PnL、风控和 JSON 行为；标准离线验证全部通过。
+- [x] 每个用于比较的基线 run 都能追溯到 `git_sha + config_hash + symbol + time range`。
+- [x] 同一配置值在 TOML 注释、maker 文档和 live-gate evidence 中不存在冲突。
+- [x] 已生产验证与未验证的 inventory-exit tuple 分开标注；未验证 tuple 不宣称可用于 live。
+- [x] 文档明确说明 `alert_*` 只通知，`stop_loss` 会 fail-safe 停机但不会自动平仓。
+- [x] 形成至少一份平静、一份趋势和一份快速波动 trace 清单；缺失字段有显式记录。
+- [x] 不改变报价、退出、PnL、风控和 JSON 行为；标准离线验证全部通过。
 
 ## 阶段 1：绩效账本与确定性回放
 

--- a/docs/evidence/maker-strategy-stage-0-baseline-2026-07-15.md
+++ b/docs/evidence/maker-strategy-stage-0-baseline-2026-07-15.md
@@ -1,0 +1,170 @@
+# Maker 策略阶段 0 基线记录 — 2026-07-15
+
+## 状态与目标
+
+- 阶段：0 — 基线与证据校准
+- 状态：`accepted`
+- 目标：在不改变交易行为的前提下，冻结可追溯基线、消除参数说明冲突，并形成三类市场
+  trace 清单，供阶段 1 的确定性回放和后续策略 A/B 共用。
+- live 授权范围：`none`
+- 策略行为变更：`none`
+
+本记录只校准配置、文档和已有证据。它不授权 live 运行，不把历史 canary 扩展为新的
+参数批准，也不把缺少原始 trace 的摘要当成可回放数据。
+
+## 冻结基线
+
+阶段 0 策略/运行时基线锁定为提交 `ccdcf3191f206c17dda89105de0ee9346ff563d4`。
+以下哈希是阶段 0 验收时的工作树内容 SHA-256；除 conservative profile 的说明注释校准外，
+数值配置与该提交一致。最终 paper run 实际使用的 `examples/maker.toml` 与基线提交逐字节一致。
+比较运行如果使用 CLI 覆盖项，还必须另外记录完整的非敏感参数覆盖，不能只引用文件哈希。
+
+| 配置 | SHA-256 | 用途 | live 验证状态 |
+|---|---|---|---|
+| `examples/maker.toml` | `37a63617b5438d949415eacc26487020cd0a35299ea2f8bddc7b1655ea9d62dd` | 通用 paper 基线；主动退出 `0 / 0` | 不作为 live profile |
+| `examples/maker-xag-100u.toml` | `0573e99a15375e6caeb95f78a467501be41a69201e89cafbbb2e57fefdb59740` | XAG 历史参考 profile；退出 `25% / 0.2` | 仅该 exact tuple 有 2026-07-10 生产证据 |
+| `examples/maker-xag-100u-conservative.toml` | `336fb9b507845ab8535291da4b14bd77eab9cc817451895f71e5342643b4b838` | XAG 保守 profile；退出 `50% / 0.2`；仅注释校准 | exact tuple 未验证 |
+| `examples/maker-xag-100u-standard.toml` | `50194d1bebc0c79a424c3365754147c144173ba3442f38281b1abd6138715ea1` | XAG 标准 profile；退出 `25% / 0.3` | exact tuple 未验证 |
+
+最终身份校准 run 使用 `ccdcf31 + examples/maker.toml + BTC-USD + paper`：
+
+| 字段 | 记录值 |
+|---|---|
+| `run_id` | `stage0-btc-paper-built-20260715` |
+| UTC 窗口 | `2026-07-15T06:37:12Z–06:38:10Z`（58 秒） |
+| git/config | `ccdcf3191f206c17dda89105de0ee9346ff563d4` / `37a63617...d62dd` |
+| program SHA-256 | `226403cab6275c20f729a2733087581a4855038c9eef5b87dd2afccaca3f4301` |
+| collector SHA-256 | manifest `1098680c...8ce64`；wrapper `9a59ecd4...70a` |
+| raw NDJSON SHA-256 | `fdc999d6528675f45f38cc2e99347e72d814cf13186bf4ea96599e02bb1f0a94` |
+| symbol metadata | price decimals `2`；qty decimals `4`；min qty `0.0001` |
+| 完整性 | 43 cycles（`0..42`）；无缺失/重复；时间单调；started/stopped；exit `0` |
+| paper 结果 | 2 simulated fills；final position `+0.002`；uptime `100%`；PnL `-0.10147` |
+| 数据质量 | 32/43 cycle 使用 REST fallback，其中 31 次为 `ws_server_time_skew` |
+
+该 run 在执行前通过 `cargo build -p standx-cli --offline` 显式重建程序。策略/运行时 source
+相对基线提交 clean；整仓 dirty paths 仅为本阶段文档、采集工具和 XAG 注释校准，均在
+manifest 中列出，实际参与运行的 collector 文件另有内容哈希。`validation.baseline_eligible=true`，但因窗口不足
+300 cycles / 600 秒，`comparison_window_eligible=false`；它只证明身份和采集闭环，不作为
+长期绩效样本。
+
+每个后续比较 run 必须继续记录：
+
+- `run_id`、完整 40 位 `git_sha`、配置内容哈希和非敏感 CLI override；
+- 整仓/策略源码 dirty paths、实际执行程序及采集脚本 SHA-256；
+- symbol、`price_tick_decimals`、`qty_tick_decimals`、`min_order_qty`；
+- UTC 起止时间、模式、行情来源和原始 NDJSON SHA-256；
+- lifecycle 是否完整、cycle 数、缺失序号和终止原因。
+
+2026-07-15 已从 StandX 公共 symbol-info 接口只读确认 BTC-USD 当时的 metadata：
+`price_tick_decimals=2`、`qty_tick_decimals=4`、`min_order_qty=0.0001`、状态 `trading`。
+这些值用于本次 baseline 的启动快照；未来 run 仍须重新读取，不能永久沿用本次结果。
+
+## 配置与语义校准
+
+| 项目 | 当前权威语义 | 校准结果 |
+|---|---|---|
+| 通用主动退出默认值 | `examples/maker.toml` 为 `0 / 0`，默认关闭 | 与 `13-maker.md` 一致 |
+| 已验证 XAG 退出 tuple | 仅 `max_position=0.8, pct=25, qty=0.2` | 与 2026-07-10 live-gate evidence 一致 |
+| XAG conservative tuple | `0.8 / 50 / 0.2` | 参数不变；注释已改为“exact tuple 未验证” |
+| XAG standard tuple | `1.2 / 25 / 0.3` | 已明确是按比例扩展、未做 exact-tuple live 验证 |
+| `alert_*` | 边沿触发通知，不改变报价/退出决策 | 已在 maker 文档分开列出 |
+| `stop_loss` | 会话 PnL 触线后 freeze、maker cleanup、critical webhook、停机 | 已明确不会自动平仓 |
+| 正常库存退出 | live-only reduce-only chunk，先确认 maker 空簿 | 与 stop-loss/fail-safe 分开 |
+| 残余仓位 | 停机后明确 handoff；当前没有默认自动 flatten | 与 live-gate/canary 证据一致 |
+
+## Trace 分类口径
+
+分类只组织数据集，不改变 maker 行为。窗口至少 300 个连续 cycle 且覆盖 600 秒；优先级为
+快速波动/压力、趋势、平静、未分类：
+
+- 快速波动/压力：`max_vol_bps >= 50`，或 halted cycle > 0 且 range ≥ 50bps；
+- 趋势：`|net move| >= 75bps`、directionality（`|net| / range`）≥ 0.7，且无 halted cycle；
+- 平静：range ≤ 10bps 且 `|net move| <= 5bps`；
+- 缺字段或不满足上述条件：`unclassified`。
+
+range 和 net move 分别按 `(max-min)/min` 与 `(end/start-1)` 计算，报告必须保存原值。
+
+## 三类 trace 清单与字段缺口
+
+| 市场类型 | 现有证据 | 身份信息 | 可用性与缺口 |
+|---|---|---|---|
+| 平静/窄幅 | `xag-live-20260711T013747Z`；XAG-USD；6120 cycles；`01:37:54–07:06:04Z` | range `6.68bps`；net `-1.67bps`；0 halted | git `957f1567a217f5dd2b189580775d82f44fbe4fea`；config `43629a9c...e84`；source `xag-live-20260711T013747Z.ndjson` |
+| 单边趋势/库存累积 | `xag-live-20260713T071547Z`；XAG-USD；1266 cycles；`07:16:11–08:26:42Z` | `58.23→58.88`；net `+111.63bps`；range `137.48bps`；directionality `0.812`；0 halted | git `4ae5d91c41f377b0f384921f3a3c8421b7c33461`；config `f94a15f2...77fa`；source `xag-live-20260713T071547Z.ndjson` |
+| 快速波动/压力 | `20260710T141618Z-3940793`；XAG-USD；1043 cycles；`14:16:24–15:13:14Z` | range `119.69bps`；max vol `116.81bps`；11 halted；net `-25.08bps` | git `563568cf89ab6dd54f7dbec01c4f2084e0907ba1`；config `3ec0e8a0...ce3f`；source `20260710T141618Z-3940793.ndjson` |
+
+三份 trace 的 `config_hash` 均已与对应完整 git commit 内的
+`examples/maker-xag-100u.toml` 逐字节 SHA-256 匹配。核心 cycle 字段 `mark/best_bid/
+best_ask/position/pnl/uptime_pct` 缺失数均为 0，事件以 `event_id` 去重。
+
+明确缺口：三份历史 trace 产生于 `market_source` 字段加入前，因此该字段全部缺失，不能
+分析 WS/REST 来源占比；原始 NDJSON 不在当前 checkout，OpenObserve 只保留 `source_file`
+和事件，无法补算原文件 SHA-256；也没有阶段 1 所需的完整 normalized market/account trace、
+fee/funding、markout、时间加权 quote interval 或 place/cancel 生命周期时间点。它们可用于
+阶段 0 regime 清单与阶段 1 schema 设计，不得伪装成已经可确定性回放的数据集。
+
+2026-07-10/14 的生产 canary 用于验证认证、命令关联、清理和 fail-closed 行为，不作为策略
+绩效基线。它们的市场窗口太短，且实验目标不是采集可回放的市场/account trace。
+
+现有 `cycle_summary` 可提供 cycle、symbol、mark/touch、position、PnL、fills、uptime、
+capture、halt/vol 和动作计数；阶段 1 所需而当前缺失的主要字段包括：完整 normalized market
+trace、有效配置快照、费用/funding、成交后 1s/5s/30s mark、时间加权 quote intervals，
+以及 place/cancel 生命周期时间点。
+
+## 阶段 0 验收进度
+
+- [x] 每个比较 run 可追溯到 `git_sha + config_hash + symbol + time range`；新 paper 校准 run
+  的 manifest 与日志哈希复验通过。
+- [x] TOML 注释、maker 文档和 live-gate evidence 的已知 tuple 冲突已消除。
+- [x] 已生产验证与未验证的 inventory-exit tuple 已分开标注。
+- [x] 已明确 `alert_*` 只通知，`stop_loss` fail-safe 停机但不自动平仓。
+- [x] 已登记互不重叠的平静、趋势和快速波动窗口，并显式记录 schema/artifact 缺口。
+- [x] 未改变报价、退出、PnL、风控或 maker JSON；标准离线验证全部通过。
+
+## 本批验证结果
+
+- `python3 scripts/test_maker_run_manifest.py`：4 个用例通过，覆盖敏感参数排除、完整 trace
+  晋级、日志篡改拒绝、缺 cycle/lifecycle/metadata 拒绝和三类 regime 口径。
+- 包装器合成日志联调：manifest 正确记录 config/override/program/collector/log 哈希和
+  生命周期。该合成日志只验证工具链，不列入三类市场 trace。
+- `HOME=/tmp/standx-test-home CARGO_HOME=~/.cargo cargo test --workspace --offline`：通过。
+  受限沙箱内 mockito 无法绑定 loopback，允许本机回环后同一离线命令全部通过；没有访问
+  生产接口或执行订单。
+- `cargo clippy --workspace --all-targets --offline -- -D warnings`：通过。
+- `cargo fmt --all -- --check`：通过。
+- `python3 -m py_compile scripts/openobserve_dashboard.py scripts/maker_run_manifest.py
+  scripts/test_maker_run_manifest.py`：通过。
+- `bash -n scripts/run_maker_observed.sh` 与 `git diff --check`：通过。
+
+阶段 0 已满足以下条件：
+
+1. 生成至少一份完整的新 paper baseline manifest，证明身份字段可复查；
+2. 登记三类互不重叠的历史 trace，并把缺失的原始 artifact/schema 字段显式标为不可用；
+3. 对新 baseline 计算文件哈希并验证 lifecycle/序号完整性；历史 trace 使用唯一
+   `run_id + source_file + event_id` 集合，不虚构当前已不存在的原文件哈希；
+4. 通过仓库标准离线验证。
+
+## 阶段 1 交接
+
+1. 回放 schema 必须补齐 normalized market/account events，不能直接把旧 `cycle_summary`
+   当成完整输入 trace。
+2. 新 trace 继续使用 sidecar manifest；没有可证明 regime 的数据保持 `unclassified`。
+3. 先解决/解释当前 paper 校准 run 中高比例 `ws_server_time_skew` fallback，再把新的长窗口
+   用作策略绩效比较；这不会阻止阶段 0 身份校准验收。
+
+## 阶段状态模板
+
+```text
+阶段：0
+状态：accepted
+baseline_git_sha：ccdcf3191f206c17dda89105de0ee9346ff563d4
+candidate_git_sha：worktree over ccdcf3191f206c17dda89105de0ee9346ff563d4 (strategy source clean)
+baseline_config_hash：37a63617b5438d949415eacc26487020cd0a35299ea2f8bddc7b1655ea9d62dd
+candidate_config_hash：same (no strategy config change)
+训练数据窗口：none（阶段 0 不调参）
+样本外验收窗口：N/A（阶段 0 不调参）；已登记 calm / trend / fast_or_stressed 三个历史窗口
+专项指标结果：baseline manifest PASS；三类 trace 清单完成；缺口已登记
+统一安全门槛结果：no strategy/runtime behavior change
+离线验证结果：PASS（workspace test / clippy / fmt / Python compile / shell syntax）
+live 授权范围（如无则写 none）：none
+release owner 决定：N/A；阶段 0 工程验收通过，不改变 live gate
+```

--- a/examples/maker-xag-100u-conservative.toml
+++ b/examples/maker-xag-100u-conservative.toml
@@ -5,12 +5,13 @@
 #     --maker-config examples/maker-xag-100u-conservative.toml \
 #     --live --yes
 #
-# Set isolated 2x leverage separately. Quote geometry and the active-exit
-# tuple are unchanged from the production-tested maker-xag-100u.toml profile
-# (max_position=0.8, inventory_exit_pct=25, inventory_exit_qty=0.2); this
-# variant only tightens the financial brakes on top of it. Around a 58.9
-# mark the full inventory is ~47 DUSD notional (~24% of 2x capacity) with
-# ~24 DUSD isolated margin, ~30 including one resting quote per side.
+# Set isolated 2x leverage separately. Quote geometry is unchanged from the
+# production-tested maker-xag-100u.toml profile, but this profile delays the
+# active-exit trigger from 25% to 50%. The exact (max_position=0.8,
+# inventory_exit_pct=50, inventory_exit_qty=0.2) tuple has NOT been validated
+# live. Around a 58.9 mark the full inventory is ~47 DUSD notional (~24% of
+# 2x capacity) with ~24 DUSD isolated margin, ~30 including one resting quote
+# per side.
 #
 # Pre-existing XAG inventory up to max_position is adopted automatically at
 # the startup mark, so maker-session PnL starts at zero. Larger inventory is
@@ -32,8 +33,7 @@ max_divergence_bps = 6.0
 vol_pause_bps = 30.0
 vol_window = 20
 
-# Supervised active inventory exit (production-tested tuple, do not scale
-# without re-validation)
+# Supervised active inventory exit (exact 50% / 0.2 tuple is not live-validated)
 inventory_exit_pct = 50.0
 inventory_exit_qty = 0.2
 

--- a/scripts/maker_run_manifest.py
+++ b/scripts/maker_run_manifest.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Create and finalize a reproducible maker-run sidecar manifest.
+
+The manifest is intentionally separate from maker stdout so baseline identity
+can improve without changing the established maker JSON event contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any, Sequence
+
+
+SCHEMA_VERSION = "maker_baseline_manifest_v1"
+STRATEGY_SOURCE_PATHS = (
+    "Cargo.toml",
+    "Cargo.lock",
+    "crates/standx-maker",
+    "crates/standx-sdk",
+    "crates/standx-cli",
+    "examples/maker.toml",
+)
+VALUE_OVERRIDES = {
+    "--spread-bps",
+    "--band-bps",
+    "--size",
+    "--levels",
+    "--level-step-bps",
+    "--refresh-bps",
+    "--interval",
+    "-i",
+    "--max-position",
+    "--skew-bps",
+    "--inventory-exit-pct",
+    "--inventory-exit-qty",
+    "--max-divergence-bps",
+    "--vol-pause-bps",
+    "--vol-window",
+    "--stop-loss",
+    "--alert-loss",
+    "--alert-inventory-pct",
+    "--alert-position-change-pct",
+    "--alert-uptime",
+    "--alert-equity-below",
+    "--alert-margin-below",
+    "--order-response-reconnect-attempts",
+    "--order-response-reconnect-backoff",
+    "--account-stream-reconnect-attempts",
+    "--account-stream-reconnect-backoff",
+    "--recovery-incidents-per-window",
+    "--recovery-window-secs",
+}
+BOOLEAN_OVERRIDES = {"--no-ws"}
+REQUIRED_CHECKS = {
+    "git_sha_present",
+    "strategy_source_clean",
+    "program_hash_present",
+    "collector_hashes_present",
+    "config_hash_present",
+    "symbol_present",
+    "symbol_matches_events",
+    "symbol_metadata_complete",
+    "time_range_present",
+    "timestamps_monotonic",
+    "json_only",
+    "cycle_sequence_complete",
+    "lifecycle_started",
+    "lifecycle_stopped",
+}
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def git_sha(repo_root: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    value = result.stdout.strip()
+    return value if result.returncode == 0 and len(value) == 40 else None
+
+
+def git_dirty_paths(repo_root: Path, paths: Sequence[str] = ()) -> list[str] | None:
+    command = ["git", "-C", str(repo_root), "status", "--porcelain", "--untracked-files=all"]
+    if paths:
+        command.extend(["--", *paths])
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return [line[3:] for line in result.stdout.splitlines() if len(line) > 3]
+
+
+def program_identity(command: Sequence[str], repo_root: Path) -> dict[str, str | None]:
+    if not command:
+        return {"path": None, "sha256": None}
+    executable = command[0]
+    located = shutil.which(executable)
+    path = Path(located) if located else Path(executable)
+    if not path.is_absolute():
+        path = repo_root / path
+    resolved = path.resolve()
+    return {
+        "path": display_path(resolved, repo_root),
+        "sha256": sha256_file(resolved) if resolved.is_file() else None,
+    }
+
+
+def collector_identity(wrapper: Path | None, repo_root: Path) -> dict[str, Any]:
+    tool = Path(__file__).resolve()
+    wrapper_path = wrapper.resolve() if wrapper else None
+    return {
+        "manifest_tool": {
+            "path": display_path(tool, repo_root),
+            "sha256": sha256_file(tool),
+        },
+        "wrapper": {
+            "path": display_path(wrapper_path, repo_root) if wrapper_path else None,
+            "sha256": sha256_file(wrapper_path)
+            if wrapper_path and wrapper_path.is_file()
+            else None,
+        },
+    }
+
+
+def maker_symbol(command: Sequence[str]) -> str | None:
+    for index in range(len(command) - 2):
+        if command[index] == "maker" and command[index + 1] == "run":
+            candidate = command[index + 2]
+            return candidate if not candidate.startswith("-") else None
+    return None
+
+
+def strategy_overrides(command: Sequence[str]) -> dict[str, Any]:
+    """Return only known non-sensitive strategy flags from a maker command."""
+    result: dict[str, Any] = {}
+    index = 0
+    while index < len(command):
+        arg = command[index]
+        if arg in BOOLEAN_OVERRIDES:
+            result[arg.removeprefix("--").replace("-", "_")] = True
+        elif arg in VALUE_OVERRIDES and index + 1 < len(command):
+            key = "interval" if arg == "-i" else arg.removeprefix("--").replace("-", "_")
+            result[key] = command[index + 1]
+            index += 1
+        elif "=" in arg:
+            name, value = arg.split("=", 1)
+            if name in VALUE_OVERRIDES:
+                result[name.removeprefix("--").replace("-", "_")] = value
+        index += 1
+    return result
+
+
+def display_path(path: Path, repo_root: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(repo_root.resolve()))
+    except ValueError:
+        return str(resolved)
+
+
+def atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def parse_event_timestamp(value: Any) -> tuple[str, float] | None:
+    try:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            parsed = dt.datetime.fromtimestamp(value, dt.timezone.utc)
+        elif isinstance(value, str) and value:
+            parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                return None
+            parsed = parsed.astimezone(dt.timezone.utc)
+        else:
+            return None
+    except (OverflowError, OSError, ValueError):
+        return None
+    return parsed.isoformat().replace("+00:00", "Z"), parsed.timestamp()
+
+
+def finite_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isfinite(parsed):
+        return parsed
+    return None
+
+
+def classify_regime(metrics: dict[str, Any], cycles: int, duration_seconds: float | None) -> str:
+    if cycles < 30 or duration_seconds is None or duration_seconds < 30:
+        return "insufficient_window"
+    range_bps = metrics.get("range_bps")
+    net_move_bps = metrics.get("net_move_bps")
+    directionality = metrics.get("directionality")
+    max_vol_bps = metrics.get("max_vol_bps")
+    halted_cycles = metrics.get("halted_cycles", 0)
+    if max_vol_bps is not None and max_vol_bps >= 50:
+        return "fast_or_stressed"
+    if halted_cycles > 0 and range_bps is not None and range_bps >= 50:
+        return "fast_or_stressed"
+    if (
+        net_move_bps is not None
+        and abs(net_move_bps) >= 75
+        and directionality is not None
+        and directionality >= 0.7
+        and halted_cycles == 0
+    ):
+        return "trend"
+    if (
+        range_bps is not None
+        and range_bps <= 10
+        and net_move_bps is not None
+        and abs(net_move_bps) <= 5
+    ):
+        return "calm"
+    return "unclassified"
+
+
+def analyze_log(path: Path) -> dict[str, Any]:
+    cycles: set[int] = set()
+    cycle_counts: dict[int, int] = {}
+    lifecycle_events: list[str] = []
+    symbols: set[str] = set()
+    market_sources: set[str] = set()
+    first_timestamp: str | None = None
+    last_timestamp: str | None = None
+    first_timestamp_epoch: float | None = None
+    last_timestamp_epoch: float | None = None
+    prior_timestamp_epoch: float | None = None
+    timestamp_regressions = 0
+    marks: list[float] = []
+    uptime_values: list[float] = []
+    max_fills_total = 0
+    halted_cycles = 0
+    fallback_cycles = 0
+    max_vol_bps: float | None = None
+    market_source_counts: dict[str, int] = {}
+    fallback_reason_counts: dict[str, int] = {}
+    json_lines = 0
+    invalid_lines = 0
+
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if not isinstance(event, dict):
+                invalid_lines += 1
+                continue
+            json_lines += 1
+            timestamp = parse_event_timestamp(event.get("ts"))
+            if timestamp is not None:
+                formatted_timestamp, timestamp_epoch = timestamp
+                first_timestamp = first_timestamp or formatted_timestamp
+                first_timestamp_epoch = (
+                    first_timestamp_epoch if first_timestamp_epoch is not None else timestamp_epoch
+                )
+                last_timestamp = formatted_timestamp
+                last_timestamp_epoch = timestamp_epoch
+                if prior_timestamp_epoch is not None and timestamp_epoch < prior_timestamp_epoch:
+                    timestamp_regressions += 1
+                prior_timestamp_epoch = timestamp_epoch
+            symbol = event.get("symbol")
+            if isinstance(symbol, str) and symbol:
+                symbols.add(symbol)
+            source = event.get("market_source")
+            if isinstance(source, str) and source:
+                market_sources.add(source)
+                market_source_counts[source] = market_source_counts.get(source, 0) + 1
+            if event.get("action") == "cycle_summary" and isinstance(event.get("cycle"), int):
+                cycle = event["cycle"]
+                cycles.add(cycle)
+                cycle_counts[cycle] = cycle_counts.get(cycle, 0) + 1
+                mark = finite_float(event.get("mark"))
+                if mark is not None and mark > 0:
+                    marks.append(mark)
+                uptime = finite_float(event.get("uptime_pct"))
+                if uptime is not None:
+                    uptime_values.append(uptime)
+                fills_total = event.get("fills_total")
+                if isinstance(fills_total, int):
+                    max_fills_total = max(max_fills_total, fills_total)
+                if event.get("halted") is True:
+                    halted_cycles += 1
+                fallback_reason = event.get("market_fallback_reason")
+                if isinstance(fallback_reason, str) and fallback_reason:
+                    fallback_cycles += 1
+                    fallback_reason_counts[fallback_reason] = (
+                        fallback_reason_counts.get(fallback_reason, 0) + 1
+                    )
+                vol_bps = finite_float(event.get("vol_bps"))
+                if vol_bps is not None:
+                    max_vol_bps = vol_bps if max_vol_bps is None else max(max_vol_bps, vol_bps)
+            if event.get("action") == "lifecycle" and isinstance(event.get("event"), str):
+                lifecycle_events.append(event["event"])
+
+    cycle_min = min(cycles) if cycles else None
+    cycle_max = max(cycles) if cycles else None
+    missing_cycles = (
+        sorted(set(range(cycle_min, cycle_max + 1)) - cycles)
+        if cycle_min is not None and cycle_max is not None
+        else []
+    )
+    duplicate_cycles = sorted(cycle for cycle, count in cycle_counts.items() if count > 1)
+    duration_seconds = (
+        last_timestamp_epoch - first_timestamp_epoch
+        if last_timestamp_epoch is not None and first_timestamp_epoch is not None
+        else None
+    )
+    start_mark = marks[0] if marks else None
+    end_mark = marks[-1] if marks else None
+    min_mark = min(marks) if marks else None
+    max_mark = max(marks) if marks else None
+    net_move_bps = (
+        (end_mark / start_mark - 1) * 10_000
+        if start_mark is not None and end_mark is not None
+        else None
+    )
+    range_bps = (
+        (max_mark - min_mark) / min_mark * 10_000
+        if min_mark is not None and max_mark is not None
+        else None
+    )
+    directionality = (
+        abs(net_move_bps) / range_bps
+        if net_move_bps is not None and range_bps is not None and range_bps > 0
+        else None
+    )
+    regime_metrics = {
+        "start_mark": start_mark,
+        "end_mark": end_mark,
+        "min_mark": min_mark,
+        "max_mark": max_mark,
+        "net_move_bps": net_move_bps,
+        "range_bps": range_bps,
+        "directionality": directionality,
+        "halted_cycles": halted_cycles,
+        "fallback_cycles": fallback_cycles,
+        "max_vol_bps": max_vol_bps,
+        "avg_uptime_pct": sum(uptime_values) / len(uptime_values) if uptime_values else None,
+        "fills_total": max_fills_total,
+    }
+    regime = classify_regime(regime_metrics, len(cycles), duration_seconds)
+    return {
+        "sha256": sha256_file(path),
+        "bytes": path.stat().st_size,
+        "json_lines": json_lines,
+        "invalid_lines": invalid_lines,
+        "first_event_at": first_timestamp,
+        "last_event_at": last_timestamp,
+        "duration_seconds": duration_seconds,
+        "timestamp_regressions": timestamp_regressions,
+        "symbols": sorted(symbols),
+        "market_sources": sorted(market_sources),
+        "market_source_counts": market_source_counts,
+        "fallback_reason_counts": fallback_reason_counts,
+        "cycle_summaries": len(cycles),
+        "cycle_summary_lines": sum(cycle_counts.values()),
+        "cycle_min": cycle_min,
+        "cycle_max": cycle_max,
+        "missing_cycles": missing_cycles,
+        "duplicate_cycles": duplicate_cycles,
+        "lifecycle_events": lifecycle_events,
+        "regime": regime,
+        "regime_metrics": regime_metrics,
+        "comparison_window_eligible": len(cycles) >= 300
+        and duration_seconds is not None
+        and duration_seconds >= 600,
+    }
+
+
+def start_manifest(args: argparse.Namespace) -> int:
+    repo_root = args.repo_root.resolve()
+    config_file = args.config_file.resolve() if args.config_file else None
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    symbol = maker_symbol(command)
+    worktree_dirty_paths = git_dirty_paths(repo_root)
+    strategy_dirty_paths = git_dirty_paths(repo_root, STRATEGY_SOURCE_PATHS)
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "running",
+        "run_id": args.run_id,
+        "started_at": utc_now(),
+        "git_sha": git_sha(repo_root),
+        "git_dirty": bool(worktree_dirty_paths) if worktree_dirty_paths is not None else None,
+        "git_dirty_paths": worktree_dirty_paths,
+        "strategy_source_paths": list(STRATEGY_SOURCE_PATHS),
+        "strategy_dirty_paths": strategy_dirty_paths,
+        "symbol": symbol,
+        "mode": "live" if "--live" in command else "paper",
+        "program": program_identity(command, repo_root),
+        "collector": collector_identity(args.collector_wrapper, repo_root),
+        "config": {
+            "path": display_path(config_file, repo_root) if config_file else None,
+            "sha256": sha256_file(config_file) if config_file and config_file.is_file() else None,
+            "strategy_overrides": strategy_overrides(command),
+        },
+        "symbol_metadata": {
+            "price_tick_decimals": args.price_tick_decimals,
+            "qty_tick_decimals": args.qty_tick_decimals,
+            "min_order_qty": args.min_order_qty,
+        },
+        "log": {"path": display_path(args.log, repo_root)},
+    }
+    atomic_write(args.manifest, payload)
+    return 0
+
+
+def finalize_manifest(args: argparse.Namespace) -> int:
+    payload = json.loads(args.manifest.read_text(encoding="utf-8"))
+    log = analyze_log(args.log)
+    declared_symbol = payload.get("symbol")
+    symbol_match = not log["symbols"] or log["symbols"] == [declared_symbol]
+    metadata = payload.get("symbol_metadata", {})
+    collector = payload.get("collector", {})
+    checks = {
+        "git_sha_present": isinstance(payload.get("git_sha"), str) and len(payload["git_sha"]) == 40,
+        "strategy_source_clean": payload.get("strategy_dirty_paths") == [],
+        "program_hash_present": isinstance(payload.get("program", {}).get("sha256"), str),
+        "collector_hashes_present": isinstance(
+            collector.get("manifest_tool", {}).get("sha256"), str
+        )
+        and isinstance(collector.get("wrapper", {}).get("sha256"), str),
+        "config_hash_present": isinstance(payload.get("config", {}).get("sha256"), str),
+        "symbol_present": isinstance(declared_symbol, str) and bool(declared_symbol),
+        "symbol_matches_events": symbol_match,
+        "symbol_metadata_complete": all(metadata.get(key) is not None for key in metadata),
+        "time_range_present": bool(log["first_event_at"] and log["last_event_at"]),
+        "timestamps_monotonic": log["timestamp_regressions"] == 0,
+        "json_only": log["invalid_lines"] == 0,
+        "cycle_sequence_complete": bool(log["cycle_summaries"])
+        and not log["missing_cycles"]
+        and not log["duplicate_cycles"],
+        "lifecycle_started": "started" in log["lifecycle_events"],
+        "lifecycle_stopped": "stopped" in log["lifecycle_events"],
+    }
+    payload.update(
+        {
+            "status": "finished",
+            "completed_at": utc_now(),
+            "exit_status": args.exit_status,
+            "log": {**payload.get("log", {}), **log},
+            "validation": {
+                "checks": checks,
+                "baseline_eligible": args.exit_status == 0 and all(checks.values()),
+            },
+        }
+    )
+    atomic_write(args.manifest, payload)
+    return 0
+
+
+def validate_manifest(args: argparse.Namespace) -> int:
+    payload = json.loads(args.manifest.read_text(encoding="utf-8"))
+    errors: list[str] = []
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        errors.append("unsupported schema_version")
+    validation = payload.get("validation", {})
+    checks = validation.get("checks", {})
+    missing_checks = REQUIRED_CHECKS - set(checks)
+    errors.extend(f"missing check: {name}" for name in sorted(missing_checks))
+    errors.extend(f"failed check: {name}" for name, passed in checks.items() if not passed)
+    if not validation.get("baseline_eligible"):
+        errors.append("manifest is not baseline eligible")
+
+    stored_path = payload.get("log", {}).get("path")
+    if not isinstance(stored_path, str) or not stored_path:
+        errors.append("log path is missing")
+    else:
+        log_path = Path(stored_path)
+        if not log_path.is_absolute():
+            log_path = args.repo_root / log_path
+        if not log_path.is_file():
+            errors.append(f"log file is missing: {log_path}")
+        else:
+            expected_hash = payload.get("log", {}).get("sha256")
+            actual_hash = sha256_file(log_path)
+            if expected_hash != actual_hash:
+                errors.append("log SHA-256 mismatch")
+
+    result = {
+        "manifest": str(args.manifest),
+        "valid": not errors,
+        "errors": errors,
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if not errors else 1
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    subparsers = root.add_subparsers(dest="operation", required=True)
+
+    start = subparsers.add_parser("start")
+    start.add_argument("--manifest", type=Path, required=True)
+    start.add_argument("--log", type=Path, required=True)
+    start.add_argument("--run-id", required=True)
+    start.add_argument("--repo-root", type=Path, required=True)
+    start.add_argument("--config-file", type=Path)
+    start.add_argument("--collector-wrapper", type=Path)
+    start.add_argument("--price-tick-decimals", type=int)
+    start.add_argument("--qty-tick-decimals", type=int)
+    start.add_argument("--min-order-qty")
+    start.add_argument("command", nargs=argparse.REMAINDER)
+    start.set_defaults(handler=start_manifest)
+
+    finalize = subparsers.add_parser("finalize")
+    finalize.add_argument("--manifest", type=Path, required=True)
+    finalize.add_argument("--log", type=Path, required=True)
+    finalize.add_argument("--exit-status", type=int, required=True)
+    finalize.set_defaults(handler=finalize_manifest)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--manifest", type=Path, required=True)
+    validate.add_argument("--repo-root", type=Path, default=Path.cwd())
+    validate.set_defaults(handler=validate_manifest)
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_maker_observed.sh
+++ b/scripts/run_maker_observed.sh
@@ -41,6 +41,7 @@ log_dir="${STANDX_LOG_DIR:-$repo_root/var/standx}"
 run_id="${STANDX_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
 stdout_log="$log_dir/$run_id.ndjson"
 stderr_log="$log_dir/$run_id.stderr.log"
+manifest_file="$log_dir/$run_id.manifest.json"
 pipe_dir=""
 child_pid=""
 uploader_pid=""
@@ -98,6 +99,25 @@ config_hash=""
 if [[ -n "$config_file" && -f "$config_file" ]]; then
   config_hash="$(shasum -a 256 "$config_file" | awk '{print $1}')"
 fi
+
+manifest_args=(
+  "$script_dir/maker_run_manifest.py" start
+  --manifest "$manifest_file"
+  --log "$stdout_log"
+  --run-id "$run_id"
+  --repo-root "$repo_root"
+  --collector-wrapper "$script_dir/run_maker_observed.sh"
+)
+[[ -n "$config_file" ]] && manifest_args+=(--config-file "$config_file")
+[[ -n "${STANDX_BASELINE_PRICE_TICK_DECIMALS:-}" ]] &&
+  manifest_args+=(--price-tick-decimals "$STANDX_BASELINE_PRICE_TICK_DECIMALS")
+[[ -n "${STANDX_BASELINE_QTY_TICK_DECIMALS:-}" ]] &&
+  manifest_args+=(--qty-tick-decimals "$STANDX_BASELINE_QTY_TICK_DECIMALS")
+[[ -n "${STANDX_BASELINE_MIN_ORDER_QTY:-}" ]] &&
+  manifest_args+=(--min-order-qty "$STANDX_BASELINE_MIN_ORDER_QTY")
+manifest_args+=(-- "${args[@]}")
+python3 "${manifest_args[@]}" ||
+  printf 'warning: maker baseline manifest could not be initialized: %s\n' "$manifest_file" >&2
 
 uploader_enabled=0
 
@@ -158,6 +178,12 @@ wait "$stderr_tee_pid" || true
 
 printf 'maker run_id=%s exit=%s stdout=%s stderr=%s\n' \
   "$run_id" "$child_status" "$stdout_log" "$stderr_log" >&2
+
+python3 "$script_dir/maker_run_manifest.py" finalize \
+  --manifest "$manifest_file" \
+  --log "$stdout_log" \
+  --exit-status "$child_status" ||
+  printf 'warning: maker baseline manifest could not be finalized: %s\n' "$manifest_file" >&2
 
 if [[ -n "$uploader_pid" ]]; then
   uploader_status=0

--- a/scripts/test_maker_run_manifest.py
+++ b/scripts/test_maker_run_manifest.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Tests for maker baseline sidecar manifests."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import maker_run_manifest as manifest
+
+
+class MakerRunManifestTests(unittest.TestCase):
+    def test_start_records_only_non_sensitive_strategy_overrides(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = root / "maker.toml"
+            config.write_text("spread_bps = 8\n", encoding="utf-8")
+            output = root / "run.manifest.json"
+            args = argparse.Namespace(
+                manifest=output,
+                log=root / "run.ndjson",
+                run_id="test-run",
+                repo_root=root,
+                config_file=config,
+                collector_wrapper=None,
+                price_tick_decimals=2,
+                qty_tick_decimals=4,
+                min_order_qty="0.0001",
+                command=[
+                    "standx",
+                    "--output",
+                    "json",
+                    "maker",
+                    "run",
+                    "BTC-USD",
+                    "--spread-bps",
+                    "7",
+                    "--alert-webhook",
+                    "https://secret.example/token",
+                    "--live",
+                ],
+            )
+            with (
+                mock.patch.object(manifest, "git_sha", return_value="a" * 40),
+                mock.patch.object(manifest, "git_dirty_paths", return_value=[]),
+            ):
+                manifest.start_manifest(args)
+
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(payload["symbol"], "BTC-USD")
+            self.assertEqual(payload["mode"], "live")
+            self.assertEqual(payload["config"]["strategy_overrides"], {"spread_bps": "7"})
+            self.assertNotIn("secret.example", output.read_text(encoding="utf-8"))
+
+    def test_finalize_marks_complete_trace_as_eligible(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "run.manifest.json"
+            log = root / "run.ndjson"
+            output.write_text(
+                json.dumps(
+                    {
+                        "schema_version": manifest.SCHEMA_VERSION,
+                        "status": "running",
+                        "git_sha": "a" * 40,
+                        "git_dirty": False,
+                        "strategy_dirty_paths": [],
+                        "symbol": "BTC-USD",
+                        "program": {"sha256": "c" * 64},
+                        "collector": {
+                            "manifest_tool": {"sha256": "d" * 64},
+                            "wrapper": {"sha256": "e" * 64},
+                        },
+                        "config": {"sha256": "b" * 64},
+                        "symbol_metadata": {
+                            "price_tick_decimals": 2,
+                            "qty_tick_decimals": 4,
+                            "min_order_qty": "0.0001",
+                        },
+                        "log": {"path": "run.ndjson"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            log.write_text(
+                '{"ts":"2026-07-15T00:00:00Z","symbol":"BTC-USD","action":"lifecycle","event":"started"}\n'
+                '{"ts":"2026-07-15T00:00:01Z","symbol":"BTC-USD","action":"cycle_summary","cycle":0,"market_source":"ws"}\n'
+                '{"ts":"2026-07-15T00:00:02Z","symbol":"BTC-USD","action":"lifecycle","event":"stopped"}\n',
+                encoding="utf-8",
+            )
+            manifest.finalize_manifest(
+                argparse.Namespace(manifest=output, log=log, exit_status=0)
+            )
+
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertTrue(payload["validation"]["baseline_eligible"])
+            self.assertEqual(payload["log"]["cycle_summaries"], 1)
+            self.assertEqual(payload["log"]["market_sources"], ["ws"])
+            self.assertEqual(payload["log"]["regime"], "insufficient_window")
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                result = manifest.validate_manifest(
+                    argparse.Namespace(manifest=output, repo_root=root)
+                )
+            self.assertEqual(result, 0)
+
+            with log.open("a", encoding="utf-8") as handle:
+                handle.write('{"action":"tampered"}\n')
+            with contextlib.redirect_stdout(io.StringIO()):
+                result = manifest.validate_manifest(
+                    argparse.Namespace(manifest=output, repo_root=root)
+                )
+            self.assertEqual(result, 1)
+
+    def test_finalize_preserves_incomplete_trace_reasons(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "run.manifest.json"
+            log = root / "run.ndjson"
+            output.write_text(
+                json.dumps(
+                    {
+                        "git_sha": "a" * 40,
+                        "git_dirty": False,
+                        "strategy_dirty_paths": [],
+                        "symbol": "BTC-USD",
+                        "program": {"sha256": "c" * 64},
+                        "collector": {
+                            "manifest_tool": {"sha256": "d" * 64},
+                            "wrapper": {"sha256": "e" * 64},
+                        },
+                        "config": {"sha256": "b" * 64},
+                        "symbol_metadata": {
+                            "price_tick_decimals": None,
+                            "qty_tick_decimals": None,
+                            "min_order_qty": None,
+                        },
+                        "log": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            log.write_text(
+                '{"ts":1,"symbol":"BTC-USD","action":"cycle_summary","cycle":0}\n'
+                '{"ts":2,"symbol":"BTC-USD","action":"cycle_summary","cycle":2}\n'
+                '{"ts":2,"symbol":"BTC-USD","action":"cycle_summary","cycle":2}\n',
+                encoding="utf-8",
+            )
+            manifest.finalize_manifest(
+                argparse.Namespace(manifest=output, log=log, exit_status=0)
+            )
+
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            checks = payload["validation"]["checks"]
+            self.assertFalse(payload["validation"]["baseline_eligible"])
+            self.assertFalse(checks["symbol_metadata_complete"])
+            self.assertFalse(checks["cycle_sequence_complete"])
+            self.assertFalse(checks["lifecycle_stopped"])
+            self.assertEqual(payload["log"]["missing_cycles"], [1])
+            self.assertEqual(payload["log"]["duplicate_cycles"], [2])
+
+    def test_regime_report_distinguishes_calm_trend_and_stress(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cases = {
+                "calm": [100.0 + (index % 2) * 0.02 for index in range(30)],
+                "trend": [100.0 + index * 0.01 for index in range(100)],
+                "fast_or_stressed": [100.0 + (2.0 if index == 15 else 0.0) for index in range(30)],
+            }
+            for expected, marks in cases.items():
+                log = root / f"{expected}.ndjson"
+                events = []
+                for index, mark in enumerate(marks):
+                    event = {
+                        "ts": index * 2,
+                        "symbol": "TEST-USD",
+                        "action": "cycle_summary",
+                        "cycle": index,
+                        "mark": mark,
+                        "uptime_pct": 100.0,
+                        "fills_total": 0,
+                        "halted": expected == "fast_or_stressed" and index == 15,
+                        "vol_bps": 200.0 if expected == "fast_or_stressed" and index == 15 else None,
+                    }
+                    events.append(json.dumps(event))
+                log.write_text("\n".join(events) + "\n", encoding="utf-8")
+                self.assertEqual(manifest.analyze_log(log)["regime"], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a sidecar manifest flow to `run_maker_observed.sh` that records run identity, repo cleanliness, config hashes, and lifecycle integrity without changing maker JSON output.
- Add validation and tests for manifest generation, then document the new baseline workflow in the maker and OpenObserve docs.
- Clarify alert and stop-loss semantics, and mark the conservative XAG inventory-exit tuple as unvalidated live.

## Testing
- Added unit tests for manifest start/finalize/validation behavior.
- Not run (not requested)