### PR TITLE
Track live maker request lifecycles with monotonic deadlines

### DIFF
--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -5,7 +5,9 @@ use super::model::{position_for_symbol, rest_order_observation};
 use super::output::{
     emit_cycle_skip, emit_maker_cycle, log_maker_event, CycleOutput, MakerLogEvent,
 };
-use super::pipeline::{fetch_account_audit, CycleRequest, CycleResult, CycleState};
+use super::pipeline::{
+    fetch_account_audit, CycleRequest, CycleResult, CycleState, OrderRequestKind,
+};
 use super::recovery::PositionReconciliationError;
 use anyhow::Result;
 use standx_maker::{
@@ -220,6 +222,7 @@ pub(super) async fn maker_cycle(
         sim_position,
         stats,
         breaker,
+        mut order_request_deadlines,
         live_account_poll,
         mut order_latency,
         latency_started,
@@ -600,6 +603,10 @@ pub(super) async fn maker_cycle(
                                 cycle,
                             }),
                         )?;
+                        order_request_deadlines
+                            .as_deref_mut()
+                            .expect("live maker cycles require initialized request deadlines")
+                            .record(request_id.clone(), OrderRequestKind::Cancel, Instant::now());
                         register_order_latency(
                             &mut order_latency,
                             LatencyRegistration {
@@ -670,6 +677,10 @@ pub(super) async fn maker_cycle(
                             cycle,
                         }),
                     )?;
