### PR TITLE
Gate live order creation during REST position rechecks

### DIFF
--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -21,7 +21,6 @@ use standx_sdk::account_stream::{OrderUpdate, TradeUpdate};
 use standx_sdk::client::order::CreateOrderParams;
 use standx_sdk::models::{Balance, OrderSide, OrderType, TimeInForce, Trade};
 use standx_sdk::order_response::{OrderCommandSender, OrderResponseHealth};
-use std::time::Duration;
 use std::time::Instant;
 
 const ORDER_LATENCY_TIMEOUT_MS: u64 = 15_000;
@@ -179,6 +178,10 @@ fn ensure_request_registry_capacity(projection: Option<&MakerAccountProjection>)
     Ok(())
 }
 
+fn order_creation_allowed(live: bool, rest_position_recheck_pending: bool) -> bool {
+    !live || !rest_position_recheck_pending
+}
+
 fn live_order_commands(commands: Option<&OrderCommandSender>) -> Result<&OrderCommandSender> {
     commands.ok_or_else(|| anyhow::anyhow!("order-command stream is unavailable"))
 }
@@ -284,6 +287,7 @@ pub(super) async fn maker_cycle(
     let mut account_balance: Option<Balance> = None;
     let mut fills: Vec<MakerFill> = Vec::new();
     let mut exit_fill_observed = false;
+    let mut rest_position_recheck_pending = false;
     if live {
         let projection = account_projection
             .as_deref_mut()
@@ -371,34 +375,49 @@ pub(super) async fn maker_cycle(
                 .map(rest_order_observation)
                 .collect::<Result<Vec<_>>>()?;
             let qty_tolerance = 10_f64.powi(-(cfg.qty_decimals as i32)) / 2.0;
-            if (observed_position - ledger.expected_position).abs() > qty_tolerance {
-                // Preserve the prior bounded anomaly window. The normal path
-                // performs no REST read; this sleep is reached only by a
-                // periodic audit that found an unexplained position gap.
-                tokio::time::sleep(Duration::from_millis(500)).await;
+            let unexpected_order_ids =
+                projection.unexpected_rest_open_order_ids(generation, &observations);
+            if !unexpected_order_ids.is_empty() {
+                eprintln!(
+                    "⚠️  REST audit found unexpected current-run open order IDs: {unexpected_order_ids:?}"
+                );
                 return Err(anyhow::Error::new(
-                    PositionReconciliationError::position_mismatch(
+                    PositionReconciliationError::unknown_current_run_order(
                         ledger.expected_position,
-                        observed_position,
                     ),
                 ));
             }
-            if let Err(error) = projection.verify_rest_snapshot(
-                generation,
-                observed_position,
-                &observations,
-                qty_tolerance,
-            ) {
-                eprintln!("⚠️  account projection audit failed: {error}");
-                // Reuse the runtime's immediate reconciliation/freeze path;
-                // the detailed order/projection mismatch is emitted above.
+
+            let projected_position = projection.observed_position();
+            if (projected_position - ledger.expected_position).abs() > qty_tolerance {
                 return Err(anyhow::Error::new(
-                    PositionReconciliationError::account_projection_mismatch(
+                    PositionReconciliationError::position_mismatch(
                         ledger.expected_position,
-                        observed_position,
-                        error.to_string(),
+                        projected_position,
                     ),
                 ));
+            }
+
+            if (observed_position - ledger.expected_position).abs() > qty_tolerance {
+                if poll.record_rest_position_mismatch(poll_now) {
+                    return Err(anyhow::Error::new(
+                        PositionReconciliationError::position_mismatch(
+                            ledger.expected_position,
+                            observed_position,
+                        ),
+                    ));
+                }
+                eprintln!(
+                    "⚠️  REST position {observed_position:+.8} differs from healthy WS/ledger {:+.8}; suppressing new orders until one recheck in 3s",
+                    ledger.expected_position
+                );
+            } else {
+                if poll.rest_position_recheck_pending() {
+                    eprintln!(
+                        "✅ REST position recheck converged at {observed_position:+.8}; resuming new orders"
+                    );
+                }
+                poll.record_account_audit(poll_now);
             }
             if let (Some(tracker), Some(started)) = (order_latency.as_deref_mut(), latency_started)
             {
@@ -411,14 +430,8 @@ pub(super) async fn maker_cycle(
                     eprintln!("⚠️ order latency REST-effective observation unavailable: {error}");
                 }
             }
-            projection.apply(
-                generation,
-                AccountProjectionEvent::PositionObserved {
-                    position: observed_position,
-                },
-            );
-            poll.record_account_audit(poll_now);
         }
+        rest_position_recheck_pending = poll.rest_position_recheck_pending();
         position = ledger.expected_position;
         projected_resting = projection.resting_quotes();
     } else {
@@ -519,7 +532,12 @@ pub(super) async fn maker_cycle(
         ));
     }
 
-    let inventory_exit = plan.inventory_exit;
+    let create_orders_allowed = order_creation_allowed(live, rest_position_recheck_pending);
+    let inventory_exit = if create_orders_allowed {
+        plan.inventory_exit
+    } else {
+        None
+    };
     // The pure reconciler intentionally knows nothing about transport state.
     // Remove desired placements whose slots are still reserved by an HTTP
     // submission before both execution and telemetry, so output never claims
@@ -528,6 +546,7 @@ pub(super) async fn maker_cycle(
         .actions
         .into_iter()
         .filter(|action| match action {
+            Action::Place(_) if !create_orders_allowed => false,
             Action::Place(q)
                 if live
                     && maker::pending_covers_slot(
@@ -954,6 +973,13 @@ mod tests {
         assert!(request.context.recovery);
         assert_eq!(request.context.generation, 7);
         assert_eq!(request.context.market_source.as_deref(), Some("ws"));
+    }
+
+    #[test]
+    fn rest_position_recheck_blocks_only_live_order_creation() {
+        assert!(!order_creation_allowed(true, true));
+        assert!(order_creation_allowed(true, false));
+        assert!(order_creation_allowed(false, true));
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 const ACCOUNT_AUDIT_INTERVAL: Duration = Duration::from_secs(30);
+const REST_POSITION_RECHECK_DELAY: Duration = Duration::from_secs(3);
 const BALANCE_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 const BALANCE_MAX_STALE: Duration = Duration::from_secs(60);
 const BALANCE_REFRESH_RETRY: Duration = Duration::from_secs(5);
@@ -184,6 +185,7 @@ pub(super) struct LiveAccountPollState {
     balance_updated_at: Instant,
     next_balance_refresh_at: Instant,
     next_account_audit_at: Instant,
+    rest_position_recheck_at: Option<Instant>,
 }
 
 impl LiveAccountPollState {
@@ -193,6 +195,7 @@ impl LiveAccountPollState {
             balance_updated_at: now,
             next_balance_refresh_at: now + BALANCE_REFRESH_INTERVAL,
             next_account_audit_at: now + ACCOUNT_AUDIT_INTERVAL,
+            rest_position_recheck_at: None,
         }
     }
 
@@ -219,6 +222,25 @@ impl LiveAccountPollState {
         now >= self.next_account_audit_at
     }
 
+    pub(super) fn rest_position_recheck_pending(&self) -> bool {
+        self.rest_position_recheck_at.is_some()
+    }
+
+    /// Defer the first REST-only position disagreement for one bounded
+    /// confirmation window. Returns true only when a successful audit still
+    /// disagrees at or after the scheduled recheck deadline.
+    pub(super) fn record_rest_position_mismatch(&mut self, now: Instant) -> bool {
+        match self.rest_position_recheck_at {
+            Some(deadline) => now >= deadline,
+            None => {
+                let deadline = now + REST_POSITION_RECHECK_DELAY;
+                self.rest_position_recheck_at = Some(deadline);
+                self.next_account_audit_at = deadline;
+                false
+            }
+        }
+    }
+
     pub(super) fn balance_is_within_stale_limit(&self, now: Instant) -> bool {
         now.duration_since(self.balance_updated_at) <= BALANCE_MAX_STALE
     }
@@ -234,6 +256,7 @@ impl LiveAccountPollState {
     }
 
     pub(super) fn record_account_audit(&mut self, now: Instant) {
+        self.rest_position_recheck_at = None;
         self.next_account_audit_at = now + ACCOUNT_AUDIT_INTERVAL;
     }
 }
@@ -487,6 +510,27 @@ mod tests {
         state.record_balance_refresh(balance(), due);
         assert!(!state.account_audit_due(due + Duration::from_secs(29)));
         assert!(!state.balance_refresh_due(due + Duration::from_secs(29)));
+    }
+
+    #[test]
+    fn rest_position_mismatch_gets_one_three_second_recheck() {
+        let now = Instant::now();
+        let mut state = LiveAccountPollState::new(balance(), now);
+        let first_audit = now + ACCOUNT_AUDIT_INTERVAL;
+
+        assert!(!state.record_rest_position_mismatch(first_audit));
+        assert!(state.rest_position_recheck_pending());
+        assert!(!state.account_audit_due(first_audit + Duration::from_millis(2_999)));
+
+        let recheck = first_audit + REST_POSITION_RECHECK_DELAY;
+        assert!(state.account_audit_due(recheck));
+        assert!(state.record_rest_position_mismatch(recheck));
+        assert!(state.account_audit_due(recheck + Duration::from_secs(1)));
+
+        state.record_account_audit(recheck);
+        assert!(!state.rest_position_recheck_pending());
+        assert!(!state.account_audit_due(recheck + Duration::from_secs(29)));
+        assert!(state.account_audit_due(recheck + ACCOUNT_AUDIT_INTERVAL));
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -23,7 +23,6 @@ const MAKER_CLEANUP_RETRY_DELAY: Duration = Duration::from_secs(1);
 #[derive(Debug)]
 pub(super) enum PositionReconciliationCause {
     PositionMismatch,
-    AccountProjectionMismatch(String),
     UnknownCurrentRunOrder,
     CycleInvalidation,
 }
@@ -32,7 +31,6 @@ impl PositionReconciliationCause {
     pub(super) fn label(&self) -> &'static str {
         match self {
             Self::PositionMismatch => "position_mismatch",
-            Self::AccountProjectionMismatch(_) => "account_projection_mismatch",
             Self::UnknownCurrentRunOrder => "unknown_current_run_order",
             Self::CycleInvalidation => "cycle_invalidation",
         }
@@ -41,9 +39,9 @@ impl PositionReconciliationCause {
     pub(super) fn recovery_trigger(&self) -> standx_maker::RecoveryTrigger {
         match self {
             Self::CycleInvalidation => standx_maker::RecoveryTrigger::CycleInvalidation,
-            Self::PositionMismatch
-            | Self::AccountProjectionMismatch(_)
-            | Self::UnknownCurrentRunOrder => standx_maker::RecoveryTrigger::PositionMismatch,
+            Self::PositionMismatch | Self::UnknownCurrentRunOrder => {
+                standx_maker::RecoveryTrigger::PositionMismatch
+            }
         }
     }
 }
@@ -61,18 +59,6 @@ impl PositionReconciliationError {
             expected,
             observed,
             cause: PositionReconciliationCause::PositionMismatch,
-        }
-    }
-
-    pub(super) fn account_projection_mismatch(
-        expected: f64,
-        observed: f64,
-        detail: String,
-    ) -> Self {
-        Self {
-            expected,
-            observed,
-            cause: PositionReconciliationCause::AccountProjectionMismatch(detail),
         }
     }
 
@@ -99,11 +85,6 @@ impl fmt::Display for PositionReconciliationError {
             PositionReconciliationCause::PositionMismatch => write!(
                 formatter,
                 "expected position {:+.8}, venue reported {:+.8}",
-                self.expected, self.observed
-            ),
-            PositionReconciliationCause::AccountProjectionMismatch(detail) => write!(
-                formatter,
-                "account projection mismatch ({detail}); ledger expected {:+.8}, venue reported {:+.8}",
                 self.expected, self.observed
             ),
             PositionReconciliationCause::UnknownCurrentRunOrder => write!(

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -2732,7 +2732,6 @@ pub(super) async fn run_maker(
                                 message: match &mismatch.cause {
                                     PositionReconciliationCause::CycleInvalidation => "account update invalidated active cycle; placements frozen and maker cleanup starting",
                                     PositionReconciliationCause::UnknownCurrentRunOrder => "unknown current-run order detected; placements frozen and maker cleanup starting",
-                                    PositionReconciliationCause::AccountProjectionMismatch(_) => "account projection audit failed; placements frozen and maker cleanup starting",
                                     PositionReconciliationCause::PositionMismatch => "position mismatch detected; placements frozen and maker cleanup starting",
                                 },
                                 symbol: &symbol,

--- a/crates/standx-maker/src/account_projection.rs
+++ b/crates/standx-maker/src/account_projection.rs
@@ -182,48 +182,6 @@ pub struct ProjectionOutcome {
     pub request_registry_error: Option<ProjectionRegistryError>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum ProjectionMismatch {
-    Position {
-        projected: f64,
-        observed: f64,
-    },
-    OrderSet {
-        projected: Vec<u64>,
-        observed: Vec<u64>,
-    },
-    OrderQuantity {
-        order_id: u64,
-        projected: f64,
-        observed: f64,
-    },
-}
-
-impl fmt::Display for ProjectionMismatch {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Position { projected, observed } => write!(
-                formatter,
-                "projected position {projected:+.8} differs from REST {observed:+.8}"
-            ),
-            Self::OrderSet { projected, observed } => write!(
-                formatter,
-                "projected maker order IDs {projected:?} differ from REST {observed:?}"
-            ),
-            Self::OrderQuantity {
-                order_id,
-                projected,
-                observed,
-            } => write!(
-                formatter,
-                "projected open qty {projected:.8} for order {order_id} differs from REST {observed:.8}"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for ProjectionMismatch {}
-
 /// One in-flight place/cancel request, tracked in a single registry.
 ///
 /// A request has two independent lifecycles that used to live in two parallel
@@ -957,24 +915,26 @@ impl MakerAccountProjection {
                 })
     }
 
-    pub fn verify_rest_snapshot(
+    /// Return current-run REST open orders that the live projection cannot
+    /// explain as either already projected or still awaiting their account
+    /// order observation.
+    ///
+    /// REST order-set absence and quantity differences are deliberately not
+    /// audited here. The authenticated account stream owns steady-state order
+    /// truth; retaining a projection-only order is conservative because its
+    /// quote slot stays occupied. A REST-only order is safe to tolerate only
+    /// while it matches an active place slot by client-order ID or an active
+    /// cancel slot by venue order ID.
+    pub fn unexpected_rest_open_order_ids(
         &self,
         generation: u64,
-        observed_position: f64,
         observed_orders: &[OrderObservation],
-        qty_tolerance: f64,
-    ) -> Result<(), ProjectionMismatch> {
+    ) -> Vec<u64> {
         if generation != self.generation {
-            return Ok(());
+            return Vec::new();
         }
-        if (self.observed_position - observed_position).abs() > qty_tolerance {
-            return Err(ProjectionMismatch::Position {
-                projected: self.observed_position,
-                observed: observed_position,
-            });
-        }
-        let mut projected = self.orders.keys().copied().collect::<Vec<_>>();
-        let mut observed = observed_orders
+
+        let mut unexpected = observed_orders
             .iter()
             .filter(|order| {
                 !order.terminal
@@ -983,29 +943,28 @@ impl MakerAccountProjection {
                         &self.run_order_prefix,
                     )
             })
+            .filter(|order| {
+                if self.orders.contains_key(&order.order_id) {
+                    return false;
+                }
+                let Some(client_order_id) = order.client_order_id.as_deref() else {
+                    return true;
+                };
+                !self.pending.iter().any(|entry| {
+                    entry.slot_open
+                        && (entry
+                            .place()
+                            .is_some_and(|place| place.client_order_id == client_order_id)
+                            || entry
+                                .cancel()
+                                .is_some_and(|cancel| cancel.order_id == order.order_id))
+                })
+            })
             .map(|order| order.order_id)
             .collect::<Vec<_>>();
-        projected.sort_unstable();
-        observed.sort_unstable();
-        if projected != observed {
-            return Err(ProjectionMismatch::OrderSet {
-                projected,
-                observed,
-            });
-        }
-        for observation in observed_orders {
-            let Some(order) = self.orders.get(&observation.order_id) else {
-                continue;
-            };
-            if (order.open_qty - observation.open_qty).abs() > qty_tolerance {
-                return Err(ProjectionMismatch::OrderQuantity {
-                    order_id: observation.order_id,
-                    projected: order.open_qty,
-                    observed: observation.open_qty,
-                });
-            }
-        }
-        Ok(())
+        unexpected.sort_unstable();
+        unexpected.dedup();
+        unexpected
     }
 }
 
@@ -1210,7 +1169,7 @@ mod tests {
         state.apply(
             1,
             AccountProjectionEvent::PlaceAccepted {
-                request_id: "p1".to_string(),
+                request_id: "p2".to_string(),
             },
         );
         state.apply(1, AccountProjectionEvent::OrderObserved(order(0.2, false)));
@@ -1503,20 +1462,114 @@ mod tests {
     }
 
     #[test]
-    fn rest_audit_detects_order_and_position_drift_without_mutation() {
+    fn rest_audit_tolerates_projection_absence_and_known_quantity_drift() {
         let mut state = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
         state.apply(1, AccountProjectionEvent::PlaceSubmitted(pending("p1")));
         state.apply(1, AccountProjectionEvent::OrderObserved(order(0.2, false)));
 
-        assert!(matches!(
-            state.verify_rest_snapshot(1, 0.1, &[order(0.2, false)], 0.001),
-            Err(ProjectionMismatch::Position { .. })
-        ));
-        assert!(matches!(
-            state.verify_rest_snapshot(1, 0.0, &[], 0.001),
-            Err(ProjectionMismatch::OrderSet { .. })
-        ));
+        assert!(state.unexpected_rest_open_order_ids(1, &[]).is_empty());
+        assert!(state
+            .unexpected_rest_open_order_ids(1, &[order(0.1, false)])
+            .is_empty());
         assert_eq!(state.resting_quotes()[0].qty, 0.2);
+    }
+
+    #[test]
+    fn rest_audit_tolerates_projected_order_plus_place_awaiting_account_stream() {
+        let mut state = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
+        state.apply(1, AccountProjectionEvent::PlaceSubmitted(pending("p1")));
+        state.apply(1, AccountProjectionEvent::OrderObserved(order(0.2, false)));
+
+        let mut second = pending("p2");
+        second.client_order_id = format!("{PREFIX}q00000002a0");
+        second.side = OrderSide::Sell;
+        second.price = 101.0;
+        second.level = 1;
+        second.cycle = 2;
+        state.apply(1, AccountProjectionEvent::PlaceSubmitted(second.clone()));
+
+        let mut projected = order(0.1, false);
+        let rest_only = OrderObservation {
+            order_id: 8,
+            client_order_id: Some(second.client_order_id),
+            side: second.side,
+            price: second.price,
+            open_qty: second.qty,
+            terminal: false,
+        };
+
+        assert!(state
+            .unexpected_rest_open_order_ids(1, &[projected.clone(), rest_only.clone()])
+            .is_empty());
+
+        state.apply(
+            1,
+            AccountProjectionEvent::PlaceAccepted {
+                request_id: "p1".to_string(),
+            },
+        );
+        projected.open_qty = 0.05;
+        assert!(state
+            .unexpected_rest_open_order_ids(1, &[projected, rest_only])
+            .is_empty());
+    }
+
+    #[test]
+    fn rest_audit_rejects_unexpected_or_retired_current_run_open_order() {
+        let mut state = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
+        let unexpected = order(0.2, false);
+        assert_eq!(
+            state.unexpected_rest_open_order_ids(1, std::slice::from_ref(&unexpected)),
+            vec![7]
+        );
+
+        state.apply(1, AccountProjectionEvent::PlaceSubmitted(pending("p1")));
+        state.apply(1, AccountProjectionEvent::OrderObserved(unexpected.clone()));
+        state.apply(1, AccountProjectionEvent::OrderObserved(order(0.0, true)));
+        assert_eq!(
+            state.unexpected_rest_open_order_ids(1, std::slice::from_ref(&unexpected)),
+            vec![7]
+        );
+
+        let mut wrong_run = unexpected;
+        wrong_run.client_order_id = Some("sxmk-other-q00000001b0".to_string());
+        assert!(state
+            .unexpected_rest_open_order_ids(1, &[wrong_run])
+            .is_empty());
+        assert!(state
+            .unexpected_rest_open_order_ids(2, &[order(0.2, false)])
+            .is_empty());
+    }
+
+    #[test]
+    fn rest_audit_tolerates_order_until_pending_cancel_resolves() {
+        let mut state = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
+        state.apply(1, AccountProjectionEvent::PlaceSubmitted(pending("p1")));
+        let open = order(0.2, false);
+        state.apply(1, AccountProjectionEvent::OrderObserved(open.clone()));
+        state.apply(
+            1,
+            AccountProjectionEvent::CancelSubmitted(ProjectionPendingCancel {
+                request_id: "c1".to_string(),
+                order_id: open.order_id,
+                side: open.side,
+                level: 0,
+                price: open.price,
+                cycle: 2,
+            }),
+        );
+
+        assert!(state
+            .unexpected_rest_open_order_ids(1, std::slice::from_ref(&open))
+            .is_empty());
+
+        state.apply(
+            1,
+            AccountProjectionEvent::CancelResolved {
+                request_id: "c1".to_string(),
+            },
+        );
+        assert_eq!(state.unexpected_rest_open_order_ids(1, &[open]), vec![7]);
     }
 
     #[test]

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -29,9 +29,9 @@ pub mod runtime;
 
 pub use account_projection::{
     AccountProjectionEvent, MakerAccountProjection, OrderObservation, OrderResponseContinuity,
-    ProjectedOrder, ProjectionMismatch, ProjectionOutcome, ProjectionPendingCancel,
-    ProjectionPendingPlace, ProjectionPendingRequest, ProjectionRegistryError,
-    ProjectionRequestResolution, MAX_PENDING_ORDER_REQUESTS,
+    ProjectedOrder, ProjectionOutcome, ProjectionPendingCancel, ProjectionPendingPlace,
+    ProjectionPendingRequest, ProjectionRegistryError, ProjectionRequestResolution,
+    MAX_PENDING_ORDER_REQUESTS,
 };
 pub use latency::{
     LatencyError, LatencyMetricSummary, LatencyRequest, LatencyRequestContext, LatencyRequestKind,


### PR DESCRIPTION
## Summary
- Add a bounded REST position recheck path that suppresses new live order creation until the follow-up audit converges.
- Tighten REST reconciliation to flag unexpected current-run open orders separately from pure position drift.
- Simplify recovery causes by folding projection-specific mismatch handling into position mismatch and unknown-order paths.
- Expand unit coverage for the new recheck timing and REST audit behavior.

## Testing
- Added unit tests for the live order gate, recheck timing, and REST audit acceptance/rejection cases.
- Not run (not requested)