### PR TITLE
Deduplicate maker incident-recovery flows behind shared helpers

### DIFF
--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -46,8 +46,8 @@ use pipeline::{
     CycleRequest, CycleState, LiveAccountPollState, OrderRequestDeadlines, TimedOutOrderRequest,
 };
 use recovery::{
-    cancel_maker_orders_with_retry, ctrl_c_latched, reconcile_ledger_snapshot,
-    reconnect_account_stream, reconnect_order_response, AccountStreamReconnect,
+    cancel_maker_orders_with_retry, ctrl_c_latched, probe_position_convergence,
+    reconnect_account_stream, reconnect_order_response, AccountStreamReconnect, ConvergenceProbe,
     PositionReconciliationCause, PositionReconciliationError, ReconcileRequest,
     ReconnectInterrupted, ReconnectRequest,
 };

--- a/crates/standx-cli/src/commands/maker/model.rs
+++ b/crates/standx-cli/src/commands/maker/model.rs
@@ -33,6 +33,7 @@ impl std::fmt::Display for FailSafeShutdown {
 
 impl std::error::Error for FailSafeShutdown {}
 
+#[derive(Debug)]
 pub(super) enum MakerExit {
     CtrlC,
     OrderResponse(String),

--- a/crates/standx-cli/src/commands/maker/model.rs
+++ b/crates/standx-cli/src/commands/maker/model.rs
@@ -240,3 +240,75 @@ pub(super) fn signed_position_quantity(
         None => qty,
     })
 }
+
+#[cfg(test)]
+mod exit_mapping_tests {
+    use super::MakerExit;
+    use standx_maker::{RecoveryTarget, RuntimeStopReason};
+
+    /// Pins the full RuntimeStopReason → MakerExit mapping so a new stop
+    /// reason (or a re-targeted CleanupFailure) cannot silently land in the
+    /// wrong fail-safe exit bucket.
+    #[test]
+    fn every_runtime_stop_reason_maps_to_the_expected_exit() {
+        assert!(matches!(
+            MakerExit::from(RuntimeStopReason::CtrlC),
+            MakerExit::CtrlC
+        ));
+        assert!(matches!(
+            MakerExit::from(RuntimeStopReason::OrderResponse("boom".to_string())),
+            MakerExit::OrderResponse(detail) if detail == "boom"
+        ));
+        assert!(matches!(
+            MakerExit::from(RuntimeStopReason::PositionReconciliation("boom".to_string())),
+            MakerExit::PositionReconciliation(detail) if detail == "boom"
+        ));
+        assert!(matches!(
+            MakerExit::from(RuntimeStopReason::ConsecutiveCycleErrors("boom".to_string())),
+            MakerExit::ConsecutiveErrors(detail) if detail == "boom"
+        ));
+        assert!(matches!(
+            MakerExit::from(RuntimeStopReason::StopLoss("boom".to_string())),
+            MakerExit::StopLoss(detail) if detail == "boom"
+        ));
+        assert!(matches!(
+            MakerExit::from(RuntimeStopReason::CleanupFailure {
+                target: RecoveryTarget::OrderResponse,
+                reason: "boom".to_string(),
+            }),
+            MakerExit::OrderResponse(detail) if detail == "boom"
+        ));
+        for target in [
+            RecoveryTarget::AccountStream,
+            RecoveryTarget::PositionReconciliation,
+        ] {
+            assert!(matches!(
+                MakerExit::from(RuntimeStopReason::CleanupFailure {
+                    target,
+                    reason: "boom".to_string(),
+                }),
+                MakerExit::PositionReconciliation(detail) if detail == "boom"
+            ));
+        }
+    }
+
+    /// Every fail-safe exit must surface a terminal error (only a clean
+    /// Ctrl+C stop is silent) so supervisors always see a reason on exit 75.
+    #[test]
+    fn only_ctrl_c_exits_without_a_terminal_error() {
+        assert!(MakerExit::CtrlC.terminal_error().is_none());
+        for exit in [
+            MakerExit::OrderResponse("boom".to_string()),
+            MakerExit::ConsecutiveErrors("boom".to_string()),
+            MakerExit::PositionReconciliation("boom".to_string()),
+            MakerExit::AccountingInvariant("boom".to_string()),
+            MakerExit::StopLoss("boom".to_string()),
+        ] {
+            let error = exit
+                .terminal_error()
+                .expect("fail-safe exits carry an error");
+            assert!(error.contains("boom"));
+            assert!(exit.lifecycle_reason().contains("boom"));
+        }
+    }
+}

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -1079,4 +1079,201 @@ mod tests {
         assert_eq!(ledger.expected_position, 0.0);
         assert!((snapshot.position - ledger.expected_position).abs() > 0.0005);
     }
+
+    struct JwtGuard {
+        original: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl JwtGuard {
+        fn set() -> Self {
+            // Share the crate-wide env lock so this STANDX_JWT mutation cannot
+            // race env reads in other modules' tests. See crate::TEST_ENV_LOCK.
+            let lock = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let original = std::env::var("STANDX_JWT").ok();
+            std::env::set_var("STANDX_JWT", "recovery-test-jwt");
+            Self {
+                original,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for JwtGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var("STANDX_JWT", value),
+                None => std::env::remove_var("STANDX_JWT"),
+            }
+        }
+    }
+
+    /// Mocks the four REST reads behind `fetch_account_audit` with the given
+    /// audit content and returns the server (kept alive by the caller).
+    async fn mock_audit_endpoints(
+        open_orders: &[Order],
+        positions: &[Position],
+        filled_orders: &[Order],
+        trades: &[Trade],
+    ) -> (mockito::ServerGuard, StandXClient) {
+        use mockito::{Matcher, Server};
+        let mut server = Server::new_async().await;
+        let wrapped = |items: String| format!(r#"{{"code":0,"message":"ok","result":{items}}}"#);
+        server
+            .mock("GET", "/api/query_open_orders")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(wrapped(serde_json::to_string(open_orders).unwrap()))
+            .create_async()
+            .await;
+        server
+            .mock("GET", "/api/query_positions")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(positions).unwrap())
+            .create_async()
+            .await;
+        server
+            .mock("GET", "/api/query_orders")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(wrapped(serde_json::to_string(filled_orders).unwrap()))
+            .create_async()
+            .await;
+        server
+            .mock("GET", "/api/query_trades")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(wrapped(serde_json::to_string(trades).unwrap()))
+            .create_async()
+            .await;
+        let client = StandXClient::with_base_url(server.url()).unwrap();
+        (server, client)
+    }
+
+    /// Invariant: one probe iteration backfills the cancel-race fill exactly
+    /// once, counts it into the caller's sink, and reports convergence when
+    /// the REST trades explain the whole position gap.
+    #[tokio::test]
+    async fn probe_backfills_trades_into_the_sink_and_converges() {
+        let _jwt = JwtGuard::set();
+        let now = chrono::Utc::now().timestamp();
+        let (_server, client) = mock_audit_endpoints(
+            &[],
+            &[short_position()],
+            &[filled_sell_order()],
+            &[sell_trade(now)],
+        )
+        .await;
+        let mut ledger = MakerLedger::new(0.0);
+        let mut stats = MakerStats::with_inventory_baseline(0.0, 58.20);
+        let mut fills_sink = 0_u64;
+
+        let probe = probe_position_convergence(
+            &client,
+            ReconcileRequest {
+                symbol: SYMBOL,
+                session_started_at: now - 60,
+                run_order_prefix: RUN_PREFIX,
+                qty_tolerance: 0.0005,
+                mark: 58.20,
+            },
+            &mut ledger,
+            &mut stats,
+            &mut fills_sink,
+            7,
+            OutputFormat::Quiet,
+        )
+        .await;
+
+        assert!(
+            matches!(probe, ConvergenceProbe::Converged { observed } if observed == -0.2),
+            "REST-explained gap must converge"
+        );
+        assert_eq!(fills_sink, 1, "the backfilled fill must be counted once");
+        assert_eq!(ledger.expected_position, -0.2);
+    }
+
+    /// Invariant: an unexplained gap stays pending — the probe must not
+    /// invent convergence, and the sink must stay untouched.
+    #[tokio::test]
+    async fn probe_reports_unexplained_gap_as_pending() {
+        let _jwt = JwtGuard::set();
+        let now = chrono::Utc::now().timestamp();
+        let (_server, client) = mock_audit_endpoints(&[], &[short_position()], &[], &[]).await;
+        let mut ledger = MakerLedger::new(0.0);
+        let mut stats = MakerStats::with_inventory_baseline(0.0, 58.20);
+        let mut fills_sink = 0_u64;
+
+        let probe = probe_position_convergence(
+            &client,
+            ReconcileRequest {
+                symbol: SYMBOL,
+                session_started_at: now - 60,
+                run_order_prefix: RUN_PREFIX,
+                qty_tolerance: 0.0005,
+                mark: 58.20,
+            },
+            &mut ledger,
+            &mut stats,
+            &mut fills_sink,
+            7,
+            OutputFormat::Quiet,
+        )
+        .await;
+
+        assert!(
+            matches!(probe, ConvergenceProbe::Pending { observed } if observed == -0.2),
+            "an unexplained gap must stay pending"
+        );
+        assert_eq!(fills_sink, 0);
+        assert_eq!(ledger.expected_position, 0.0);
+    }
+
+    /// Invariant: a failed REST snapshot is reported as such — the caller
+    /// keeps its previous observation and its own error reporting.
+    #[tokio::test]
+    async fn probe_surfaces_snapshot_failures() {
+        use mockito::{Matcher, Server};
+        let _jwt = JwtGuard::set();
+        let now = chrono::Utc::now().timestamp();
+        let mut server = Server::new_async().await;
+        server
+            .mock("GET", "/api/query_open_orders")
+            .match_query(Matcher::Any)
+            .with_status(500)
+            .with_body("venue unavailable")
+            .create_async()
+            .await;
+        let client = StandXClient::with_base_url(server.url()).unwrap();
+        let mut ledger = MakerLedger::new(0.0);
+        let mut stats = MakerStats::with_inventory_baseline(0.0, 58.20);
+        let mut fills_sink = 0_u64;
+
+        let probe = probe_position_convergence(
+            &client,
+            ReconcileRequest {
+                symbol: SYMBOL,
+                session_started_at: now - 60,
+                run_order_prefix: RUN_PREFIX,
+                qty_tolerance: 0.0005,
+                mark: 58.20,
+            },
+            &mut ledger,
+            &mut stats,
+            &mut fills_sink,
+            7,
+            OutputFormat::Quiet,
+        )
+        .await;
+
+        assert!(matches!(probe, ConvergenceProbe::SnapshotFailed(_)));
+        assert_eq!(fills_sink, 0);
+    }
 }

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -1,5 +1,6 @@
 use super::ledger::{adopt_order, apply_rest_trade};
 use super::model::{is_current_run_order, is_maker_order, position_for_symbol};
