### PR TITLE
Differentiate maker reconciliation causes in recovery handling

### DIFF
--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -262,10 +262,12 @@ pub(super) async fn maker_cycle(
                 // performs no REST read; this sleep is reached only by a
                 // periodic audit that found an unexplained position gap.
                 tokio::time::sleep(Duration::from_millis(500)).await;
-                return Err(anyhow::Error::new(PositionReconciliationError {
-                    expected: ledger.expected_position,
-                    observed: observed_position,
-                }));
+                return Err(anyhow::Error::new(
+                    PositionReconciliationError::position_mismatch(
+                        ledger.expected_position,
+                        observed_position,
+                    ),
+                ));
             }
             if let Err(error) = projection.verify_rest_snapshot(
                 generation,
@@ -276,10 +278,13 @@ pub(super) async fn maker_cycle(
                 eprintln!("⚠️  account projection audit failed: {error}");
                 // Reuse the runtime's immediate reconciliation/freeze path;
                 // the detailed order/projection mismatch is emitted above.
-                return Err(anyhow::Error::new(PositionReconciliationError {
-                    expected: ledger.expected_position,
-                    observed: observed_position,
-                }));
+                return Err(anyhow::Error::new(
+                    PositionReconciliationError::account_projection_mismatch(
+                        ledger.expected_position,
+                        observed_position,
+                        error.to_string(),
+                    ),
+                ));
             }
             projection.apply(
                 generation,

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -45,7 +45,8 @@ use pipeline::{CycleRequest, CycleState, LiveAccountPollState};
 use recovery::{
     cancel_maker_orders_with_retry, ctrl_c_latched, reconcile_ledger_snapshot,
     reconnect_account_stream, reconnect_order_response, AccountStreamReconnect,
-    PositionReconciliationError, ReconcileRequest, ReconnectInterrupted, ReconnectRequest,
+    PositionReconciliationCause, PositionReconciliationError, ReconcileRequest,
+    ReconnectInterrupted, ReconnectRequest,
 };
 #[cfg(test)]
 use recovery::{

--- a/crates/standx-cli/src/commands/maker/output.rs
+++ b/crates/standx-cli/src/commands/maker/output.rs
@@ -376,6 +376,7 @@ pub(super) fn emit_reconciliation_state(
     symbol: &str,
     cycle: u64,
     event: &str,
+    cause: &str,
     expected: f64,
     observed: f64,
 ) {
@@ -388,13 +389,14 @@ pub(super) fn emit_reconciliation_state(
                 "cycle": cycle,
                 "action": "position_reconciliation",
                 "event": event,
+                "cause": cause,
                 "expected_position": expected,
                 "observed_position": observed,
             })
         );
     } else {
         eprintln!(
-            "⚠️  position reconciliation {event}: expected {expected:+.8}, observed {observed:+.8}"
+            "⚠️  position reconciliation {event} ({cause}): expected {expected:+.8}, observed {observed:+.8}"
         );
     }
 }

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -20,18 +20,102 @@ const MAKER_CLEANUP_VERIFY_DELAY: Duration = Duration::from_millis(500);
 const MAKER_CLEANUP_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]
