### PR TITLE
Model cleanup continuity + ADR for maker recovery architecture

### DIFF
--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -2,9 +2,10 @@ use crate::cli::*;
 use anyhow::Result;
 use standx_maker::{
     self as maker, AccountProjectionEvent, AlertMonitor, MakerAccountProjection, MakerConfig,
-    MakerEffect, MakerEvent, MakerFill, MakerLedger, MakerState, MakerStats, PositionAlertAnchor,
-    ProjectionPendingRequest, ProjectionRegistryError, RecoveryTarget, RestingQuote,
-    RuntimeStopReason, VolBreaker, WorkToken, MAKER_CL_ORD_ID_PREFIX,
+    MakerEffect, MakerEvent, MakerFill, MakerLedger, MakerState, MakerStats,
+    OrderResponseContinuity, PositionAlertAnchor, ProjectionPendingRequest,
+    ProjectionRegistryError, RecoveryTarget, RestingQuote, RuntimeStopReason, VolBreaker,
+    WorkToken, MAKER_CL_ORD_ID_PREFIX,
 };
 use standx_sdk::account_stream::{
     AccountChannel, AccountEvent, AccountStream, AccountStreamHealth,

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -438,7 +438,7 @@ mod tests {
             .timed_out(&projection, submitted_at + timeout, timeout)
             .expect("a preserved unacked placement must still fail closed on timeout");
         assert_eq!(timed_out.kind, OrderRequestKind::Place);
-        assert_eq!(timed_out.phase, OrderRequestTimeoutPhase::Acknowledgement);
+        assert_eq!(timed_out.phase, RequestTimeoutPhase::Acknowledgement);
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -258,7 +258,9 @@ pub(super) async fn fetch_account_audit(
 mod tests {
     use super::*;
     use mockito::{Matcher, Server};
-    use standx_maker::{AccountProjectionEvent, OrderObservation, ProjectionPendingPlace};
+    use standx_maker::{
+        AccountProjectionEvent, OrderObservation, OrderResponseContinuity, ProjectionPendingPlace,
+    };
     use standx_sdk::models::OrderSide;
 
     const TEST_RUN_PREFIX: &str = "sxmk-deadline-";
@@ -410,6 +412,60 @@ mod tests {
             .unwrap();
         assert_eq!(timed_out.kind, OrderRequestKind::Place);
         assert_eq!(timed_out.phase, RequestTimeoutPhase::Acknowledgement);
+    }
+
+    #[test]
+    fn preserved_cleanup_keeps_an_unacked_deadline_until_it_times_out() {
+        // A freeze whose order-response channel survives (account-stream or
+        // reconciliation) must not release an in-flight placement's deadline:
+        // the ack can still arrive, so the request must keep timing out if it
+        // never does.
+        let submitted_at = Instant::now();
+        let timeout = Duration::from_secs(10);
+        let mut projection = projection_with_pending_place("p1");
+        let mut deadlines = OrderRequestDeadlines::default();
+        deadlines.record("p1".to_owned(), OrderRequestKind::Place, submitted_at);
+
+        projection.finish_verified_cleanup(OrderResponseContinuity::Preserved);
+        deadlines.retain_pending(&projection);
+
+        assert_eq!(
+            deadlines.next_deadline(timeout),
+            Some(submitted_at + timeout),
+            "a preserved unacked placement must keep its deadline"
+        );
+        let timed_out = deadlines
+            .timed_out(&projection, submitted_at + timeout, timeout)
+            .expect("a preserved unacked placement must still fail closed on timeout");
+        assert_eq!(timed_out.kind, OrderRequestKind::Place);
+        assert_eq!(timed_out.phase, OrderRequestTimeoutPhase::Acknowledgement);
+    }
+
+    #[test]
+    fn replaced_cleanup_retires_the_old_deadline_so_it_cannot_time_out() {
+        // A freeze that replaces the order-response channel ends the old ack
+        // obligation: no response can arrive on the torn-down stream, so the
+        // stale deadline must be dropped and can never fire a spurious timeout.
+        let submitted_at = Instant::now();
+        let timeout = Duration::from_secs(10);
+        let mut projection = projection_with_pending_place("p1");
+        let mut deadlines = OrderRequestDeadlines::default();
+        deadlines.record("p1".to_owned(), OrderRequestKind::Place, submitted_at);
+
+        projection.finish_verified_cleanup(OrderResponseContinuity::Replaced);
+        deadlines.retain_pending(&projection);
+
+        assert_eq!(
+            deadlines.next_deadline(timeout),
+            None,
+            "a replaced channel's stale deadline must be dropped"
+        );
+        assert!(
+            deadlines
+                .timed_out(&projection, submitted_at + timeout, timeout)
+                .is_none(),
+            "a retired request must never fire a spurious timeout"
+        );
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -131,17 +131,6 @@ fn stop_requested_exit(runtime_state: &mut MakerState, reason: RuntimeStopReason
     take_stop_effect(runtime_state, MakerExit::PositionReconciliation)
 }
 
-/// Which projection clear an incident flow performs after freeze cleanup.
-#[derive(Clone, Copy)]
-enum ProjectionReset {
-    /// `clear_orders_preserving_pending_acks` — a current-run ack may still
-    /// replay after cleanup (account-stream and reconciliation freezes).
-    PreservePendingAcks,
-    /// `clear_orders_and_pending` — the placement channel is being torn down,
-    /// so pending request acks can never arrive (order-response freeze).
-    DropPendingRequests,
-}
-
 /// How a missing or mismatched runtime effect maps to the flow's stop reason.
 /// (`RuntimeStopReason::CleanupFailure` carries the target, so a plain
 /// `fn(String) -> RuntimeStopReason` pointer cannot express it.)
@@ -163,13 +152,6 @@ fn effect_failure_stop(
         EffectFailureStop::PositionReconciliation => {
             RuntimeStopReason::PositionReconciliation(reason)
         }
-    }
-}
-
-fn reset_projection(projection: &mut MakerAccountProjection, reset: ProjectionReset) {
-    match reset {
-        ProjectionReset::PreservePendingAcks => projection.clear_orders_preserving_pending_acks(),
-        ProjectionReset::DropPendingRequests => projection.clear_orders_and_pending(),
     }
 }
 
@@ -221,7 +203,10 @@ struct FreezeSpec<'a> {
     /// Account-stream flow only: abort the stale stream task before
     /// reporting cleanup complete.
     abort_account_stream_handle: bool,
-    projection_reset: ProjectionReset,
+    /// Whether the order-response channel survives this freeze (account-stream
+    /// and reconciliation) or is being replaced (order-response), deciding
+    /// whether pending request acks stay correlated across the cleanup.
+    continuity: OrderResponseContinuity,
 }
 
 /// Freeze/cleanup preamble shared by the three incident-recovery flows:
@@ -274,7 +259,7 @@ async fn freeze_and_cleanup_for_recovery(
     io.resting.clear();
     if let Some(session) = io.session.as_deref_mut() {
         invalidate_session_latency(session);
-        reset_projection(&mut session.projection, spec.projection_reset);
+        session.projection.finish_verified_cleanup(spec.continuity);
     }
     *io.inventory_exit_pending = false;
     if spec.abort_account_stream_handle {
@@ -300,7 +285,7 @@ struct ResumeSpec<'a> {
     recovery_token: WorkToken,
     /// Venue position fed to the projection as authoritative after recovery.
     observed: f64,
-    projection_reset: ProjectionReset,
+    continuity: OrderResponseContinuity,
     /// Order-response flow only: the paper book is cleared again because the
     /// placement channel was replaced underneath it.
     clear_resting: bool,
@@ -319,7 +304,7 @@ async fn resume_quoting_after_recovery(io: &mut RecoveryIo<'_>, spec: ResumeSpec
         io.resting.clear();
     }
     if let Some(session) = io.session.as_deref_mut() {
-        reset_projection(&mut session.projection, spec.projection_reset);
+        session.projection.finish_verified_cleanup(spec.continuity);
         let generation = session.projection.generation();
         session.projection.apply(
             generation,
@@ -1492,7 +1477,7 @@ pub(super) async fn run_maker(
                         notice,
                         frozen_note: None,
                         abort_account_stream_handle: true,
-                        projection_reset: ProjectionReset::PreservePendingAcks,
+                        continuity: OrderResponseContinuity::Preserved,
                     },
                 )
                 .await
@@ -1733,7 +1718,7 @@ pub(super) async fn run_maker(
                     ResumeSpec {
                         recovery_token,
                         observed,
-                        projection_reset: ProjectionReset::PreservePendingAcks,
+                        continuity: OrderResponseContinuity::Preserved,
                         clear_resting: false,
                         recovered_note: None,
                         notice: RiskNotice {
@@ -1822,7 +1807,7 @@ pub(super) async fn run_maker(
                         notice,
                         frozen_note: None,
                         abort_account_stream_handle: false,
-                        projection_reset: ProjectionReset::DropPendingRequests,
+                        continuity: OrderResponseContinuity::Replaced,
                     },
                 )
                 .await
@@ -1910,7 +1895,7 @@ pub(super) async fn run_maker(
                                 ResumeSpec {
                                     recovery_token,
                                     observed: reconciled_position,
-                                    projection_reset: ProjectionReset::DropPendingRequests,
+                                    continuity: OrderResponseContinuity::Replaced,
                                     clear_resting: true,
                                     recovered_note: None,
                                     notice: RiskNotice {
@@ -2758,7 +2743,7 @@ pub(super) async fn run_maker(
                                 observed: mismatch.observed,
                             }),
                             abort_account_stream_handle: false,
-                            projection_reset: ProjectionReset::PreservePendingAcks,
+                            continuity: OrderResponseContinuity::Preserved,
                         },
                     )
                     .await
@@ -2923,7 +2908,7 @@ pub(super) async fn run_maker(
                             ResumeSpec {
                                 recovery_token,
                                 observed: last_observed,
-                                projection_reset: ProjectionReset::PreservePendingAcks,
+                                continuity: OrderResponseContinuity::Preserved,
                                 clear_resting: false,
                                 recovered_note: Some(ReconciliationStateNote {
                                     cause: reconciliation_cause,
@@ -4498,7 +4483,7 @@ mod tests {
             notice: FreezeNotice::Risk(warning_notice("order_response")),
             frozen_note: None,
             abort_account_stream_handle: false,
-            projection_reset: ProjectionReset::DropPendingRequests,
+            continuity: OrderResponseContinuity::Replaced,
         }
     }
 
@@ -4743,7 +4728,7 @@ mod tests {
             ResumeSpec {
                 recovery_token,
                 observed: 0.0,
-                projection_reset: ProjectionReset::PreservePendingAcks,
+                continuity: OrderResponseContinuity::Preserved,
                 clear_resting: true,
                 recovered_note: None,
                 notice: RiskNotice {
@@ -4771,23 +4756,23 @@ mod tests {
         );
     }
 
-    /// Invariant: the projection-reset knob keeps its per-flow semantics —
-    /// preserving pending request lifecycles for late acks, or dropping them
-    /// when the placement channel is being replaced.
+    /// Invariant: the continuity knob keeps its per-flow semantics —
+    /// preserving pending request lifecycles for late acks when the channel
+    /// survives, or dropping them when the placement channel is replaced.
     #[test]
-    fn projection_reset_knobs_preserve_or_drop_pending_requests() {
+    fn finish_verified_cleanup_preserves_or_drops_pending_requests() {
         let mut projection = projection_with_pending(&["request-1"]);
-        reset_projection(&mut projection, ProjectionReset::PreservePendingAcks);
+        projection.finish_verified_cleanup(OrderResponseContinuity::Preserved);
         assert!(
             projection.has_pending_request_lifecycle("request-1"),
-            "PreservePendingAcks must keep pending request lifecycles"
+            "Preserved continuity must keep pending request lifecycles"
         );
 
         let mut projection = projection_with_pending(&["request-1"]);
-        reset_projection(&mut projection, ProjectionReset::DropPendingRequests);
+        projection.finish_verified_cleanup(OrderResponseContinuity::Replaced);
         assert!(
             !projection.has_pending_request_lifecycle("request-1"),
-            "DropPendingRequests must clear pending request lifecycles"
+            "Replaced continuity must clear pending request lifecycles"
         );
     }
 }

--- a/crates/standx-maker/src/account_projection.rs
+++ b/crates/standx-maker/src/account_projection.rs
@@ -1261,6 +1261,52 @@ mod tests {
     }
 
     #[test]
+    fn late_unknown_open_after_verified_cleanup_forces_reconciliation() {
+        // After a verified cleanup (either continuity), a fresh current-run
+        // open order with no pending place must never silently become a
+        // holdable quote: it is flagged unknown and adopted at the sentinel
+        // level so reconciliation cancels it rather than resuming on it.
+        for continuity in [
+            OrderResponseContinuity::Preserved,
+            OrderResponseContinuity::Replaced,
+        ] {
+            let mut state = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
+            // Establish and adopt an initial quote, then verify-cleanup it.
+            state.apply(1, AccountProjectionEvent::PlaceSubmitted(pending("p1")));
+            state.apply(
+                1,
+                AccountProjectionEvent::PlaceAccepted {
+                    request_id: "p1".to_string(),
+                },
+            );
+            state.apply(1, AccountProjectionEvent::OrderObserved(order(0.2, false)));
+            state.finish_verified_cleanup(continuity);
+            assert!(
+                state.resting_quotes().is_empty(),
+                "{continuity:?}: cleanup must leave no executable quote"
+            );
+
+            // A brand-new current-run order (unseen id, no pending place) lands
+            // late on the venue.
+            let mut late = order(0.2, false);
+            late.order_id = 4242;
+            late.client_order_id = Some(format!("{PREFIX}q00000099x9"));
+            let outcome = state.apply(1, AccountProjectionEvent::OrderObserved(late));
+
+            assert!(
+                outcome.unknown_current_run_order,
+                "{continuity:?}: a late unknown current-run order must require reconciliation"
+            );
+            let resting = state.resting_quotes();
+            assert_eq!(resting.len(), 1);
+            assert_eq!(
+                resting[0].level, UNKNOWN_ADOPTED_LEVEL,
+                "{continuity:?}: it must be adopted at the sentinel level, not a holdable quote"
+            );
+        }
+    }
+
+    #[test]
     fn account_reconnect_reset_preserves_unacked_order_response_registry() {
         let mut state = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
         state.apply(1, AccountProjectionEvent::PlaceSubmitted(pending("p1")));

--- a/crates/standx-maker/src/account_projection.rs
+++ b/crates/standx-maker/src/account_projection.rs
@@ -60,6 +60,21 @@ pub enum ProjectionRequestResolution {
     CancelResolved,
 }
 
+/// Whether the order-response (placement) channel survived a verified maker
+/// cleanup or was torn down and replaced. This is the *decision* a recovery
+/// flow makes; [`MakerAccountProjection::finish_verified_cleanup`] maps it to
+/// the mechanical projection reset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderResponseContinuity {
+    /// The order-response stream is still the same channel, so acknowledgements
+    /// it has not yet delivered may still arrive and must stay correlated.
+    Preserved,
+    /// The order-response stream was replaced, so no acknowledgement for a
+    /// request issued on the old channel can ever arrive; end those
+    /// obligations as part of the cleanup.
+    Replaced,
+}
+
 impl ProjectionRequestResolution {
     pub fn accepts_response(self, accepted: bool) -> bool {
         match self {
@@ -400,6 +415,20 @@ impl MakerAccountProjection {
         self.generation = generation;
         self.clear_orders_preserving_pending_acks();
         self.observed_position = position;
+    }
+
+    /// Close every executable quote slot after a maker cleanup has verified
+    /// the venue book is empty, resolving in-flight order-response
+    /// acknowledgements according to `continuity`. Both variants close the
+    /// venue slots — that invariant lives here, in one place — and differ only
+    /// in whether pending request correlation survives the cleanup. Recovery
+    /// flows call this instead of the mechanical `clear_orders_*` primitives so
+    /// the decision they make (did the placement channel survive?) is explicit.
+    pub fn finish_verified_cleanup(&mut self, continuity: OrderResponseContinuity) {
+        match continuity {
+            OrderResponseContinuity::Preserved => self.clear_orders_preserving_pending_acks(),
+            OrderResponseContinuity::Replaced => self.clear_orders_and_pending(),
+        }
     }
 
     pub fn clear_orders_and_pending(&mut self) {

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -28,10 +28,10 @@ pub mod risk;
 pub mod runtime;
 
 pub use account_projection::{
-    AccountProjectionEvent, MakerAccountProjection, OrderObservation, ProjectedOrder,
-    ProjectionMismatch, ProjectionOutcome, ProjectionPendingCancel, ProjectionPendingPlace,
-    ProjectionPendingRequest, ProjectionRegistryError, ProjectionRequestResolution,
-    MAX_PENDING_ORDER_REQUESTS,
+    AccountProjectionEvent, MakerAccountProjection, OrderObservation, OrderResponseContinuity,
+    ProjectedOrder, ProjectionMismatch, ProjectionOutcome, ProjectionPendingCancel,
+    ProjectionPendingPlace, ProjectionPendingRequest, ProjectionRegistryError,
+    ProjectionRequestResolution, MAX_PENDING_ORDER_REQUESTS,
 };
 pub use latency::{
     LatencyError, LatencyMetricSummary, LatencyRequest, LatencyRequestContext, LatencyRequestKind,

--- a/docs/adr/0001-maker-recovery-supervision.md
+++ b/docs/adr/0001-maker-recovery-supervision.md
@@ -1,0 +1,80 @@
+# ADR 0001：Maker 事故恢复的监督架构
+
+- 状态：已采纳（2026-07-15）
+- 相关：[13-maker.md](../13-maker.md)、[14-maker-live-gate.md](../14-maker-live-gate.md)、[18-maker-strategy-roadmap.md](../18-maker-strategy-roadmap.md)
+
+## 背景
+
+`standx maker` 的 `run_maker` 主循环有三条事故恢复流程：account-stream 断连、
+order-response 断连、position reconciliation。它们曾是彼此的近似拷贝，逐渐语义漂移
+——order-response 恢复一度缺少 account-stream 恢复已有的 REST trade backfill
+（已由 commit `4a49104` 修复）。
+
+漂移的根因是：**恢复步骤的顺序属于安全策略，却由三份平行的 CLI 过程代码各自维护**。
+`standx-maker` 的纯状态机已经保证外层顺序（`Abort → Cleanup → Recover → Resume`），
+但每条流程的执行体（冻结清理、REST 收敛、恢复恢复报价）是手写的，没有单一事实源。
+
+已经完成的收口（方案 F + B）：
+
+- core 状态机保证外层次序，并有全故障类型的 conformance 测试钉住；
+- CLI 三条流程共用 `freeze_and_cleanup_for_recovery`、`probe_position_convergence`、
+  `resume_quoting_after_recovery`；
+- freeze 后的 pending 处理差异被建模为
+  `OrderResponseContinuity { Preserved, Replaced }`，经
+  `MakerAccountProjection::finish_verified_cleanup` 单一入口执行；
+- fault matrix 与 fail-closed 不变量已有测试覆盖。
+
+在此基础上评估了两个更进一步的架构方向。
+
+### 方案 C：把恢复次序下沉进 core 状态机
+
+让 core 把恢复拆成细粒度转移（`CleanupPending → TransportRecoveryPending →
+BackfillPending → VerificationPending → Ready / Stop`），CLI 退化为薄执行器。
+`Verify` 是 core 内部纯判断，`Resume` 是状态转移，不必膨胀成独立 I/O effect。
+
+- 优点：恢复次序本身成为 core 的纯转移逻辑，可直接单测，杜绝过程代码漂移。
+- 代价：一次性触碰 core、CLI、effect/result 关联和大量测试；在 F+B 已显著降低漂移
+  风险之后，完整迁移的边际收益变小。
+
+### 方案 D：恢复 = 整包重建 order-response（crash-only 式）
+
+任何失信故障都整包替换 order-response session，使 pending 处理表面统一。
+
+- 否决理由：会无差别丢弃仍可送达的 ACK（`Preserved` 语义的存在正说明通道常常还活着）；
+  失去「旧 order-response 是否还能交付响应」的健康探针；更依赖 REST 回补；健康流也被
+  拆除；position mismatch 的原因在账本、重连传输并不能解决；并且增加双流联合连接与原子
+  session 替换的失败面。当前代码也没有任何「双流可信度耦合失效」的检测信号，D 连触发器
+  都不存在。
+
+## 决策
+
+1. **保留当前架构**：core 状态机保证外层次序（外框）+ CLI 薄共享执行器执行 I/O。
+   不实施完整方案 C，不采用方案 D 作为默认恢复模型。
+
+2. **把 pending 差异建模为 order-response continuity**：`Preserved`（通道存活，保留
+   ACK 关联与 deadline）与 `Replaced`（通道被替换，结束旧 ACK 义务）。两者都必须关闭
+   已验证为空的 venue slot——该不变量集中在 `finish_verified_cleanup` 一处。
+
+3. **方案 C 的触发规则（本 ADR 的核心约定）**：出现下列**任一**情形时，直接迁移到
+   C-lite，不再往 CLI 增加第四条恢复过程分支：
+
+   - 需要新增一个恢复**阶段**（例如在 cleanup 与 recover 之间插入新的中间状态）；
+   - 需要新增一条恢复**重试分支**或新的恢复**目标**（第四种 `RecoveryTarget`）；
+   - 发生**任何一次新的次序漂移事故**（两条流程在某个共享步骤上再次分叉）。
+
+   在触发之前，恢复架构**冻结**：只做 bug 修复和等价重构，不做结构扩张。
+
+4. **方案 D 的触发条件**：仅当有证据表明两个 stream 的可信度已经**耦合失效**
+   （而非单流断开或单纯仓位失配）时，才将 D 作为升级恢复手段引入；且需先补上检测该
+   耦合失效的信号。在此之前 D 不预留结构。
+
+## 后果
+
+- **正面**：三条流程只剩一份执行体；恢复决策（continuity）显式且可单测；次序不变量由
+  core + conformance 测试守护；后续复杂度增长有明确的、写入代码库的迁移触发点，不再依赖
+  口头共识。
+- **负面 / 需承担**：外框在 core、执行体在 CLI 的分工仍然存在——次序保证与执行分处两个
+  crate。这是刻意的取舍：换取不必一次性重写一个已在跑生产的资金系统。触发规则把这笔债的
+  偿还时机绑定到「真正需要扩张时」。
+- **落实**：本规则应在 review 中据以拦截「第四条过程分支」类改动；相关 PR 若命中上述任一
+  触发条件，应引用本 ADR 并转向 C-lite 设计。


### PR DESCRIPTION
## Why

Follow-up to #292 (maker incident-recovery dedup, now merged). That PR left the three recovery flows sharing helpers but described their post-cleanup pending handling with a mechanism-named knob (`ProjectionReset`). This PR turns that knob into the *decision* it actually represents, sinks the shared cleanup invariant into one place, records the architecture decision (including when to escalate to a full state-machine recovery), and adds the cross-cutting tests the dedup relies on.

## What changed

**Model post-cleanup pending handling as order-response continuity**
- Rename `ProjectionReset { PreservePendingAcks, DropPendingRequests }` → `OrderResponseContinuity { Preserved, Replaced }`. The enum now names the decision each freeze makes — did the order-response placement channel survive, or was it replaced? — instead of the mechanism it triggers.
- Add `MakerAccountProjection::finish_verified_cleanup(continuity)` as the single entry point. The shared invariant "both variants close the verified-empty venue slots" now lives in one documented method; `Preserved`/`Replaced` map to the existing `clear_orders_*` primitives. **No behavior change.**

**ADR 0001 — maker recovery supervision architecture** (`docs/adr/0001-maker-recovery-supervision.md`)
- Records the decision to keep the current "core state machine owns the outer ordering + thin CLI executor" architecture rather than migrating to a full in-core recovery state machine (C) or a crash-only session rebuild (D).
- The core of the ADR is a **written trigger rule** for when to adopt C-lite: a new recovery stage, a new retry branch / recovery target, or any fresh ordering-drift incident. Until then the recovery architecture is frozen (bug fixes and equivalent refactors only). D stays out until there's evidence of coupled dual-stream distrust, plus a signal to detect it.

**Cross-cutting tests**
- Preserved cleanup keeps an unacked placement's deadline, so a request whose ack never arrives still fails closed on timeout.
- Replaced cleanup retires the stale deadline, so a request on the torn-down channel can never fire a spurious timeout. (This test pins the `retain_pending`-before-`timed_out` ordering invariant — chosen deliberately over adding a second deadline-cleanup path, which would reintroduce the drift surface the dedup removed.)
- After a verified cleanup (both continuities), a fresh unknown current-run open order is flagged for reconciliation and adopted at the sentinel level, never silently resumed as a holdable quote.

## Reviewer notes

- Branched off the (now-merged) #292 work and rebased onto `main`; the 7 recovery-dedup commits dropped out by patch-id, so this PR is exactly the 3 continuity commits.
- Deliberately **not** included: the reviewer-suggested "synchronously clear the deadline inside `finish_verified_cleanup`". Deadlines are derived solely from the projection's pending lifecycle (`retain_pending` is the only prune path); adding a second, cross-crate prune path would recreate a drift surface. The `retain`-before-`timed_out`/`next_deadline` ordering already closes any observable window, and the Replaced test pins it.

Gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, full workspace tests, and `python3 -m py_compile` on the OpenObserve dashboard scripts all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