+use super::output::emit_live_fill;
 use super::pipeline::{fetch_account_audit, AccountAudit};
 use crate::cli::OutputFormat;
 use anyhow::Result;
@@ -276,6 +277,51 @@ pub(super) struct ReconcileRequest<'a> {
     pub(super) run_order_prefix: &'a str,
     pub(super) qty_tolerance: f64,
     pub(super) mark: f64,
+}
+
+pub(super) enum ConvergenceProbe {
+    Converged {
+        observed: f64,
+    },
+    Pending {
+        observed: f64,
+    },
+    /// The REST snapshot failed; the caller reports it its own way and keeps
+    /// its previously observed position.
+    SnapshotFailed(anyhow::Error),
+}
+
+/// One iteration of the bounded position-convergence window shared by the
+/// account-stream and position-reconciliation recovery paths: REST-reconcile
+/// the ledger, emit every newly explained fill, count fills into `fills_sink`,
+/// and compare the observed venue position against `ledger.expected_position`
+/// at `qty_tolerance`. The caller owns the retry loop, its delays, and the
+/// preceding account-event drain.
+pub(super) async fn probe_position_convergence(
+    client: &StandXClient,
+    request: ReconcileRequest<'_>,
+    ledger: &mut MakerLedger,
+    stats: &mut MakerStats,
+    fills_sink: &mut u64,
+    cycle: u64,
+    output_format: OutputFormat,
+) -> ConvergenceProbe {
+    let symbol = request.symbol;
+    let qty_tolerance = request.qty_tolerance;
+    match reconcile_ledger_snapshot(client, request, ledger, stats).await {
+        Ok((observed, fills)) => {
+            *fills_sink += fills.len() as u64;
+            for fill in &fills {
+                emit_live_fill(fill, symbol, cycle, output_format);
+            }
+            if (observed - ledger.expected_position).abs() <= qty_tolerance {
+                ConvergenceProbe::Converged { observed }
+            } else {
+                ConvergenceProbe::Pending { observed }
+            }
+        }
+        Err(error) => ConvergenceProbe::SnapshotFailed(error),
+    }
 }
 
 pub(super) async fn cancel_maker_orders_with_retry(

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -91,6 +91,156 @@ fn stop_requested_exit(runtime_state: &mut MakerState, reason: RuntimeStopReason
     take_stop_effect(runtime_state, MakerExit::PositionReconciliation)
 }
 
+/// Which projection clear an incident flow performs after freeze cleanup.
+#[derive(Clone, Copy)]
+enum ProjectionReset {
+    /// `clear_orders_preserving_pending_acks` — a current-run ack may still
+    /// replay after cleanup (account-stream and reconciliation freezes).
+    PreservePendingAcks,
+    /// `clear_orders_and_pending` — the placement channel is being torn down,
+    /// so pending request acks can never arrive (order-response freeze).
+    DropPendingRequests,
+}
+
+/// How a missing or mismatched runtime effect maps to the flow's stop reason.
+/// (`RuntimeStopReason::CleanupFailure` carries the target, so a plain
+/// `fn(String) -> RuntimeStopReason` pointer cannot express it.)
+#[derive(Clone, Copy)]
+enum EffectFailureStop {
+    CleanupFailure,
+    OrderResponse,
+    PositionReconciliation,
+}
+
+fn effect_failure_stop(
+    kind: EffectFailureStop,
+    target: RecoveryTarget,
+    reason: String,
+) -> RuntimeStopReason {
+    match kind {
+        EffectFailureStop::CleanupFailure => RuntimeStopReason::CleanupFailure { target, reason },
+        EffectFailureStop::OrderResponse => RuntimeStopReason::OrderResponse(reason),
+        EffectFailureStop::PositionReconciliation => {
+            RuntimeStopReason::PositionReconciliation(reason)
+        }
+    }
+}
+
+/// Payload for the position-reconciliation flow's structured
+/// `emit_reconciliation_state` emits around freeze and resume.
+struct ReconciliationStateNote {
+    cause: &'static str,
+    expected: f64,
+    observed: f64,
+}
+
+/// Borrowed bundle of the `run_maker` locals every incident-recovery block
+/// touches. Constructed fresh immediately before each helper call; all
+/// borrows end when the helper returns, so flow-specific code in between
+/// re-borrows the same locals freely.
+struct RecoveryIo<'a> {
+    runtime_state: &'a mut MakerState,
+    notifier: &'a MakerNotifier,
+    client: &'a StandXClient,
+    session: Option<&'a mut LiveSession>,
+    resting: &'a mut Vec<RestingQuote>,
+    inventory_exit_pending: &'a mut bool,
+    symbol: &'a str,
+    cycle: u64,
+    output_format: OutputFormat,
+}
+
+/// Everything that differs between the three incident flows' freeze/cleanup
+/// preambles. The `notice` is built entirely by the caller so the risk
+/// payloads stay reviewable string-for-string at the call sites.
+struct FreezeSpec<'a> {
+    target: RecoveryTarget,
+    trigger: MakerEvent,
+    cleanup_effect_stop: EffectFailureStop,
+    recovery_effect_stop: EffectFailureStop,
+    /// Prepended to `"freeze cleanup failed: {error}"` in the CleanupFailed
+    /// reason so each flow keeps its exact historical wording.
+    cleanup_failure_prefix: String,
+    cleanup_failed_exit: fn(String) -> MakerExit,
+    notice: RiskNotice<'a>,
+    frozen_note: Option<ReconciliationStateNote>,
+    /// Account-stream flow only: abort the stale stream task before
+    /// reporting cleanup complete.
+    abort_account_stream_handle: bool,
+    projection_reset: ProjectionReset,
+}
+
+/// Freeze/cleanup preamble shared by the three incident-recovery flows:
+/// report the fault to the runtime, drain the cleanup effect, notify,
+/// cancel every maker order, reset the local book state, and drain the
+/// recovery effect. `Ok` carries the recovery token for the flow-specific
+/// reconnect/convergence work; `Err` carries the exit the caller must
+/// `break 'main` with.
+async fn freeze_and_cleanup_for_recovery(
+    io: &mut RecoveryIo<'_>,
+    spec: FreezeSpec<'_>,
+) -> std::result::Result<WorkToken, MakerExit> {
+    io.runtime_state.handle(spec.trigger);
+    let cleanup_token = match take_cleanup_effect(io.runtime_state, spec.target) {
+        Ok(token) => token,
+        Err(error) => {
+            return Err(stop_requested_exit(
+                io.runtime_state,
+                effect_failure_stop(spec.cleanup_effect_stop, spec.target, error.to_string()),
+            ));
+        }
+    };
+    if let Some(note) = &spec.frozen_note {
+        emit_reconciliation_state(
+            io.output_format,
+            io.symbol,
+            io.cycle,
+            "frozen",
+            note.cause,
+            note.expected,
+            note.observed,
+        );
+    }
+    io.notifier.risk(spec.notice, false).await;
+    if let Err(error) =
+        cancel_maker_orders_with_retry(io.client, io.symbol, 3, io.output_format).await
+    {
+        io.runtime_state.handle(MakerEvent::CleanupFailed {
+            token: cleanup_token,
+            reason: format!(
+                "{}freeze cleanup failed: {error}",
+                spec.cleanup_failure_prefix
+            ),
+        });
+        return Err(take_stop_effect(io.runtime_state, spec.cleanup_failed_exit));
+    }
+    io.resting.clear();
+    if let Some(session) = io.session.as_deref_mut() {
+        invalidate_session_latency(session);
+        match spec.projection_reset {
+            ProjectionReset::PreservePendingAcks => {
+                session.projection.clear_orders_preserving_pending_acks()
+            }
+            ProjectionReset::DropPendingRequests => session.projection.clear_orders_and_pending(),
+        }
+    }
+    *io.inventory_exit_pending = false;
+    if spec.abort_account_stream_handle {
+        if let Some(session) = io.session.as_deref_mut() {
+            session.account_stream_handle.abort();
+        }
+    }
+    io.runtime_state
+        .handle(MakerEvent::CleanupCompleted(cleanup_token));
+    match take_recovery_effect(io.runtime_state, spec.target) {
+        Ok(token) => Ok(token),
+        Err(error) => Err(stop_requested_exit(
+            io.runtime_state,
+            effect_failure_stop(spec.recovery_effect_stop, spec.target, error.to_string()),
+        )),
+    }
+}
+
 /// A buffered or queued order-response signals a genuine correlation failure
 /// only when it carried a `request_id` that matched no pending request. A
 /// matched accepted placement/cancel or rejected placement remains correlated,