+pub(super) enum PositionReconciliationCause {
+    PositionMismatch,
+    AccountProjectionMismatch(String),
+    UnknownCurrentRunOrder,
+    CycleInvalidation,
+}
+
+impl PositionReconciliationCause {
+    pub(super) fn label(&self) -> &'static str {
+        match self {
+            Self::PositionMismatch => "position_mismatch",
+            Self::AccountProjectionMismatch(_) => "account_projection_mismatch",
+            Self::UnknownCurrentRunOrder => "unknown_current_run_order",
+            Self::CycleInvalidation => "cycle_invalidation",
+        }
+    }
+
+    pub(super) fn recovery_trigger(&self) -> standx_maker::RecoveryTrigger {
+        match self {
+            Self::CycleInvalidation => standx_maker::RecoveryTrigger::CycleInvalidation,
+            Self::PositionMismatch
+            | Self::AccountProjectionMismatch(_)
+            | Self::UnknownCurrentRunOrder => standx_maker::RecoveryTrigger::PositionMismatch,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub(super) struct PositionReconciliationError {
     pub(super) expected: f64,
     pub(super) observed: f64,
+    pub(super) cause: PositionReconciliationCause,
+}
+
+impl PositionReconciliationError {
+    pub(super) fn position_mismatch(expected: f64, observed: f64) -> Self {
+        Self {
+            expected,
+            observed,
+            cause: PositionReconciliationCause::PositionMismatch,
+        }
+    }
+
+    pub(super) fn account_projection_mismatch(
+        expected: f64,
+        observed: f64,
+        detail: String,
+    ) -> Self {
+        Self {
+            expected,
+            observed,
+            cause: PositionReconciliationCause::AccountProjectionMismatch(detail),
+        }
+    }
+
+    pub(super) fn unknown_current_run_order(position: f64) -> Self {
+        Self {
+            expected: position,
+            observed: position,
+            cause: PositionReconciliationCause::UnknownCurrentRunOrder,
+        }
+    }
+
+    pub(super) fn cycle_invalidation(position: f64) -> Self {
+        Self {
+            expected: position,
+            observed: position,
+            cause: PositionReconciliationCause::CycleInvalidation,
+        }
+    }
 }
 
 impl fmt::Display for PositionReconciliationError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "expected position {:+.8}, venue reported {:+.8}",
-            self.expected, self.observed
-        )
+        match &self.cause {
+            PositionReconciliationCause::PositionMismatch => write!(
+                formatter,
+                "expected position {:+.8}, venue reported {:+.8}",
+                self.expected, self.observed
+            ),
+            PositionReconciliationCause::AccountProjectionMismatch(detail) => write!(
+                formatter,
+                "account projection mismatch ({detail}); ledger expected {:+.8}, venue reported {:+.8}",
+                self.expected, self.observed
+            ),
+            PositionReconciliationCause::UnknownCurrentRunOrder => write!(
+                formatter,
+                "unknown current-run order requires reconciliation at position {:+.8}",
+                self.expected
+            ),
+            PositionReconciliationCause::CycleInvalidation => write!(
+                formatter,
+                "account event invalidated active cycle at reconciled position {:+.8}",
+                self.expected
+            ),
+        }
     }
 }
 