+                    order_request_deadlines
+                        .as_deref_mut()
+                        .expect("live maker cycles require initialized request deadlines")
+                        .record(request_id.clone(), OrderRequestKind::Place, Instant::now());
                     register_order_latency(
                         &mut order_latency,
                         LatencyRegistration {
@@ -743,8 +754,9 @@ pub(super) async fn maker_cycle(
             // Register the exit submission so its asynchronous ack correlates
             // to a pending entry instead of counting as an unmatched response.
             // The sentinel level keeps it out of quote-slot reservation; a
-            // reduce-only market order never rests, so reconciliation drops it
-            // when `pending` ages out.
+            // reduce-only market order never rests, so its request lifecycle
+            // stays tracked until a correlated response/account event or
+            // explicit cleanup resolves it.
             let projection = account_projection
                 .as_deref_mut()
                 .expect("live inventory exits require initialized account projection");
@@ -761,6 +773,13 @@ pub(super) async fn maker_cycle(
                     cycle,
                 }),
             )?;
+            order_request_deadlines
+                .expect("live inventory exits require initialized request deadlines")
+                .record(
+                    request_id.clone(),
+                    OrderRequestKind::InventoryExit,
+                    Instant::now(),
+                );
             register_order_latency(
                 &mut order_latency,
                 LatencyRegistration {

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -42,7 +42,9 @@ pub use model::{FailSafeShutdown, FAIL_SAFE_EXIT_CODE};
 #[cfg(test)]
 use notify::webhook_body;
 use notify::{token_expiry_level, MakerNotifier, PositionChange, RiskNotice, TokenExpiryLevel};
-use pipeline::{CycleRequest, CycleState, LiveAccountPollState};
+use pipeline::{
+    CycleRequest, CycleState, LiveAccountPollState, OrderRequestDeadlines, TimedOutOrderRequest,
+};
 use recovery::{
     cancel_maker_orders_with_retry, ctrl_c_latched, reconcile_ledger_snapshot,
     reconnect_account_stream, reconnect_order_response, AccountStreamReconnect,

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -9,12 +9,119 @@ use standx_sdk::account_stream::AccountStreamHealth;
 use standx_sdk::client::StandXClient;
 use standx_sdk::models::{Balance, Order, Position, Trade};
 use standx_sdk::order_response::{OrderCommandSender, OrderResponseHealth};
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 const ACCOUNT_AUDIT_INTERVAL: Duration = Duration::from_secs(30);
 const BALANCE_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 const BALANCE_MAX_STALE: Duration = Duration::from_secs(60);
 const BALANCE_REFRESH_RETRY: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum OrderRequestKind {
+    Place,
+    Cancel,
+    InventoryExit,
+}
+
+impl OrderRequestKind {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Place => "place",
+            Self::Cancel => "cancel",
+            Self::InventoryExit => "inventory_exit",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum OrderRequestTimeoutPhase {
+    Acknowledgement,
+    AccountOrder,
+}
+
+impl OrderRequestTimeoutPhase {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Acknowledgement => "acknowledgement",
+            Self::AccountOrder => "account_order",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TrackedOrderRequest {
+    kind: OrderRequestKind,
+    submitted_at: Instant,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct TimedOutOrderRequest {
+    pub(super) request_id: String,
+    pub(super) kind: OrderRequestKind,
+    pub(super) phase: OrderRequestTimeoutPhase,
+    pub(super) age: Duration,
+}
+
+/// CLI-owned monotonic deadlines for requests registered in the pure account
+/// projection. Timing stays outside `standx-maker`; correlation stays inside.
+#[derive(Debug, Default)]
+pub(super) struct OrderRequestDeadlines {
+    requests: HashMap<String, TrackedOrderRequest>,
+}
+
+impl OrderRequestDeadlines {
+    pub(super) fn record(
+        &mut self,
+        request_id: String,
+        kind: OrderRequestKind,
+        submitted_at: Instant,
+    ) {
+        self.requests
+            .insert(request_id, TrackedOrderRequest { kind, submitted_at });
+    }
+
+    pub(super) fn retain_pending(&mut self, projection: &MakerAccountProjection) {
+        self.requests
+            .retain(|request_id, _| projection.has_pending_request_lifecycle(request_id));
+    }
+
+    pub(super) fn next_deadline(&self, timeout: Duration) -> Option<Instant> {
+        self.requests
+            .values()
+            .map(|request| request.submitted_at + timeout)
+            .min()
+    }
+
+    pub(super) fn timed_out(
+        &self,
+        projection: &MakerAccountProjection,
+        now: Instant,
+        timeout: Duration,
+    ) -> Option<TimedOutOrderRequest> {
+        self.requests
+            .iter()
+            .filter_map(|(request_id, request)| {
+                let age = now.saturating_duration_since(request.submitted_at);
+                (age >= timeout).then_some((request_id, request, age))
+            })
+            .min_by(|(left_id, left, _), (right_id, right, _)| {
+                left.submitted_at
+                    .cmp(&right.submitted_at)
+                    .then_with(|| left_id.cmp(right_id))
+            })
+            .map(|(request_id, request, age)| TimedOutOrderRequest {
+                request_id: request_id.clone(),
+                kind: request.kind,
+                phase: if projection.pending_request(request_id).is_some() {
+                    OrderRequestTimeoutPhase::Acknowledgement
+                } else {
+                    OrderRequestTimeoutPhase::AccountOrder
+                },
+                age,
+            })
+    }
+}
 
 pub(super) struct CycleRequest<'a> {
     pub(super) client: &'a StandXClient,
@@ -53,6 +160,7 @@ pub(super) struct CycleState<'a> {
     pub(super) sim_position: &'a mut f64,
     pub(super) stats: &'a mut MakerStats,
     pub(super) breaker: &'a mut VolBreaker,
+    pub(super) order_request_deadlines: Option<&'a mut OrderRequestDeadlines>,
     /// Live-only REST polling state. It is deliberately a CLI concern: it
     /// controls I/O cadence and cached account presentation, not strategy.
     pub(super) live_account_poll: Option<&'a mut LiveAccountPollState>,
@@ -165,6 +273,43 @@ pub(super) async fn fetch_account_audit(
 mod tests {
     use super::*;
     use mockito::{Matcher, Server};
+    use standx_maker::{AccountProjectionEvent, OrderObservation, ProjectionPendingPlace};
+    use standx_sdk::models::OrderSide;
+
+    const TEST_RUN_PREFIX: &str = "sxmk-deadline-";
+
+    fn pending_place(request_id: &str) -> ProjectionPendingPlace {
+        ProjectionPendingPlace {
+            request_id: request_id.to_owned(),
+            client_order_id: format!("{TEST_RUN_PREFIX}q00000001b0"),
+            side: OrderSide::Buy,
+            price: 100.0,
+            qty: 0.2,
+            level: 0,
+            ref_center: 100.0,
+            cycle: 1,
+        }
+    }
+
+    fn observed_order() -> OrderObservation {
+        OrderObservation {
+            order_id: 7,
+            client_order_id: Some(format!("{TEST_RUN_PREFIX}q00000001b0")),
+            side: OrderSide::Buy,
+            price: 100.0,
+            open_qty: 0.2,
+            terminal: false,
+        }
+    }
+
+    fn projection_with_pending_place(request_id: &str) -> MakerAccountProjection {
+        let mut projection = MakerAccountProjection::new(1, TEST_RUN_PREFIX, 0.0, 0.005, 0.00005);
+        projection.apply(
+            1,
+            AccountProjectionEvent::PlaceSubmitted(pending_place(request_id)),
+        );
+        projection
+    }
 
     struct JwtGuard {
         original: Option<String>,
@@ -213,6 +358,73 @@ mod tests {
             pnl_freeze: "0".to_string(),
             upnl: "0".to_string(),
         }
+    }
+
+    #[test]
+    fn request_deadline_distinguishes_ack_and_account_order_phases() {
+        let submitted_at = Instant::now();
+        let timeout = Duration::from_secs(10);
+        let mut projection = projection_with_pending_place("p1");
+        let mut deadlines = OrderRequestDeadlines::default();
+        deadlines.record("p1".to_owned(), OrderRequestKind::Place, submitted_at);
+
+        assert_eq!(
+            deadlines.next_deadline(timeout),
+            Some(submitted_at + timeout)
+        );
+        assert!(deadlines
+            .timed_out(
+                &projection,
+                submitted_at + timeout - Duration::from_millis(1),
+                timeout,
+            )
+            .is_none());
+        assert_eq!(
+            deadlines
+                .timed_out(&projection, submitted_at + timeout, timeout)
+                .unwrap()
+                .phase,
+            OrderRequestTimeoutPhase::Acknowledgement
+        );
+
+        projection.apply(
+            1,
+            AccountProjectionEvent::PlaceAccepted {
+                request_id: "p1".to_owned(),
+            },
+        );
+        assert_eq!(
+            deadlines
+                .timed_out(&projection, submitted_at + timeout, timeout)
+                .unwrap()
+                .phase,
+            OrderRequestTimeoutPhase::AccountOrder
+        );
+
+        projection.apply(1, AccountProjectionEvent::OrderObserved(observed_order()));
+        deadlines.retain_pending(&projection);
+        assert_eq!(deadlines.next_deadline(timeout), None);
+        assert!(deadlines
+            .timed_out(&projection, submitted_at + timeout, timeout)
+            .is_none());
+    }
+
+    #[test]
+    fn account_order_before_ack_keeps_ack_deadline_open() {
+        let submitted_at = Instant::now();
+        let timeout = Duration::from_secs(10);
+        let mut projection = projection_with_pending_place("p1");
+        let mut deadlines = OrderRequestDeadlines::default();
+        deadlines.record("p1".to_owned(), OrderRequestKind::Place, submitted_at);
+
+        projection.apply(1, AccountProjectionEvent::OrderObserved(observed_order()));
+        deadlines.retain_pending(&projection);
+
+        let timed_out = deadlines
+            .timed_out(&projection, submitted_at + timeout, timeout)
+            .unwrap();
+        assert_eq!(timed_out.kind, OrderRequestKind::Place);
+        assert_eq!(timed_out.phase, OrderRequestTimeoutPhase::Acknowledgement);
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -5,6 +5,18 @@ use super::output::{
 use super::*;
 use standx_sdk::order_response::OrderResponse;
 
+const ORDER_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn order_request_timeout_detail(timeout: &TimedOutOrderRequest) -> String {
+    format!(
+        "order request lifecycle timed out after {:.3}s: kind={} request_id={} waiting_for={}; refusing further live orders",
+        timeout.age.as_secs_f64(),
+        timeout.kind.label(),
+        timeout.request_id,
+        timeout.phase.label(),
+    )
+}
+
 fn take_cleanup_effect(
     runtime_state: &mut MakerState,
     expected_target: RecoveryTarget,
@@ -930,6 +942,10 @@ pub(super) async fn run_maker(
                 args.order_response_reconnect_attempts, args.order_response_reconnect_backoff
             );
             println!(
+                "│ order request deadline: {}s to correlated ACK/account visibility",
+                ORDER_REQUEST_TIMEOUT.as_secs()
+            );
+            println!(
                 "│ account-stream recovery: {} attempt(s), {}s base backoff",
                 args.account_stream_reconnect_attempts, args.account_stream_reconnect_backoff
             );
@@ -1762,6 +1778,21 @@ pub(super) async fn run_maker(
                 &mut session.account_poll,
                 std::time::Instant::now(),
             );
+            session
+                .order_request_deadlines
+                .retain_pending(&session.projection);
+            if session.order_response_health.is_healthy() {
+                if let Some(timeout) = session.order_request_deadlines.timed_out(
+                    &session.projection,
+                    std::time::Instant::now(),
+                    ORDER_REQUEST_TIMEOUT,
+                ) {
+                    session
+                        .order_response_health
+                        .mark_unhealthy(order_request_timeout_detail(&timeout));
+                    continue;
+                }
+            }
         }
         if account_position_mismatch
             .is_some_and(|position| (position - ledger.expected_position).abs() <= qty_tolerance)
@@ -1819,6 +1850,7 @@ pub(super) async fn run_maker(
             cycle_order_response_health,
             cycle_account_stream_health,
             mut cycle_projection,
+            mut cycle_order_request_deadlines,
             mut cycle_account_poll,
             mut cycle_order_latency,
             cycle_latency_started,
@@ -1830,6 +1862,7 @@ pub(super) async fn run_maker(
                 account_events,
                 account_stream_health,
                 projection,
+                order_request_deadlines,
                 account_poll,
                 order_latency,
                 latency_started,
@@ -1841,11 +1874,12 @@ pub(super) async fn run_maker(
                 Some(&*order_response_health),
                 Some(&*account_stream_health),
                 Some(projection),
+                Some(order_request_deadlines),
                 Some(account_poll),
                 Some(order_latency),
                 Some(*latency_started),
             ),
-            None => (None, None, None, None, None, None, None, None, None),
+            None => (None, None, None, None, None, None, None, None, None, None),
         };
         let work = async {
             if let Some(observed) = mismatch {
@@ -1901,6 +1935,7 @@ pub(super) async fn run_maker(
                     sim_position: &mut sim_position,
                     stats: &mut stats,
                     breaker: &mut breaker,
+                    order_request_deadlines: cycle_order_request_deadlines.as_deref_mut(),
                     live_account_poll: cycle_account_poll.as_deref_mut(),
                     order_latency: cycle_order_latency.as_deref_mut(),
                     latency_started: cycle_latency_started,
@@ -2659,6 +2694,19 @@ pub(super) async fn run_maker(
         let deadline = tokio::time::Instant::now() + Duration::from_secs(args.interval);
         let min_gap = tokio::time::Instant::now() + Duration::from_secs(1);
         loop {
+            let request_deadline = live_session.as_ref().and_then(|session| {
+                session
+                    .order_request_deadlines
+                    .next_deadline(ORDER_REQUEST_TIMEOUT)
+            });
+            let request_timeout = async {
+                match request_deadline {
+                    Some(deadline) => {
+                        tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await
+                    }
+                    None => std::future::pending().await,
+                }
+            };
             let update = async {
                 match updates.as_mut() {
                     Some(rx) => rx.changed().await.is_ok(),
@@ -2677,6 +2725,7 @@ pub(super) async fn run_maker(
                     break 'main take_stop_effect(&mut runtime_state, MakerExit::PositionReconciliation);
                 },
                 _ = tokio::time::sleep_until(deadline) => break,
+                _ = request_timeout => break,
                 event = account_update => {
                     // The branch futures are dropped before select! handlers
                     // run, so the session can be re-borrowed here. An event
@@ -2835,10 +2884,26 @@ pub(super) async fn run_maker(
 
 #[cfg(test)]
 mod tests {
+    use super::super::pipeline::{OrderRequestKind, OrderRequestTimeoutPhase};
     use super::*;
     use standx_maker::{OrderObservation, ProjectionPendingCancel, ProjectionPendingPlace};
     use standx_sdk::account_stream::{OrderUpdate, PositionUpdate};
     use standx_sdk::order_response::OrderResponseHealth;
+
+    #[test]
+    fn request_timeout_detail_identifies_request_kind_and_missing_phase() {
+        let detail = order_request_timeout_detail(&TimedOutOrderRequest {
+            request_id: "request-7".to_string(),
+            kind: OrderRequestKind::Cancel,
+            phase: OrderRequestTimeoutPhase::AccountOrder,
+            age: Duration::from_millis(10_250),
+        });
+
+        assert_eq!(
+            detail,
+            "order request lifecycle timed out after 10.250s: kind=cancel request_id=request-7 waiting_for=account_order; refusing further live orders"
+        );
+    }
 
     fn pending_place(request_id: &str) -> ProjectionPendingPlace {
         ProjectionPendingPlace {

--- a/crates/standx-cli/src/commands/maker/startup.rs
+++ b/crates/standx-cli/src/commands/maker/startup.rs
@@ -22,6 +22,7 @@ pub(super) struct LiveSession {
     /// Bumped on every account-stream reconnect; stamps projection generations.
     pub(super) account_stream_epoch: u64,
     pub(super) projection: MakerAccountProjection,
+    pub(super) order_request_deadlines: OrderRequestDeadlines,
     pub(super) account_poll: LiveAccountPollState,
     pub(super) order_latency: maker::OrderLatencyTracker,
     pub(super) latency_started: std::time::Instant,
@@ -467,6 +468,7 @@ pub(super) async fn run_startup(
                 cfg.price_tick() / 2.0,
                 qty_tolerance,
             ),
+            order_request_deadlines: OrderRequestDeadlines::default(),
             account_poll,
             order_latency: maker::OrderLatencyTracker::default(),
             latency_started: std::time::Instant::now(),

--- a/crates/standx-maker/src/account_projection.rs
+++ b/crates/standx-maker/src/account_projection.rs
@@ -470,6 +470,19 @@ impl MakerAccountProjection {
             .count()
     }
 
+    /// Whether either half of a submitted request lifecycle is still open.
+    ///
+    /// A request remains live while its acknowledgement or venue-exposure
+    /// slot is still open. For an accepted place that means waiting for the
+    /// corresponding account-order observation; terminal responses and
+    /// explicit cleanup may close a lifecycle earlier. The CLI uses this
+    /// clock-free query without duplicating projection correlation rules.
+    pub fn has_pending_request_lifecycle(&self, request_id: &str) -> bool {
+        self.pending
+            .iter()
+            .any(|entry| entry.request_id() == request_id)
+    }
+
     pub fn completed_request_resolution(
         &self,
         request_id: &str,

--- a/docs/13-maker.md
+++ b/docs/13-maker.md
@@ -199,7 +199,7 @@ live 启动时会先清理旧 `sxmk-` 订单并同步账本，再认证 `order +
 
 运行时使用单一事件循环同时等待周期任务、account/order-response 回调、行情刷新和 Ctrl+C。仓位、成交或流错误在多动作 cycle 中途到达时，会先递增 generation 并进入冻结清理，再取消当前 REST/下单 future；因此本轮后续 placement 不会继续提交，可能已到达交易所的请求也始终由 maker 清理和 REST 对账补偿。旧 generation 的工作结果不会重新开启挂单。普通订单生命周期回报在 cycle 内短暂缓冲，普通行情刷新则合并为一次后续 replan，避免首单确认撕裂多订单计划或产生并发 cycle。
 
-订单回报连接每 30 秒主动发送 heartbeat，45 秒无任何入站流量视为半开，并在 24 小时上限前（23 小时 50 分）主动轮换。create、cancel 和库存退出共用最多 256 项的 request registry；接受、拒绝和晚到回报都按 `request_id` 严格闭环。未确认 place/cancel 的 quote slot 不按策略 cycle 数过期：账户事件可能在一秒内推进多个 cycle，只有关联响应、账户订单终态或显式 cleanup 才能释放对应的 venue exposure。坏载荷、缺失或未知 `request_id`、close/error、registry 重复或溢出都会立即冻结 placement，执行 maker 清理，并以 REST 空簿与仓位对账作为最终确认。
+订单回报连接每 30 秒主动发送 heartbeat，45 秒无任何入站流量视为半开，并在 24 小时上限前（23 小时 50 分）主动轮换。create、cancel 和库存退出共用最多 256 项的 request registry；接受、拒绝和晚到回报都按 `request_id` 严格闭环。每个已提交请求还有独立的 10 秒单调时钟截止：ACK 未闭环，或已接受 place 的对应 account-order 仍不可见，都会把 order-response 标记为不健康，立即冻结 placement、清理 maker 订单并进入 REST 空簿/仓位对账和有界重连；绝不会因超时直接释放占位并继续下单。未确认 place/cancel 的 quote slot 不按策略 cycle 数过期：账户事件可能在一秒内推进多个 cycle，只有关联响应、账户订单终态或显式 cleanup 才能释放对应的 venue exposure。坏载荷、缺失或未知 `request_id`、close/error、registry 重复或溢出也会走相同 fail-closed 路径。
 
 `alert_position_change_pct` 默认 `0`（关闭）。设置为 `20` 时，实际仓位相对上次通知锚点累计变化达到 `max_position` 的 20% 会输出 `risk_notification(kind=position_jump)` 并复用现有 webhook；跨越 inventory-exit/max-position 阈值或多空翻转不受该百分比限制。account stream 断流/恢复、reconciliation 冻结/恢复/失败、volatility breaker、inventory exit、cleanup residual 和最终 fail-safe 也会生成结构化风险通知。
 - **Quiet（`--quiet`）**：只打印成交与增删挂单。

--- a/docs/14-maker-live-gate.md
+++ b/docs/14-maker-live-gate.md
@@ -23,6 +23,7 @@ maker by itself.
 - Account-order cumulative fills and REST trades are tested in both arrival orders and never double-count fills, expected position, or maker-session PnL.
 - Every accepted current-run fill atomically synchronizes ledger position and session telemetry position; an internal mismatch beyond half a quantity tick fails closed before further live placement or risk evaluation.
 - Pending place/cancel quote slots remain reserved across arbitrarily fast strategy cycles until a correlated response, account-order terminal state, or explicit cleanup closes the venue exposure; cycle count alone never authorizes a replacement order.
+- Every submitted create/cancel/inventory-exit request has a 10-second monotonic lifecycle deadline. A missing acknowledgement, or an accepted place that never becomes visible on the correlated account-order stream, freezes placement and requires maker cleanup plus authoritative REST reconciliation; timeout never releases a quote slot by itself.
 - Position jumps, account-stream state changes, reconciliation, volatility breaker, inventory exit, residual cleanup, and final fail-safe emit `risk_notification` telemetry; critical shutdown/cleanup delivery is awaited with a timeout.
 - Inventory-exit configuration remains disabled unless a supervised test has approved its exact threshold and chunk; the recorded XAG-USD test approves only `max_position=0.8`, trigger `25%`, and chunk `0.2`.
 


### PR DESCRIPTION
## Summary
- Add CLI-owned monotonic deadlines for live place, cancel, and inventory-exit requests
- Freeze placement when an ACK or correlated account-order observation fails to arrive within 10 seconds
- Keep request lifecycle tracking aligned with the maker account projection and document the fail-closed behavior

## Testing
- Added unit tests for ACK vs account-order timeout phases
- Added unit tests for out-of-order account-order visibility keeping the ACK deadline open
- Updated maker docs to reflect the new lifecycle deadline behavior