@@ -1167,26 +1317,33 @@ pub(super) async fn run_maker(
                     .unwrap_or_else(|| {
                         "account stream became unhealthy without a recorded reason".to_string()
                     });
-                runtime_state.handle(MakerEvent::AccountStreamDisconnected(detail.clone()));
-                let cleanup_token =
-                    match take_cleanup_effect(&mut runtime_state, RecoveryTarget::AccountStream) {
-                        Ok(token) => token,
-                        Err(error) => {
-                            break stop_requested_exit(
-                                &mut runtime_state,
-                                RuntimeStopReason::CleanupFailure {
-                                    target: RecoveryTarget::AccountStream,
-                                    reason: error.to_string(),
-                                },
-                            );
-                        }
-                    };
                 let message = format!(
                     "account stream unavailable; placements frozen and cleanup starting: {detail}"
                 );
-                notifier
-                    .risk(
-                        RiskNotice {
+                // Freeze immediately: no further cycle can place while the
+                // authoritative account stream is unavailable. The stale
+                // receiver/health stay in place until the reconnect replaces
+                // them; every failure path below exits the loop.
+                let recovery_token = match freeze_and_cleanup_for_recovery(
+                    &mut RecoveryIo {
+                        runtime_state: &mut runtime_state,
+                        notifier: &notifier,
+                        client: &client,
+                        session: Some(&mut *session),
+                        resting: &mut resting,
+                        inventory_exit_pending: &mut inventory_exit_pending,
+                        symbol: &symbol,
+                        cycle,
+                        output_format,
+                    },
+                    FreezeSpec {
+                        target: RecoveryTarget::AccountStream,
+                        trigger: MakerEvent::AccountStreamDisconnected(detail.clone()),
+                        cleanup_effect_stop: EffectFailureStop::CleanupFailure,
+                        recovery_effect_stop: EffectFailureStop::PositionReconciliation,
+                        cleanup_failure_prefix: format!("account stream disconnected ({detail}); "),
+                        cleanup_failed_exit: MakerExit::PositionReconciliation,
+                        notice: RiskNotice {
                             kind: "account_stream",
                             severity: "warning",
                             event: "disconnected_frozen",
@@ -1198,40 +1355,16 @@ pub(super) async fn run_maker(
                             expected: Some(ledger.expected_position),
                             observed: None,
                         },
-                        false,
-                    )
-                    .await;
-                // Freeze immediately: no further cycle can place while the
-                // authoritative account stream is unavailable.
-                if let Err(cleanup_error) =
-                    cancel_maker_orders_with_retry(&client, &symbol, 3, output_format).await
+                        frozen_note: None,
+                        abort_account_stream_handle: true,
+                        projection_reset: ProjectionReset::PreservePendingAcks,
+                    },
+                )
+                .await
                 {
-                    runtime_state.handle(MakerEvent::CleanupFailed {
-                        token: cleanup_token,
-                        reason: format!(
-                            "account stream disconnected ({detail}); freeze cleanup failed: {cleanup_error}"
-                        ),
-                    });
-                    break take_stop_effect(&mut runtime_state, MakerExit::PositionReconciliation);
-                }
-                resting.clear();
-                invalidate_session_latency(session);
-                session.projection.clear_orders_preserving_pending_acks();
-                inventory_exit_pending = false;
-                // The stale receiver/health stay in place until the reconnect
-                // replaces them; every failure path below exits the loop.
-                session.account_stream_handle.abort();
-                runtime_state.handle(MakerEvent::CleanupCompleted(cleanup_token));
-                let recovery_token =
-                    match take_recovery_effect(&mut runtime_state, RecoveryTarget::AccountStream) {
-                        Ok(token) => token,
-                        Err(error) => {
-                            break stop_requested_exit(
-                                &mut runtime_state,
-                                RuntimeStopReason::PositionReconciliation(error.to_string()),
-                            );
-                        }
-                    };
+                    Ok(token) => token,
+                    Err(exit) => break exit,
+                };
 
                 if args.account_stream_reconnect_attempts == 0 {
                     break recovery_failed_exit(
@@ -1473,25 +1606,31 @@ pub(super) async fn run_maker(
                         "order-response stream became unhealthy without a recorded reason"
                             .to_string()
                     });
-                runtime_state.handle(MakerEvent::OrderResponseDisconnected(detail.clone()));
-                let cleanup_token =
-                    match take_cleanup_effect(&mut runtime_state, RecoveryTarget::OrderResponse) {
-                        Ok(token) => token,
-                        Err(error) => {
-                            break stop_requested_exit(
-                                &mut runtime_state,
-                                RuntimeStopReason::OrderResponse(error.to_string()),
-                            );
-                        }
-                    };
                 let controlled_fault = detail.starts_with("controlled fault injection");
                 // Mirror the account-stream path: the order-response stream was
                 // previously silent on the webhook across disconnect/reconnect.
                 let disconnect_message =
                     format!("order-response stream unavailable; placements frozen: {detail}");
-                notifier
-                    .risk(
-                        RiskNotice {
+                let recovery_token = match freeze_and_cleanup_for_recovery(
+                    &mut RecoveryIo {
+                        runtime_state: &mut runtime_state,
+                        notifier: &notifier,
+                        client: &client,
+                        session: Some(&mut *session),
+                        resting: &mut resting,
+                        inventory_exit_pending: &mut inventory_exit_pending,
+                        symbol: &symbol,
+                        cycle,
+                        output_format,
+                    },
+                    FreezeSpec {
+                        target: RecoveryTarget::OrderResponse,
+                        trigger: MakerEvent::OrderResponseDisconnected(detail.clone()),
+                        cleanup_effect_stop: EffectFailureStop::OrderResponse,
+                        recovery_effect_stop: EffectFailureStop::OrderResponse,
+                        cleanup_failure_prefix: "order-response ".to_string(),
+                        cleanup_failed_exit: MakerExit::OrderResponse,
+                        notice: RiskNotice {
                             kind: "order_response",
                             severity: "warning",
                             event: "disconnected_frozen",
@@ -1503,33 +1642,16 @@ pub(super) async fn run_maker(
                             expected: Some(ledger.expected_position),
                             observed: None,
                         },
-                        false,
-                    )
-                    .await;
-                if let Err(error) =
-                    cancel_maker_orders_with_retry(&client, &symbol, 3, output_format).await
+                        frozen_note: None,
+                        abort_account_stream_handle: false,
+                        projection_reset: ProjectionReset::DropPendingRequests,
+                    },
+                )
+                .await
                 {
-                    runtime_state.handle(MakerEvent::CleanupFailed {
-                        token: cleanup_token,
-                        reason: format!("order-response freeze cleanup failed: {error}"),
-                    });
-                    break take_stop_effect(&mut runtime_state, MakerExit::OrderResponse);
-                }
-                resting.clear();
-                invalidate_session_latency(session);
-                session.projection.clear_orders_and_pending();
-                inventory_exit_pending = false;
-                runtime_state.handle(MakerEvent::CleanupCompleted(cleanup_token));
-                let recovery_token =
-                    match take_recovery_effect(&mut runtime_state, RecoveryTarget::OrderResponse) {
-                        Ok(token) => token,
-                        Err(error) => {
-                            break stop_requested_exit(
-                                &mut runtime_state,
-                                RuntimeStopReason::OrderResponse(error.to_string()),
-                            );
-                        }
-                    };
+                    Ok(token) => token,
+                    Err(exit) => break exit,
+                };
                 let reconnect_unavailable = if controlled_fault {
                     Some("controlled fault injection requires fail-safe shutdown".to_string())
                 } else if args.order_response_reconnect_attempts == 0 {
@@ -2386,47 +2508,39 @@ pub(super) async fn run_maker(
                 }
                 if let Some(mismatch) = e.downcast_ref::<PositionReconciliationError>() {
                     let reconciliation_cause = mismatch.cause.label();
-                    runtime_state.handle(MakerEvent::PositionMismatch);
-                    let cleanup_token = match take_cleanup_effect(
-                        &mut runtime_state,
-                        RecoveryTarget::PositionReconciliation,
-                    ) {
-                        Ok(token) => token,
-                        Err(error) => {
-                            break 'main stop_requested_exit(
-                                &mut runtime_state,
-                                RuntimeStopReason::CleanupFailure {
-                                    target: RecoveryTarget::PositionReconciliation,
-                                    reason: error.to_string(),
-                                },
-                            );
-                        }
-                    };
                     // A mismatch is not a normal cycle error. Freeze quoting,
                     // empty the maker book, and give account-order callbacks
                     // plus REST settlement a bounded three-second window to
                     // converge before failing closed.
-                    emit_reconciliation_state(
-                        output_format,
-                        &symbol,
-                        cycle,
-                        "frozen",
-                        reconciliation_cause,
-                        mismatch.expected,
-                        mismatch.observed,
-                    );
-                    notifier
-                        .risk(
-                            RiskNotice {
-                            kind: "position_reconciliation",
-                            severity: "warning",
-                            event: "frozen",
-                            message: match &mismatch.cause {
-                                PositionReconciliationCause::CycleInvalidation => "account update invalidated active cycle; placements frozen and maker cleanup starting",
-                                PositionReconciliationCause::UnknownCurrentRunOrder => "unknown current-run order detected; placements frozen and maker cleanup starting",
-                                PositionReconciliationCause::AccountProjectionMismatch(_) => "account projection audit failed; placements frozen and maker cleanup starting",
-                                PositionReconciliationCause::PositionMismatch => "position mismatch detected; placements frozen and maker cleanup starting",
-                            },
+                    let recovery_token = match freeze_and_cleanup_for_recovery(
+                        &mut RecoveryIo {
+                            runtime_state: &mut runtime_state,
+                            notifier: &notifier,
+                            client: &client,
+                            session: live_session.as_mut(),
+                            resting: &mut resting,
+                            inventory_exit_pending: &mut inventory_exit_pending,
+                            symbol: &symbol,
+                            cycle,
+                            output_format,
+                        },
+                        FreezeSpec {
+                            target: RecoveryTarget::PositionReconciliation,
+                            trigger: MakerEvent::PositionMismatch,
+                            cleanup_effect_stop: EffectFailureStop::CleanupFailure,
+                            recovery_effect_stop: EffectFailureStop::PositionReconciliation,
+                            cleanup_failure_prefix: String::new(),
+                            cleanup_failed_exit: MakerExit::PositionReconciliation,
+                            notice: RiskNotice {
+                                kind: "position_reconciliation",
+                                severity: "warning",
+                                event: "frozen",
+                                message: match &mismatch.cause {
+                                    PositionReconciliationCause::CycleInvalidation => "account update invalidated active cycle; placements frozen and maker cleanup starting",
+                                    PositionReconciliationCause::UnknownCurrentRunOrder => "unknown current-run order detected; placements frozen and maker cleanup starting",
+                                    PositionReconciliationCause::AccountProjectionMismatch(_) => "account projection audit failed; placements frozen and maker cleanup starting",
+                                    PositionReconciliationCause::PositionMismatch => "position mismatch detected; placements frozen and maker cleanup starting",
+                                },
                                 symbol: &symbol,
                                 cycle,
                                 position_before: None,
@@ -2434,39 +2548,19 @@ pub(super) async fn run_maker(
                                 expected: Some(mismatch.expected),
                                 observed: Some(mismatch.observed),
                             },
-                            false,
-                        )
-                    .await;
-                    if let Err(cleanup_error) =
-                        cancel_maker_orders_with_retry(&client, &symbol, 3, output_format).await
+                            frozen_note: Some(ReconciliationStateNote {
+                                cause: reconciliation_cause,
+                                expected: mismatch.expected,
+                                observed: mismatch.observed,
+                            }),
+                            abort_account_stream_handle: false,
+                            projection_reset: ProjectionReset::PreservePendingAcks,
+                        },
+                    )
+                    .await
                     {
-                        runtime_state.handle(MakerEvent::CleanupFailed {
-                            token: cleanup_token,
-                            reason: format!("freeze cleanup failed: {cleanup_error}"),
-                        });
-                        break 'main take_stop_effect(
-                            &mut runtime_state,
-                            MakerExit::PositionReconciliation,
-                        );
-                    }
-                    resting.clear();
-                    if let Some(session) = live_session.as_mut() {
-                        invalidate_session_latency(session);
-                        session.projection.clear_orders_preserving_pending_acks();
-                    }
-                    inventory_exit_pending = false;
-                    runtime_state.handle(MakerEvent::CleanupCompleted(cleanup_token));
-                    let recovery_token = match take_recovery_effect(
-                        &mut runtime_state,
-                        RecoveryTarget::PositionReconciliation,
-                    ) {
                         Ok(token) => token,
-                        Err(error) => {
-                            break 'main stop_requested_exit(
-                                &mut runtime_state,
-                                RuntimeStopReason::PositionReconciliation(error.to_string()),
-                            );
-                        }
+                        Err(exit) => break 'main exit,
                     };
                     // Genuine mismatch/projection anomalies share the same
                     // rolling budget as transport reconnects. A normal account
@@ -2933,6 +3027,52 @@ mod tests {
         assert_eq!(
             detail,
             "order request lifecycle timed out after 10.250s: kind=cancel request_id=request-7 waiting_for=account_order; refusing further live orders"
+        );
+    }
+
+    /// Pins the per-flow mapping from a missing/mismatched runtime effect to
+    /// its stop reason: the order-response flow stops as OrderResponse even
+    /// for cleanup failures, while the other flows carry the target through
+    /// CleanupFailure or fall back to PositionReconciliation.
+    #[test]
+    fn effect_failure_stop_maps_each_flow_variant() {
+        assert_eq!(
+            effect_failure_stop(
+                EffectFailureStop::CleanupFailure,
+                RecoveryTarget::AccountStream,
+                "boom".to_string(),
+            ),
+            RuntimeStopReason::CleanupFailure {
+                target: RecoveryTarget::AccountStream,
+                reason: "boom".to_string(),
+            }
+        );
+        assert_eq!(
+            effect_failure_stop(
+                EffectFailureStop::CleanupFailure,
+                RecoveryTarget::PositionReconciliation,
+                "boom".to_string(),
+            ),
+            RuntimeStopReason::CleanupFailure {
+                target: RecoveryTarget::PositionReconciliation,
+                reason: "boom".to_string(),
+            }
+        );
+        assert_eq!(
+            effect_failure_stop(
+                EffectFailureStop::OrderResponse,
+                RecoveryTarget::OrderResponse,
+                "boom".to_string(),
+            ),
+            RuntimeStopReason::OrderResponse("boom".to_string())
+        );
+        assert_eq!(
+            effect_failure_stop(
+                EffectFailureStop::PositionReconciliation,
+                RecoveryTarget::AccountStream,
+                "boom".to_string(),
+            ),
+            RuntimeStopReason::PositionReconciliation("boom".to_string())
         );
     }
 

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -145,6 +145,8 @@ struct RecoveryIo<'a> {
     session: Option<&'a mut LiveSession>,
     resting: &'a mut Vec<RestingQuote>,
     inventory_exit_pending: &'a mut bool,
+    consecutive_errors: &'a mut u32,
+    next_cycle_is_recovery: &'a mut bool,
     symbol: &'a str,
     cycle: u64,
     output_format: OutputFormat,
@@ -239,6 +241,70 @@ async fn freeze_and_cleanup_for_recovery(
             effect_failure_stop(spec.recovery_effect_stop, spec.target, error.to_string()),
         )),
     }
+}
+
+/// Everything that differs between the three incident flows' resume tails.
+/// As with [`FreezeSpec`], the resolved `notice` is built entirely by the
+/// caller.
+struct ResumeSpec<'a> {
+    recovery_token: WorkToken,
+    /// Venue position fed to the projection as authoritative after recovery.
+    observed: f64,
+    projection_reset: ProjectionReset,
+    /// Order-response flow only: the paper book is cleared again because the
+    /// placement channel was replaced underneath it.
+    clear_resting: bool,
+    reset_consecutive_errors: bool,
+    recovered_note: Option<ReconciliationStateNote>,
+    notice: RiskNotice<'a>,
+}
+
+/// Resume tail shared by the three incident-recovery flows: reset the
+/// projection to an empty verified book, seed it with the reconciled venue
+/// position, report RecoverySucceeded, and send the resolved notice. The
+/// caller performs its flow-specific final book verification and session
+/// half installation *before* calling this, and `continue`s the main loop
+/// afterwards.
+async fn resume_quoting_after_recovery(io: &mut RecoveryIo<'_>, spec: ResumeSpec<'_>) {
+    if spec.clear_resting {
+        io.resting.clear();
+    }
+    if let Some(session) = io.session.as_deref_mut() {
+        match spec.projection_reset {
+            ProjectionReset::PreservePendingAcks => {
+                session.projection.clear_orders_preserving_pending_acks()
+            }
+            ProjectionReset::DropPendingRequests => session.projection.clear_orders_and_pending(),
+        }
+        let generation = session.projection.generation();
+        session.projection.apply(
+            generation,
+            AccountProjectionEvent::PositionObserved {
+                position: spec.observed,
+            },
+        );
+    }
+    if spec.reset_consecutive_errors {
+        *io.consecutive_errors = 0;
+    }
+    io.runtime_state
+        .handle(MakerEvent::RecoverySucceeded(spec.recovery_token));
+    *io.next_cycle_is_recovery = true;
+    // The mutations above must stay synchronous and contiguous: no awaits or
+    // output may be inserted between them, so the runtime state, projection,
+    // and loop flags advance atomically with respect to the notice below.
+    if let Some(note) = &spec.recovered_note {
+        emit_reconciliation_state(
+            io.output_format,
+            io.symbol,
+            io.cycle,
+            "recovered",
+            note.cause,
+            note.expected,
+            note.observed,
+        );
+    }
+    io.notifier.risk(spec.notice, false).await;
 }
 
 /// A buffered or queued order-response signals a genuine correlation failure
@@ -1332,6 +1398,8 @@ pub(super) async fn run_maker(
                         session: Some(&mut *session),
                         resting: &mut resting,
                         inventory_exit_pending: &mut inventory_exit_pending,
+                        consecutive_errors: &mut consecutive_errors,
+                        next_cycle_is_recovery: &mut next_cycle_is_recovery,
                         symbol: &symbol,
                         cycle,
                         output_format,
@@ -1566,22 +1634,32 @@ pub(super) async fn run_maker(
                         ),
                     );
                 }