@@ -579,10 +663,12 @@ pub(super) async fn reconnect_order_response(
                         Ok(snapshot) => {
                             if (snapshot.position - expected_position).abs() > qty_tolerance {
                                 handle.abort();
-                                return Err(anyhow::Error::new(PositionReconciliationError {
-                                    expected: expected_position,
-                                    observed: snapshot.position,
-                                }));
+                                return Err(anyhow::Error::new(
+                                    PositionReconciliationError::position_mismatch(
+                                        expected_position,
+                                        snapshot.position,
+                                    ),
+                                ));
                             }
                             if !health.is_healthy() {
                                 let reason = health.failure_reason().unwrap_or_else(|| {

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -367,10 +367,27 @@ fn reconciliation_error_for_cycle(
     account_position_mismatch: Option<f64>,
     cycle_invalidated_by_account: bool,
 ) -> Option<PositionReconciliationError> {
-    mismatch
-        .or(account_position_mismatch)
-        .or(cycle_invalidated_by_account.then_some(expected))
-        .map(|observed| PositionReconciliationError { expected, observed })
+    if let Some(observed) = mismatch.or(account_position_mismatch) {
+        Some(PositionReconciliationError::position_mismatch(
+            expected, observed,
+        ))
+    } else if cycle_invalidated_by_account {
+        Some(PositionReconciliationError::cycle_invalidation(expected))
+    } else {
+        None
+    }
+}
+
+fn reconciliation_recovery_admission(
+    reconciliation: &PositionReconciliationError,
+    breaker: &mut maker::RecoveryCircuitBreaker,
+    now_secs: u64,
+) -> Option<maker::RecoveryAdmission> {
+    reconciliation
+        .cause
+        .recovery_trigger()
+        .meters_circuit()
+        .then(|| breaker.admit(now_secs))
 }
 
 fn market_update_requires_replan(
@@ -942,11 +959,11 @@ pub(super) async fn run_maker(
     let mut last_mark: Option<f64> = None;
     let mut last_src: Option<&'static str> = None;
     let recovery_clock_started = std::time::Instant::now();
-    // One rolling budget shared across every automatic recovery — account-stream
-    // reconnect, order-response reconnect, and position-mismatch freeze/recover.
-    // The operator's "N incidents per window" bounds total recovery churn before
-    // a human must step in; letting any one path recover unmetered would defeat
-    // that ceiling.
+    // One rolling budget shared across abnormal automatic recoveries —
+    // account-stream reconnect, order-response reconnect, and genuine
+    // position/projection mismatch. A normal account event that invalidates an
+    // in-flight cycle still performs cleanup and reconciliation, but is not an
+    // incident: otherwise ordinary fills eventually exhaust the live budget.
     let mut recovery_breaker = maker::RecoveryCircuitBreaker::new(
         args.recovery_incidents_per_window,
         args.recovery_window_secs,
@@ -1714,16 +1731,19 @@ pub(super) async fn run_maker(
         };
         let work = async {
             if let Some(observed) = mismatch {
-                return Err(anyhow::Error::new(PositionReconciliationError {
-                    expected: ledger.expected_position,
-                    observed,
-                }));
+                return Err(anyhow::Error::new(
+                    PositionReconciliationError::position_mismatch(
+                        ledger.expected_position,
+                        observed,
+                    ),
+                ));
             }
             if order_reconciliation_required {
-                return Err(anyhow::Error::new(PositionReconciliationError {
-                    expected: ledger.expected_position,
-                    observed: ledger.expected_position,
-                }));
+                return Err(anyhow::Error::new(
+                    PositionReconciliationError::unknown_current_run_order(
+                        ledger.expected_position,
+                    ),
+                ));
             }
             let (mark, best_bid, best_ask, src, market_fallback_reason) =
                 market_snapshot(&client, &symbol, feed.as_ref()).await?;
@@ -2165,8 +2185,7 @@ pub(super) async fn run_maker(
                     continue 'main;
                 }
                 if let Some(mismatch) = e.downcast_ref::<PositionReconciliationError>() {
-                    let invalidated_without_position_gap =
-                        (mismatch.expected - mismatch.observed).abs() <= qty_tolerance;
+                    let reconciliation_cause = mismatch.cause.label();
                     runtime_state.handle(MakerEvent::PositionMismatch);
                     let cleanup_token = match take_cleanup_effect(
                         &mut runtime_state,
@@ -2192,6 +2211,7 @@ pub(super) async fn run_maker(
                         &symbol,
                         cycle,
                         "frozen",
+                        reconciliation_cause,
                         mismatch.expected,
                         mismatch.observed,
                     );
@@ -2201,10 +2221,11 @@ pub(super) async fn run_maker(
                             kind: "position_reconciliation",
                             severity: "warning",
                             event: "frozen",
-                            message: if invalidated_without_position_gap {
-                                "account update invalidated active cycle; placements frozen and maker cleanup starting"
-                            } else {
-                                "position mismatch detected; placements frozen and maker cleanup starting"
+                            message: match &mismatch.cause {
+                                PositionReconciliationCause::CycleInvalidation => "account update invalidated active cycle; placements frozen and maker cleanup starting",
+                                PositionReconciliationCause::UnknownCurrentRunOrder => "unknown current-run order detected; placements frozen and maker cleanup starting",
+                                PositionReconciliationCause::AccountProjectionMismatch(_) => "account projection audit failed; placements frozen and maker cleanup starting",
+                                PositionReconciliationCause::PositionMismatch => "position mismatch detected; placements frozen and maker cleanup starting",
                             },
                                 symbol: &symbol,
                                 cycle,
@@ -2246,25 +2267,26 @@ pub(super) async fn run_maker(
                             );
                         }
                     };
-                    // Meter this recovery against the same rolling budget as the
-                    // transport reconnects. An oscillating mismatch source (a
-                    // second actor on the account, settlement jitter around the
-                    // tolerance boundary) would otherwise drive unbounded
-                    // freeze -> cancel-all -> backfill -> resume churn that the
-                    // circuit breaker exists to stop.
-                    let admission =
-                        recovery_breaker.admit(recovery_clock_started.elapsed().as_secs());
-                    if !admission.is_admitted() {
-                        break 'main recovery_failed_exit(
-                            &mut runtime_state,
-                            recovery_token,
-                            format!(
-                                "position mismatch (expected {:+.8}, observed {:+.8}); {}; refusing further live orders",
-                                mismatch.expected,
-                                mismatch.observed,
-                                recovery_circuit_detail(admission)
-                            ),
-                        );
+                    // Genuine mismatch/projection anomalies share the same
+                    // rolling budget as transport reconnects. A normal account
+                    // event that invalidated in-flight cycle work is unmetered,
+                    // but still follows the complete cleanup + REST reconcile +
+                    // empty-book verification path below.
+                    if let Some(admission) = reconciliation_recovery_admission(
+                        mismatch,
+                        &mut recovery_breaker,
+                        recovery_clock_started.elapsed().as_secs(),
+                    ) {
+                        if !admission.is_admitted() {
+                            break 'main recovery_failed_exit(
+                                &mut runtime_state,
+                                recovery_token,
+                                format!(
+                                    "{mismatch}; {}; refusing further live orders",
+                                    recovery_circuit_detail(admission)
+                                ),
+                            );
+                        }
                     }
                     let mut recovered = false;
                     let mut last_observed = mismatch.observed;
@@ -2381,6 +2403,7 @@ pub(super) async fn run_maker(
                             &symbol,
                             cycle,
                             "recovered",
+                            reconciliation_cause,
                             ledger.expected_position,
                             last_observed,
                         );
@@ -2410,6 +2433,7 @@ pub(super) async fn run_maker(
                         &symbol,
                         cycle,
                         "failed",
+                        reconciliation_cause,
                         ledger.expected_position,
                         last_observed,
                     );
@@ -3363,6 +3387,7 @@ mod tests {
             .expect("an invalidated cycle must enter reconciliation cleanup");
         assert_eq!(reconciliation.expected, 0.2);
         assert_eq!(reconciliation.observed, 0.2);
+        assert_eq!(reconciliation.cause.label(), "cycle_invalidation");
 
         let mut runtime_state = MakerState::starting();
         runtime_state.handle(MakerEvent::StartupReady);
@@ -3390,6 +3415,27 @@ mod tests {
             runtime_state.next_effect(),
             Some(MakerEffect::RunCycle(_))
         ));
+    }
+
+    #[test]
+    fn normal_cycle_invalidations_do_not_consume_recovery_incident_budget() {
+        let invalidation = PositionReconciliationError::cycle_invalidation(0.0);
+        let mismatch = PositionReconciliationError::position_mismatch(0.0, 0.2);
+        let mut breaker = maker::RecoveryCircuitBreaker::new(1, 3_600);
+
+        for now in [10, 20, 30, 40] {
+            assert!(reconciliation_recovery_admission(&invalidation, &mut breaker, now).is_none());
+        }
+        assert!(
+            reconciliation_recovery_admission(&mismatch, &mut breaker, 50)
+                .expect("a true mismatch must be metered")
+                .is_admitted()
+        );
+        assert!(
+            !reconciliation_recovery_admission(&mismatch, &mut breaker, 60)
+                .expect("a true mismatch must be metered")
+                .is_admitted()
+        );
     }
 
     #[test]

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -36,7 +36,7 @@ pub use ownership::{
     open_qty_adopts, pending_covers_slot, position_within_limit, quote_client_order_id, QuoteSlot,
     MAKER_CL_ORD_ID_PREFIX,
 };
-pub use recovery::{RecoveryAdmission, RecoveryCircuitBreaker};
+pub use recovery::{RecoveryAdmission, RecoveryCircuitBreaker, RecoveryTrigger};
 pub use risk::{PositionAlertAnchor, PositionRiskEvent, PositionRiskKind};
 pub use runtime::{
     order_cancel_rejection_reason, MakerEffect, MakerEvent, MakerState, RecoveryTarget,

--- a/crates/standx-maker/src/recovery.rs
+++ b/crates/standx-maker/src/recovery.rs
@@ -3,6 +3,24 @@
 
 use std::collections::VecDeque;
 
+/// Why the live runtime entered a cleanup/recovery flow.
+///
+/// A cycle invalidated by an account event still requires compensating cleanup
+/// and authoritative reconciliation, but it is expected during normal fills.
+/// Counting it as an incident would eventually stop every healthy active maker.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoveryTrigger {
+    TransportFailure,
+    PositionMismatch,
+    CycleInvalidation,
+}
+
+impl RecoveryTrigger {
+    pub fn meters_circuit(self) -> bool {
+        !matches!(self, Self::CycleInvalidation)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RecoveryAdmission {
     Admitted {
@@ -104,5 +122,12 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn normal_cycle_invalidation_does_not_meter_the_incident_circuit() {
+        assert!(!RecoveryTrigger::CycleInvalidation.meters_circuit());
+        assert!(RecoveryTrigger::PositionMismatch.meters_circuit());
+        assert!(RecoveryTrigger::TransportFailure.meters_circuit());
     }
 }


### PR DESCRIPTION
## Summary
- Add explicit reconciliation causes for position mismatches, account projection failures, unknown current-run orders, and cycle invalidation
- Include the reconciliation cause in JSON and terminal output for frozen/recovered/failed states
- Meter only genuine mismatch/projection incidents against the recovery circuit breaker, while normal cycle invalidations still run cleanup and reconciliation
- Add unit coverage for the new recovery trigger and the unmetered cycle-invalidation path

## Testing
- Added unit tests for `RecoveryTrigger` circuit metering
- Added unit tests covering cycle invalidation not consuming recovery incident budget
- Not run (not requested)