-                projection.clear_orders_preserving_pending_acks();
-
                 session.account_events = events;
                 session.account_stream_health = health;
                 session.account_stream_handle = handle;
-                let generation = session.projection.generation();
-                session.projection.apply(
-                    generation,
-                    AccountProjectionEvent::PositionObserved { position: observed },
-                );
                 total_fills += reconnect_fills;
-                runtime_state.handle(MakerEvent::RecoverySucceeded(recovery_token));
-                next_cycle_is_recovery = true;
-                notifier
-                    .risk(
-                        RiskNotice {
+                resume_quoting_after_recovery(
+                    &mut RecoveryIo {
+                        runtime_state: &mut runtime_state,
+                        notifier: &notifier,
+                        client: &client,
+                        session: Some(&mut *session),
+                        resting: &mut resting,
+                        inventory_exit_pending: &mut inventory_exit_pending,
+                        consecutive_errors: &mut consecutive_errors,
+                        next_cycle_is_recovery: &mut next_cycle_is_recovery,
+                        symbol: &symbol,
+                        cycle,
+                        output_format,
+                    },
+                    ResumeSpec {
+                        recovery_token,
+                        observed,
+                        projection_reset: ProjectionReset::PreservePendingAcks,
+                        clear_resting: false,
+                        reset_consecutive_errors: false,
+                        recovered_note: None,
+                        notice: RiskNotice {
                             kind: "account_stream",
                             severity: "resolved",
                             event: "reconnected",
@@ -1593,8 +1671,8 @@ pub(super) async fn run_maker(
                             expected: Some(ledger.expected_position),
                             observed: Some(observed),
                         },
-                        false,
-                    )
+                    },
+                )
                 .await;
                 continue;
             }
@@ -1619,6 +1697,8 @@ pub(super) async fn run_maker(
                         session: Some(&mut *session),
                         resting: &mut resting,
                         inventory_exit_pending: &mut inventory_exit_pending,
+                        consecutive_errors: &mut consecutive_errors,
+                        next_cycle_is_recovery: &mut next_cycle_is_recovery,
                         symbol: &symbol,
                         cycle,
                         output_format,
@@ -1715,21 +1795,28 @@ pub(super) async fn run_maker(
                             session.order_response_handle = reconnected.handle;
                             // Cleanup verified an empty maker book. The next
                             // cycle rebuilds exchange state before it may place.
-                            resting.clear();
-                            session.projection.clear_orders_and_pending();
-                            let generation = session.projection.generation();
-                            session.projection.apply(
-                                generation,
-                                AccountProjectionEvent::PositionObserved {
-                                    position: reconciled_position,
+                            resume_quoting_after_recovery(
+                                &mut RecoveryIo {
+                                    runtime_state: &mut runtime_state,
+                                    notifier: &notifier,
+                                    client: &client,
+                                    session: Some(&mut *session),
+                                    resting: &mut resting,
+                                    inventory_exit_pending: &mut inventory_exit_pending,
+                                    consecutive_errors: &mut consecutive_errors,
+                                    next_cycle_is_recovery: &mut next_cycle_is_recovery,
+                                    symbol: &symbol,
+                                    cycle,
+                                    output_format,
                                 },
-                            );
-                            consecutive_errors = 0;
-                            runtime_state.handle(MakerEvent::RecoverySucceeded(recovery_token));
-                            next_cycle_is_recovery = true;
-                            notifier
-                                .risk(
-                                    RiskNotice {
+                                ResumeSpec {
+                                    recovery_token,
+                                    observed: reconciled_position,
+                                    projection_reset: ProjectionReset::DropPendingRequests,
+                                    clear_resting: true,
+                                    reset_consecutive_errors: true,
+                                    recovered_note: None,
+                                    notice: RiskNotice {
                                         kind: "order_response",
                                         severity: "resolved",
                                         event: "reconnected",
@@ -1741,9 +1828,9 @@ pub(super) async fn run_maker(
                                         expected: Some(ledger.expected_position),
                                         observed: Some(reconciled_position),
                                     },
-                                    false,
-                                )
-                                .await;
+                                },
+                            )
+                            .await;
                             continue;
                         }
                         Err(error) => {
@@ -2520,6 +2607,8 @@ pub(super) async fn run_maker(
                             session: live_session.as_mut(),
                             resting: &mut resting,
                             inventory_exit_pending: &mut inventory_exit_pending,
+                            consecutive_errors: &mut consecutive_errors,
+                            next_cycle_is_recovery: &mut next_cycle_is_recovery,
                             symbol: &symbol,
                             cycle,
                             output_format,
@@ -2685,28 +2774,32 @@ pub(super) async fn run_maker(
                             );
                         }
                         account_order_reconciliation_required = false;
-                        if let Some(session) = live_session.as_mut() {
-                            session.projection.clear_orders_preserving_pending_acks();
-                            let generation = session.projection.generation();
-                            session.projection.apply(
-                                generation,
-                                AccountProjectionEvent::PositionObserved {
-                                    position: last_observed,
-                                },
-                            );
-                        }
-                        emit_reconciliation_state(
-                            output_format,
-                            &symbol,
-                            cycle,
-                            "recovered",
-                            reconciliation_cause,
-                            ledger.expected_position,
-                            last_observed,
-                        );
-                        notifier
-                            .risk(
-                                RiskNotice {
+                        resume_quoting_after_recovery(
+                            &mut RecoveryIo {
+                                runtime_state: &mut runtime_state,
+                                notifier: &notifier,
+                                client: &client,
+                                session: live_session.as_mut(),
+                                resting: &mut resting,
+                                inventory_exit_pending: &mut inventory_exit_pending,
+                                consecutive_errors: &mut consecutive_errors,
+                                next_cycle_is_recovery: &mut next_cycle_is_recovery,
+                                symbol: &symbol,
+                                cycle,
+                                output_format,
+                            },
+                            ResumeSpec {
+                                recovery_token,
+                                observed: last_observed,
+                                projection_reset: ProjectionReset::PreservePendingAcks,
+                                clear_resting: false,
+                                reset_consecutive_errors: true,
+                                recovered_note: Some(ReconciliationStateNote {
+                                    cause: reconciliation_cause,
+                                    expected: ledger.expected_position,
+                                    observed: last_observed,
+                                }),
+                                notice: RiskNotice {
                                     kind: "position_reconciliation",
                                     severity: "resolved",
                                     event: "recovered",
@@ -2718,12 +2811,9 @@ pub(super) async fn run_maker(
                                     expected: Some(ledger.expected_position),
                                     observed: Some(last_observed),
                                 },
-                                false,
-                            )
+                            },
+                        )
                         .await;
-                        consecutive_errors = 0;
-                        runtime_state.handle(MakerEvent::RecoverySucceeded(recovery_token));
-                        next_cycle_is_recovery = true;
                         continue;
                     }
                     emit_reconciliation_state(

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -126,6 +126,13 @@ fn effect_failure_stop(
     }
 }
 
+fn reset_projection(projection: &mut MakerAccountProjection, reset: ProjectionReset) {
+    match reset {
+        ProjectionReset::PreservePendingAcks => projection.clear_orders_preserving_pending_acks(),
+        ProjectionReset::DropPendingRequests => projection.clear_orders_and_pending(),
+    }
+}
+
 /// Payload for the position-reconciliation flow's structured
 /// `emit_reconciliation_state` emits around freeze and resume.
 struct ReconciliationStateNote {
@@ -219,12 +226,7 @@ async fn freeze_and_cleanup_for_recovery(
     io.resting.clear();
     if let Some(session) = io.session.as_deref_mut() {
         invalidate_session_latency(session);
-        match spec.projection_reset {
-            ProjectionReset::PreservePendingAcks => {
-                session.projection.clear_orders_preserving_pending_acks()
-            }
-            ProjectionReset::DropPendingRequests => session.projection.clear_orders_and_pending(),
-        }
+        reset_projection(&mut session.projection, spec.projection_reset);
     }
     *io.inventory_exit_pending = false;
     if spec.abort_account_stream_handle {
@@ -270,12 +272,7 @@ async fn resume_quoting_after_recovery(io: &mut RecoveryIo<'_>, spec: ResumeSpec
         io.resting.clear();
     }
     if let Some(session) = io.session.as_deref_mut() {
-        match spec.projection_reset {
-            ProjectionReset::PreservePendingAcks => {
-                session.projection.clear_orders_preserving_pending_acks()
-            }
-            ProjectionReset::DropPendingRequests => session.projection.clear_orders_and_pending(),
-        }
+        reset_projection(&mut session.projection, spec.projection_reset);
         let generation = session.projection.generation();
         session.projection.apply(
             generation,
@@ -4257,6 +4254,378 @@ mod tests {
             accounting_invariant_exit(&notifier, "XAG-USD", 1396, 0.0, 0.00049, 0.0005,)
                 .await
                 .is_none()
+        );
+    }
+
+    // ---- Fault-injection conformance tests for the shared recovery helpers ----
+
+    struct JwtGuard {
+        original: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl JwtGuard {
+        fn set() -> Self {
+            // Share the crate-wide env lock so this STANDX_JWT mutation cannot
+            // race env reads in other modules' tests. See crate::TEST_ENV_LOCK.
+            let lock = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let original = std::env::var("STANDX_JWT").ok();
+            std::env::set_var("STANDX_JWT", "runtime-test-jwt");
+            Self {
+                original,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for JwtGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var("STANDX_JWT", value),
+                None => std::env::remove_var("STANDX_JWT"),
+            }
+        }
+    }
+
+    fn quiet_notifier() -> MakerNotifier {
+        MakerNotifier::new(
+            OutputFormat::Quiet,
+            None,
+            crate::cli::AlertWebhookFormat::Raw,
+        )
+    }
+
+    fn resting_quote() -> RestingQuote {
+        RestingQuote {
+            order_id: None,
+            side: OrderSide::Buy,
+            level: 0,
+            price: 100.0,
+            qty: 0.001,
+            ref_center: 100.0,
+            placed_at_cycle: 1,
+        }
+    }
+
+    fn warning_notice(kind: &'static str) -> RiskNotice<'static> {
+        RiskNotice {
+            kind,
+            severity: "warning",
+            event: "disconnected_frozen",
+            message: "test freeze",
+            symbol: "BTC-USD",
+            cycle: 7,
+            position_before: None,
+            position_after: None,
+            expected: Some(0.0),
+            observed: None,
+        }
+    }
+
+    fn order_response_freeze_spec() -> FreezeSpec<'static> {
+        FreezeSpec {
+            target: RecoveryTarget::OrderResponse,
+            trigger: MakerEvent::OrderResponseDisconnected("stream closed".to_string()),
+            cleanup_effect_stop: EffectFailureStop::OrderResponse,
+            recovery_effect_stop: EffectFailureStop::OrderResponse,
+            cleanup_failure_prefix: "order-response ".to_string(),
+            cleanup_failed_exit: MakerExit::OrderResponse,
+            notice: warning_notice("order_response"),
+            frozen_note: None,
+            abort_account_stream_handle: false,
+            projection_reset: ProjectionReset::DropPendingRequests,
+        }
+    }
+
+    /// Invariant: the freeze preamble empties the maker book on the venue
+    /// (cancelling only maker-owned orders), clears local book state, and
+    /// hands back a recovery token from which quoting can resume.
+    #[tokio::test]
+    async fn freeze_preamble_empties_the_maker_book_and_hands_back_recovery() {
+        use mockito::{Matcher, Server};
+        let _jwt = JwtGuard::set();
+        let mut server = Server::new_async().await;
+        let open_before = server
+            .mock("GET", "/api/query_open_orders")
+            .match_query(Matcher::UrlEncoded("symbol".into(), "BTC-USD".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"code":0,"message":"ok","result":[
+                    {"id":"42","cl_ord_id":"sxmk-freeze-buy","symbol":"BTC-USD","side":"buy","order_type":"limit","qty":"0.001","fill_qty":"0","price":"63000","status":"open","created_at":"2026-07-10T00:00:00Z","updated_at":"2026-07-10T00:00:00Z"},
+                    {"id":"99","cl_ord_id":"manual-order","symbol":"BTC-USD","side":"sell","order_type":"limit","qty":"0.001","fill_qty":"0","price":"65000","status":"open","created_at":"2026-07-10T00:00:00Z","updated_at":"2026-07-10T00:00:00Z"}
+                ]}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let cancel = server
+            .mock("POST", "/api/cancel_orders")
+            .match_body(Matcher::Json(serde_json::json!({ "order_id_list": [42] })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"code":0,"message":"accepted"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let open_after = server
+            .mock("GET", "/api/query_open_orders")
+            .match_query(Matcher::UrlEncoded("symbol".into(), "BTC-USD".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"code":0,"message":"ok","result":[
+                    {"id":"99","cl_ord_id":"manual-order","symbol":"BTC-USD","side":"sell","order_type":"limit","qty":"0.001","fill_qty":"0","price":"65000","status":"open","created_at":"2026-07-10T00:00:00Z","updated_at":"2026-07-10T00:00:00Z"}
+                ]}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = StandXClient::with_base_url(server.url()).unwrap();
+        let notifier = quiet_notifier();
+        let mut runtime_state = MakerState::starting();
+        runtime_state.handle(MakerEvent::StartupReady);
+        assert!(matches!(
+            runtime_state.next_effect(),
+            Some(MakerEffect::RunCycle(_))
+        ));
+        let mut resting = vec![resting_quote()];
+        let mut inventory_exit_pending = true;
+        let mut consecutive_errors = 2;
+        let mut next_cycle_is_recovery = false;
+
+        let recovery_token = freeze_and_cleanup_for_recovery(
+            &mut RecoveryIo {
+                runtime_state: &mut runtime_state,
+                notifier: &notifier,
+                client: &client,
+                session: None,
+                resting: &mut resting,
+                inventory_exit_pending: &mut inventory_exit_pending,
+                consecutive_errors: &mut consecutive_errors,
+                next_cycle_is_recovery: &mut next_cycle_is_recovery,
+                symbol: "BTC-USD",
+                cycle: 7,
+                output_format: OutputFormat::Quiet,
+            },
+            order_response_freeze_spec(),
+        )
+        .await
+        .expect("freeze preamble must hand back a recovery token");
+
+        assert!(resting.is_empty(), "local book must be cleared");
+        assert!(!inventory_exit_pending);
+        assert!(
+            runtime_state.pending_effect().is_none(),
+            "no stale effects may remain after the preamble"
+        );
+        open_before.assert_async().await;
+        cancel.assert_async().await;
+        open_after.assert_async().await;
+
+        // Recovery success must resume quoting with a fresh cycle.
+        runtime_state.handle(MakerEvent::RecoverySucceeded(recovery_token));
+        assert!(matches!(
+            runtime_state.next_effect(),
+            Some(MakerEffect::RunCycle(_))
+        ));
+    }
+
+    /// Invariant: when the venue book cannot be emptied, the preamble stops
+    /// the runtime with the flow's exit and its exact historical wording.
+    #[tokio::test]
+    async fn freeze_preamble_cleanup_failure_stops_with_the_flow_exit() {
+        use mockito::{Matcher, Server};
+        let _jwt = JwtGuard::set();
+        let mut server = Server::new_async().await;
+        let open_orders = server
+            .mock("GET", "/api/query_open_orders")
+            .match_query(Matcher::UrlEncoded("symbol".into(), "BTC-USD".into()))
+            .with_status(500)
+            .with_body("venue unavailable")
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let client = StandXClient::with_base_url(server.url()).unwrap();
+        let notifier = quiet_notifier();
+        let mut runtime_state = MakerState::starting();
+        runtime_state.handle(MakerEvent::StartupReady);
+        let _ = runtime_state.next_effect();
+        let mut resting = vec![resting_quote()];
+        let mut inventory_exit_pending = false;
+        let mut consecutive_errors = 0;
+        let mut next_cycle_is_recovery = false;
+
+        let exit = freeze_and_cleanup_for_recovery(
+            &mut RecoveryIo {
+                runtime_state: &mut runtime_state,
+                notifier: &notifier,
+                client: &client,
+                session: None,
+                resting: &mut resting,
+                inventory_exit_pending: &mut inventory_exit_pending,
+                consecutive_errors: &mut consecutive_errors,
+                next_cycle_is_recovery: &mut next_cycle_is_recovery,
+                symbol: "BTC-USD",
+                cycle: 7,
+                output_format: OutputFormat::Quiet,
+            },
+            order_response_freeze_spec(),
+        )
+        .await
+        .expect_err("cleanup failure must stop the runtime");
+
+        match exit {
+            MakerExit::OrderResponse(reason) => {
+                assert!(
+                    reason.contains("order-response freeze cleanup failed:"),
+                    "cleanup-failure wording drifted: {reason}"
+                );
+            }
+            other => panic!(
+                "order-response cleanup failure must exit as OrderResponse, got {:?}",
+                other.lifecycle_reason()
+            ),
+        }
+        // The runtime is stopping: no further work may be scheduled.
+        runtime_state.handle(MakerEvent::Timer);
+        assert!(runtime_state.pending_effect().is_none());
+        open_orders.assert_async().await;
+    }
+
+    /// Invariant: if the runtime cannot enter the freeze (it is already
+    /// stopping), the preamble fails closed instead of proceeding to cleanup.
+    #[tokio::test]
+    async fn freeze_preamble_fails_closed_when_runtime_cannot_freeze() {
+        let client = StandXClient::new().unwrap();
+        let notifier = quiet_notifier();
+        let mut runtime_state = MakerState::starting();
+        runtime_state.handle(MakerEvent::StartupReady);
+        let _ = runtime_state.next_effect();
+        runtime_state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
+        while runtime_state.next_effect().is_some() {}
+        let mut resting = vec![resting_quote()];
+        let mut inventory_exit_pending = false;
+        let mut consecutive_errors = 0;
+        let mut next_cycle_is_recovery = false;
+
+        let exit = freeze_and_cleanup_for_recovery(
+            &mut RecoveryIo {
+                runtime_state: &mut runtime_state,
+                notifier: &notifier,
+                client: &client,
+                session: None,
+                resting: &mut resting,
+                inventory_exit_pending: &mut inventory_exit_pending,
+                consecutive_errors: &mut consecutive_errors,
+                next_cycle_is_recovery: &mut next_cycle_is_recovery,
+                symbol: "BTC-USD",
+                cycle: 7,
+                output_format: OutputFormat::Quiet,
+            },
+            order_response_freeze_spec(),
+        )
+        .await
+        .expect_err("a stopping runtime must not begin cleanup");
+        assert!(matches!(exit, MakerExit::PositionReconciliation(_)));
+        assert!(
+            !resting.is_empty(),
+            "no cleanup may run when the freeze was rejected"
+        );
+    }
+
+    /// Invariant: the resume tail restores quoting state (flags, error
+    /// streak, paper book) and schedules the next cycle via the runtime.
+    #[tokio::test]
+    async fn resume_tail_restores_quoting_state_and_schedules_a_cycle() {
+        let client = StandXClient::new().unwrap();
+        let notifier = quiet_notifier();
+        let mut runtime_state = MakerState::starting();
+        runtime_state.handle(MakerEvent::StartupReady);
+        let _ = runtime_state.next_effect();
+        runtime_state.handle(MakerEvent::PositionMismatch);
+        let _ = runtime_state.next_effect(); // AbortInFlight
+        let cleanup = match runtime_state.next_effect() {
+            Some(MakerEffect::Cleanup { token, .. }) => token,
+            other => panic!("expected cleanup effect, got {other:?}"),
+        };
+        runtime_state.handle(MakerEvent::CleanupCompleted(cleanup));
+        let recovery_token = match runtime_state.next_effect() {
+            Some(MakerEffect::Recover { token, .. }) => token,
+            other => panic!("expected recovery effect, got {other:?}"),
+        };
+        let mut resting = vec![resting_quote()];
+        let mut inventory_exit_pending = false;
+        let mut consecutive_errors = 2;
+        let mut next_cycle_is_recovery = false;
+
+        resume_quoting_after_recovery(
+            &mut RecoveryIo {
+                runtime_state: &mut runtime_state,
+                notifier: &notifier,
+                client: &client,
+                session: None,
+                resting: &mut resting,
+                inventory_exit_pending: &mut inventory_exit_pending,
+                consecutive_errors: &mut consecutive_errors,
+                next_cycle_is_recovery: &mut next_cycle_is_recovery,
+                symbol: "BTC-USD",
+                cycle: 7,
+                output_format: OutputFormat::Quiet,
+            },
+            ResumeSpec {
+                recovery_token,
+                observed: 0.0,
+                projection_reset: ProjectionReset::PreservePendingAcks,
+                clear_resting: true,
+                reset_consecutive_errors: true,
+                recovered_note: None,
+                notice: RiskNotice {
+                    kind: "position_reconciliation",
+                    severity: "resolved",
+                    event: "recovered",
+                    message: "test resume",
+                    symbol: "BTC-USD",
+                    cycle: 7,
+                    position_before: None,
+                    position_after: None,
+                    expected: Some(0.0),
+                    observed: Some(0.0),
+                },
+            },
+        )
+        .await;
+
+        assert!(resting.is_empty());
+        assert_eq!(consecutive_errors, 0);
+        assert!(next_cycle_is_recovery);
+        assert!(
+            matches!(runtime_state.next_effect(), Some(MakerEffect::RunCycle(_))),
+            "resume must schedule the next quoting cycle"
+        );
+    }
+
+    /// Invariant: the projection-reset knob keeps its per-flow semantics —
+    /// preserving pending request lifecycles for late acks, or dropping them
+    /// when the placement channel is being replaced.
+    #[test]
+    fn projection_reset_knobs_preserve_or_drop_pending_requests() {
+        let mut projection = projection_with_pending(&["request-1"]);
+        reset_projection(&mut projection, ProjectionReset::PreservePendingAcks);
+        assert!(
+            projection.has_pending_request_lifecycle("request-1"),
+            "PreservePendingAcks must keep pending request lifecycles"
+        );
+
+        let mut projection = projection_with_pending(&["request-1"]);
+        reset_projection(&mut projection, ProjectionReset::DropPendingRequests);
+        assert!(
+            !projection.has_pending_request_lifecycle("request-1"),
+            "DropPendingRequests must clear pending request lifecycles"
         );
     }
 }

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -1376,7 +1376,7 @@ pub(super) async fn run_maker(
                                 );
                             }
                         }
-                        match reconcile_ledger_snapshot(
+                        match probe_position_convergence(
                             &client,
                             ReconcileRequest {
                                 symbol: &symbol,
@@ -1387,21 +1387,19 @@ pub(super) async fn run_maker(
                             },
                             &mut ledger,
                             &mut stats,
+                            &mut reconnect_fills,
+                            cycle,
+                            output_format,
                         )
                         .await
                         {
-                            Ok((obs, fills)) => {
+                            ConvergenceProbe::Converged { observed: obs } => {
                                 observed = obs;
-                                reconnect_fills += fills.len() as u64;
-                                for fill in &fills {
-                                    emit_live_fill(fill, &symbol, cycle, output_format);
-                                }
-                                if (observed - ledger.expected_position).abs() <= qty_tolerance {
-                                    gap_closed = true;
-                                    break;
-                                }
+                                gap_closed = true;
+                                break;
                             }
-                            Err(error) => eprintln!(
+                            ConvergenceProbe::Pending { observed: obs } => observed = obs,
+                            ConvergenceProbe::SnapshotFailed(error) => eprintln!(
                                 "⚠️  account stream reconnect REST trade backfill failed: {error}"
                             ),
                         }
@@ -2543,7 +2541,7 @@ pub(super) async fn run_maker(
                                 }
                             }
                         }
-                        match reconcile_ledger_snapshot(
+                        match probe_position_convergence(
                             &client,
                             ReconcileRequest {
                                 symbol: &symbol,
@@ -2554,26 +2552,26 @@ pub(super) async fn run_maker(
                             },
                             &mut ledger,
                             &mut stats,
+                            &mut total_fills,
+                            cycle,
+                            output_format,
                         )
                         .await
                         {
-                            Ok((observed, fills)) => {
+                            ConvergenceProbe::Converged { observed } => {
                                 last_observed = observed;
-                                total_fills += fills.len() as u64;
-                                for fill in &fills {
-                                    emit_live_fill(fill, &symbol, cycle, output_format);
-                                }
-                                if (observed - ledger.expected_position).abs() <= qty_tolerance {
-                                    recovered = true;
-                                    break;
-                                }
+                                recovered = true;
+                                break;
                             }
-                            Err(error) => emit_reconciliation_snapshot_error(
-                                output_format,
-                                &symbol,
-                                cycle,
-                                &error.to_string(),
-                            ),
+                            ConvergenceProbe::Pending { observed } => last_observed = observed,
+                            ConvergenceProbe::SnapshotFailed(error) => {
+                                emit_reconciliation_snapshot_error(
+                                    output_format,
+                                    &symbol,
+                                    cycle,
+                                    &error.to_string(),
+                                )
+                            }
                         }
                     }
                     if recovered {

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -256,7 +256,6 @@ struct ResumeSpec<'a> {
     /// Order-response flow only: the paper book is cleared again because the
     /// placement channel was replaced underneath it.
     clear_resting: bool,
-    reset_consecutive_errors: bool,
     recovered_note: Option<ReconciliationStateNote>,
     notice: RiskNotice<'a>,
 }
@@ -281,9 +280,7 @@ async fn resume_quoting_after_recovery(io: &mut RecoveryIo<'_>, spec: ResumeSpec
             },
         );
     }
-    if spec.reset_consecutive_errors {
-        *io.consecutive_errors = 0;
-    }
+    *io.consecutive_errors = 0;
     io.runtime_state
         .handle(MakerEvent::RecoverySucceeded(spec.recovery_token));
     *io.next_cycle_is_recovery = true;
@@ -1543,7 +1540,18 @@ pub(super) async fn run_maker(
                     // failing closed.
                     let mut gap_closed = false;
                     for delay in [500_u64, 1_000, 1_500] {
-                        tokio::time::sleep(Duration::from_millis(delay)).await;
+                        // The maker book is verified empty at this point, so
+                        // aborting the convergence wait on Ctrl+C is safe.
+                        tokio::select! {
+                            _ = ctrl_c_latched(&mut ctrl_c_rx) => {
+                                handle.abort();
+                                break 'main stop_requested_exit(
+                                    &mut runtime_state,
+                                    RuntimeStopReason::CtrlC,
+                                );
+                            }
+                            _ = tokio::time::sleep(Duration::from_millis(delay)) => {}
+                        }
                         match apply_account_events(
                             &mut events,
                             &mut AccountEventState {
@@ -1654,7 +1662,6 @@ pub(super) async fn run_maker(
                         observed,
                         projection_reset: ProjectionReset::PreservePendingAcks,
                         clear_resting: false,
-                        reset_consecutive_errors: false,
                         recovered_note: None,
                         notice: RiskNotice {
                             kind: "account_stream",
@@ -1811,7 +1818,6 @@ pub(super) async fn run_maker(
                                     observed: reconciled_position,
                                     projection_reset: ProjectionReset::DropPendingRequests,
                                     clear_resting: true,
-                                    reset_consecutive_errors: true,
                                     recovered_note: None,
                                     notice: RiskNotice {
                                         kind: "order_response",
@@ -2672,7 +2678,17 @@ pub(super) async fn run_maker(
                     let mut recovered = false;
                     let mut last_observed = mismatch.observed;
                     for delay in [500_u64, 1_000, 1_500] {
-                        tokio::time::sleep(Duration::from_millis(delay)).await;
+                        // The maker book is verified empty at this point, so
+                        // aborting the convergence wait on Ctrl+C is safe.
+                        tokio::select! {
+                            _ = ctrl_c_latched(&mut ctrl_c_rx) => {
+                                break 'main stop_requested_exit(
+                                    &mut runtime_state,
+                                    RuntimeStopReason::CtrlC,
+                                );
+                            }
+                            _ = tokio::time::sleep(Duration::from_millis(delay)) => {}
+                        }
                         if let Some(session) = live_session.as_mut() {
                             match apply_account_events(
                                 &mut session.account_events,
@@ -2715,9 +2731,16 @@ pub(super) async fn run_maker(
                                     }
                                 }
                                 Err(error) => {
-                                    session
-                                        .account_stream_health
-                                        .mark_unhealthy(error.to_string());
+                                    // Fail closed like the account-stream
+                                    // path: recovery cannot trust a ledger
+                                    // whose event drain failed validation.
+                                    break 'main recovery_failed_exit(
+                                        &mut runtime_state,
+                                        recovery_token,
+                                        format!(
+                                            "position reconciliation event validation failed during REST backfill: {error}"
+                                        ),
+                                    );
                                 }
                             }
                         }
@@ -2790,7 +2813,6 @@ pub(super) async fn run_maker(
                                 observed: last_observed,
                                 projection_reset: ProjectionReset::PreservePendingAcks,
                                 clear_resting: false,
-                                reset_consecutive_errors: true,
                                 recovered_note: Some(ReconciliationStateNote {
                                     cause: reconciliation_cause,
                                     expected: ledger.expected_position,
@@ -4582,7 +4604,6 @@ mod tests {
                 observed: 0.0,
                 projection_reset: ProjectionReset::PreservePendingAcks,
                 clear_resting: true,
-                reset_consecutive_errors: true,
                 recovered_note: None,
                 notice: RiskNotice {
                     kind: "position_reconciliation",

--- a/crates/standx-maker/src/runtime.rs
+++ b/crates/standx-maker/src/runtime.rs
@@ -608,6 +608,298 @@ mod tests {
         ));
     }
 
+    /// Every event that must freeze the runtime, paired with the recovery
+    /// target its cleanup and recovery effects must carry. Conformance tests
+    /// below iterate this table so a new fault variant that misses one of the
+    /// shared safety steps fails here rather than drifting silently.
+    fn freeze_cases() -> Vec<(MakerEvent, RecoveryTarget)> {
+        vec![
+            (
+                MakerEvent::AccountStreamDisconnected("stream closed".to_string()),
+                RecoveryTarget::AccountStream,
+            ),
+            (
+                MakerEvent::OrderResponseDisconnected("stream closed".to_string()),
+                RecoveryTarget::OrderResponse,
+            ),
+            (
+                MakerEvent::PositionMismatch,
+                RecoveryTarget::PositionReconciliation,
+            ),
+            (
+                MakerEvent::OrderResponseUnmatched {
+                    request_id: "req-1".to_string(),
+                },
+                RecoveryTarget::OrderResponse,
+            ),
+            (
+                MakerEvent::OrderCancelRejected {
+                    request_id: "cancel-1".to_string(),
+                    code: 400,
+                    message: "rejected".to_string(),
+                },
+                RecoveryTarget::OrderResponse,
+            ),
+            (
+                MakerEvent::CycleInvalidated {
+                    reason: "account state changed".to_string(),
+                },
+                RecoveryTarget::PositionReconciliation,
+            ),
+        ]
+    }
+
+    fn stop_reasons() -> Vec<RuntimeStopReason> {
+        vec![
+            RuntimeStopReason::CtrlC,
+            RuntimeStopReason::OrderResponse("boom".to_string()),
+            RuntimeStopReason::PositionReconciliation("boom".to_string()),
+            RuntimeStopReason::ConsecutiveCycleErrors("boom".to_string()),
+            RuntimeStopReason::StopLoss("boom".to_string()),
+            RuntimeStopReason::CleanupFailure {
+                target: RecoveryTarget::OrderResponse,
+                reason: "boom".to_string(),
+            },
+        ]
+    }
+
+    /// Freezes a fresh runtime with `event` and returns the cleanup token,
+    /// asserting the queued effects are exactly AbortInFlight → Cleanup.
+    fn freeze_and_take_cleanup(
+        event: MakerEvent,
+        target: RecoveryTarget,
+    ) -> (MakerState, WorkToken) {
+        let mut state = MakerState::starting();
+        state.handle(MakerEvent::StartupReady);
+        let cycle = next_cycle(&mut state);
+        state.handle(event);
+        assert_eq!(state.next_effect(), Some(MakerEffect::AbortInFlight(cycle)));
+        let cleanup = match state.next_effect().expect("cleanup effect") {
+            MakerEffect::Cleanup {
+                token,
+                target: actual,
+            } => {
+                assert_eq!(actual, target);
+                token
+            }
+            effect => panic!("expected cleanup, got {effect:?}"),
+        };
+        assert_eq!(state.next_effect(), None);
+        (state, cleanup)
+    }
+
+    #[test]
+    fn every_fault_clears_queued_work_and_freezes_with_abort_then_cleanup() {
+        for (event, target) in freeze_cases() {
+            let mut state = MakerState::starting();
+            // Leave StartupReady's RunCycle effect *undrained* so the test
+            // proves a fault clears stale queued work instead of leaving a
+            // placement effect behind the abort/cleanup pair.
+            state.handle(MakerEvent::StartupReady);
+            let queued = match state.pending_effect() {
+                Some(MakerEffect::RunCycle(token)) => *token,
+                effect => panic!("expected queued cycle, got {effect:?}"),
+            };
+            state.handle(event.clone());
+            assert!(state.is_frozen(), "{event:?} must freeze the runtime");
+            assert_eq!(
+                state.next_effect(),
+                Some(MakerEffect::AbortInFlight(queued)),
+                "{event:?} must abort in-flight work first"
+            );
+            assert!(
+                matches!(
+                    state.next_effect(),
+                    Some(MakerEffect::Cleanup { target: actual, .. }) if actual == target
+                ),
+                "{event:?} must queue cleanup for {target:?}"
+            );
+            assert_eq!(
+                state.next_effect(),
+                None,
+                "{event:?} must not leave stale effects behind cleanup"
+            );
+        }
+    }
+
+    #[test]
+    fn frozen_runtime_ignores_market_events_and_later_faults() {
+        for (event, target) in freeze_cases() {
+            let (mut state, cleanup) = freeze_and_take_cleanup(event.clone(), target);
+            state.handle(MakerEvent::Timer);
+            state.handle(MakerEvent::MarketChanged);
+            for (other, _) in freeze_cases() {
+                state.handle(other);
+            }
+            assert_eq!(
+                state.next_effect(),
+                None,
+                "no effect may be queued while frozen for {event:?}"
+            );
+            // The original fault still owns the recovery flow.
+            state.handle(MakerEvent::CleanupCompleted(cleanup));
+            assert!(
+                matches!(
+                    state.next_effect(),
+                    Some(MakerEffect::Recover { target: actual, .. }) if actual == target
+                ),
+                "recovery after {event:?} must keep target {target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn stale_cleanup_and_recovery_tokens_are_rejected() {
+        for (event, target) in freeze_cases() {
+            let (mut state, cleanup) = freeze_and_take_cleanup(event.clone(), target);
+            let stale = WorkToken {
+                generation: cleanup.generation + 7,
+                kind: cleanup.kind,
+            };
+            state.handle(MakerEvent::CleanupCompleted(stale));
+            state.handle(MakerEvent::CleanupFailed {
+                token: stale,
+                reason: "stale".to_string(),
+            });
+            assert_eq!(state.next_effect(), None);
+            assert!(state.is_frozen());
+
+            state.handle(MakerEvent::CleanupCompleted(cleanup));
+            let recovery = match state.next_effect().expect("recovery effect") {
+                MakerEffect::Recover { token, .. } => token,
+                effect => panic!("expected recovery, got {effect:?}"),
+            };
+            let stale = WorkToken {
+                generation: recovery.generation + 7,
+                kind: recovery.kind,
+            };
+            state.handle(MakerEvent::RecoverySucceeded(stale));
+            state.handle(MakerEvent::RecoveryFailed {
+                token: stale,
+                reason: "stale".to_string(),
+            });
+            assert_eq!(state.next_effect(), None);
+            assert!(state.is_frozen());
+        }
+    }
+
+    #[test]
+    fn recovery_failure_stop_reason_maps_by_target() {
+        for (event, target) in freeze_cases() {
+            let (mut state, cleanup) = freeze_and_take_cleanup(event.clone(), target);
+            state.handle(MakerEvent::CleanupCompleted(cleanup));
+            let recovery = match state.next_effect().expect("recovery effect") {
+                MakerEffect::Recover { token, .. } => token,
+                effect => panic!("expected recovery, got {effect:?}"),
+            };
+            state.handle(MakerEvent::RecoveryFailed {
+                token: recovery,
+                reason: "reconnect exhausted".to_string(),
+            });
+            let stop = match state.next_effect().expect("stop effect") {
+                MakerEffect::Stop(reason) => reason,
+                effect => panic!("expected stop, got {effect:?}"),
+            };
+            match target {
+                RecoveryTarget::OrderResponse => assert_eq!(
+                    stop,
+                    RuntimeStopReason::OrderResponse("reconnect exhausted".to_string()),
+                    "order-response recovery failure must stop as OrderResponse for {event:?}"
+                ),
+                RecoveryTarget::AccountStream | RecoveryTarget::PositionReconciliation => {
+                    assert_eq!(
+                        stop,
+                        RuntimeStopReason::PositionReconciliation(
+                            "reconnect exhausted".to_string()
+                        ),
+                        "recovery failure must stop as PositionReconciliation for {event:?}"
+                    )
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn cleanup_failure_stop_carries_the_recovery_target() {
+        for (event, target) in freeze_cases() {
+            let (mut state, cleanup) = freeze_and_take_cleanup(event.clone(), target);
+            state.handle(MakerEvent::CleanupFailed {
+                token: cleanup,
+                reason: "residual orders".to_string(),
+            });
+            assert_eq!(
+                state.next_effect(),
+                Some(MakerEffect::Stop(RuntimeStopReason::CleanupFailure {
+                    target,
+                    reason: "residual orders".to_string(),
+                })),
+                "cleanup failure must stop with CleanupFailure {target:?} for {event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn stop_requested_passes_the_reason_through_and_seals_the_runtime() {
+        for reason in stop_reasons() {
+            let mut state = MakerState::starting();
+            state.handle(MakerEvent::StartupReady);
+            let cycle = next_cycle(&mut state);
+            state.handle(MakerEvent::StopRequested(reason.clone()));
+            assert_eq!(state.next_effect(), Some(MakerEffect::AbortInFlight(cycle)));
+            assert_eq!(state.next_effect(), Some(MakerEffect::Stop(reason.clone())));
+            // Once stopping, nothing may queue further work or a second stop.
+            state.handle(MakerEvent::Timer);
+            state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
+            for (fault, _) in freeze_cases() {
+                state.handle(fault);
+            }
+            assert_eq!(
+                state.next_effect(),
+                None,
+                "stopping runtime must ignore all later events after {reason:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn recovery_success_resets_the_cycle_error_streak() {
+        let mut state = MakerState::starting();
+        state.handle(MakerEvent::StartupReady);
+        for attempt in 0..2 {
+            let token = next_cycle(&mut state);
+            state.handle(MakerEvent::CycleFailed {
+                token,
+                reason: format!("failure {attempt}"),
+            });
+            assert!(state.pending_effect().is_none());
+            state.handle(MakerEvent::Timer);
+        }
+        let _ = next_cycle(&mut state);
+        state.handle(MakerEvent::PositionMismatch);
+        let _ = state.next_effect();
+        let cleanup = match state.next_effect().expect("cleanup effect") {
+            MakerEffect::Cleanup { token, .. } => token,
+            effect => panic!("expected cleanup, got {effect:?}"),
+        };
+        state.handle(MakerEvent::CleanupCompleted(cleanup));
+        let recovery = match state.next_effect().expect("recovery effect") {
+            MakerEffect::Recover { token, .. } => token,
+            effect => panic!("expected recovery, got {effect:?}"),
+        };
+        state.handle(MakerEvent::RecoverySucceeded(recovery));
+        // A third consecutive failure would have stopped the runtime had the
+        // streak survived recovery; a fresh failure must not.
+        let token = next_cycle(&mut state);
+        state.handle(MakerEvent::CycleFailed {
+            token,
+            reason: "post-recovery failure".to_string(),
+        });
+        assert!(
+            state.pending_effect().is_none(),
+            "recovery must reset the consecutive cycle error streak"
+        );
+    }
+
     #[test]
     fn invalidated_cycle_aborts_cleans_up_and_rejects_stale_completion() {
         let mut state = MakerState::starting();

--- a/crates/standx-sdk/src/account_stream.rs
+++ b/crates/standx-sdk/src/account_stream.rs
@@ -208,7 +208,13 @@ pub struct AccountStreamHealth {
 }
 
 impl AccountStreamHealth {
-    fn new(epoch: u64) -> Self {
+    /// Constructs a standalone healthy handle for the given epoch. Production
+    /// handles are created by [`AccountStream::connect`]; this constructor
+    /// exists so downstream tests can build a session fixture and drive
+    /// [`Self::mark_unhealthy`], mirroring `OrderResponseHealth`. The epoch is
+    /// explicit (no `Default`) so fixtures cannot silently disagree with the
+    /// projection generation they are paired with.
+    pub fn new(epoch: u64) -> Self {
         Self {
             healthy: Arc::new(AtomicBool::new(true)),
             failure_reason: Arc::new(Mutex::new(None)),


### PR DESCRIPTION
## Why

`run_maker` hand-wrote the same incident-recovery protocol three times — for account-stream disconnect, order-response disconnect, and position reconciliation. Because the flows were near-duplicates rather than one shared path, they drifted: order-response recovery was for a while missing the REST trade backfill the other two flows had (since fixed in `4a49104`). This PR removes the duplication so the flows can't diverge again, and adds a conformance test net that turns any future drift into a red test.

The work follows the approved plan (方案 F + B) and is sliced into reviewable commits.

## What changed

**Conformance tests first (the safety net)**
- Table-driven state-machine tests in `standx-maker` over every freeze-triggering event: freezing clears queued work and emits `AbortInFlight → Cleanup(target)`; a frozen runtime ignores market ticks and later faults; recovery failure maps to the right stop reason by target; cleanup failure carries the target; stale tokens are rejected; a stopping runtime is sealed; recovery resets the cycle-error streak.
- CLI-side test pinning the full `RuntimeStopReason → MakerExit` mapping.
- REST-orchestration invariant tests (mockito) for the extracted helpers: the freeze preamble cancels only maker-owned orders and clears local book state before handing back a recovery token; cleanup failure stops with the flow's exit and exact wording; a runtime that can't freeze fails closed without touching the venue; the convergence probe backfills cancel-race trades into the caller's sink exactly once, keeps unexplained gaps pending, and surfaces snapshot failures.

**Deduplication (behavior-preserving extraction)**
- `probe_position_convergence` (recovery.rs) — the REST-reconcile half of the bounded convergence window, shared by the account-stream and reconciliation flows.
- `freeze_and_cleanup_for_recovery` (runtime.rs) — the freeze/cleanup preamble, parameterized by a `FreezeSpec` whose knobs preserve each flow's exact behavior. Risk notices stay fully caller-built so the payloads remain reviewable string-for-string; the `await_delivery=true` critical notices deliberately stay at the call sites.
- `resume_quoting_after_recovery` (runtime.rs) — the resume tail, driven by a `ResumeSpec`. Flow-specific final book verification (with its divergent error paths), session-half installation, and fill accounting stay inline.

**Behavior changes (single commit, intentional)**
The last commit unifies three unexplained divergences to fail-closed:
- Every recovery now resets the consecutive-cycle-error streak on success (account-stream flow previously didn't).
- A failed account-event drain inside the reconciliation convergence window now fails recovery closed (previously marked the stream unhealthy and continued on an unvalidated ledger).
- Both runtime-side convergence waits are now Ctrl+C-interruptible, routed through `StopRequested(CtrlC)` so no dangling recovery token is left; the maker book is verified empty before these waits, so aborting is safe.

## Reviewer notes

- The freeze/resume extraction commit is best read as a three-column diff of `FreezeSpec`/`ResumeSpec` knob values against the deleted blocks.
- Two non-observable micro-reorderings in the resume tail are called out in the `1b5febb` commit message (disjoint field writes / synchronous task-local mutations, no I/O between them).
- A full `LiveSession` test fixture is blocked by `OrderCommandSender`'s private constructor, so the projection-reset knob is pinned directly via an extracted `reset_projection` and helper tests pass `session: None`. Completing the fixture would need a SDK-side test constructor.
- **Not yet verified live:** the `--live --controlled-disconnect-after` end-to-end path (needs credentials). Paper-mode smoke is unavailable on this machine — `maker run` errors at `invalid performance baseline position=0, mark=0`, which also reproduces on `main` (environment can't reach market data), so it's unrelated to this change.

Gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and full workspace tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
