### PR TITLE
Add market-data recovery for stale public feed

### DIFF
--- a/crates/standx-cli/src/commands/maker/feed.rs
+++ b/crates/standx-cli/src/commands/maker/feed.rs
@@ -14,6 +14,7 @@ pub(super) struct FeedState {
     best_bid: Option<f64>,
     best_ask: Option<f64>,
     book_meta: Option<FeedMeta>,
+    reconnect_issue: Option<WsSnapshotIssue>,
 }
 
 #[derive(Clone)]
@@ -64,6 +65,12 @@ const WS_STALE_AFTER: Duration = Duration::from_secs(5);
 /// time is preferred; local receive-time skew is used only when either venue
 /// timestamp is unavailable.
 const WS_SNAPSHOT_MAX_SKEW: Duration = WS_STALE_AFTER;
+/// A socket can stay TCP-healthy while one subscribed channel stops yielding
+/// usable updates. Rebuild the whole public connection when either channel
+/// has been idle this long.
+const MARKET_FEED_IDLE_AFTER: Duration = Duration::from_secs(15);
+const MARKET_FEED_REBUILD_DELAY: Duration = Duration::from_secs(10);
+const MARKET_FEED_IDLE_REBUILD_DELAY: Duration = Duration::from_secs(1);
 
 /// Why the latest public WebSocket cache cannot safely be used for a maker
 /// cycle. These stable labels are emitted with `cycle_summary` so a REST
@@ -74,6 +81,10 @@ pub(super) enum WsSnapshotIssue {
     MarkStale,
     BookStale,
     MarkAndBookStale,
+    PriceIdle,
+    BookIdle,
+    PriceAndBookIdle,
+    StreamEnded,
     LocalSkew,
     ServerTimeSkew,
     InvalidSnapshot,
@@ -86,9 +97,65 @@ impl WsSnapshotIssue {
             Self::MarkStale => "ws_mark_stale",
             Self::BookStale => "ws_book_stale",
             Self::MarkAndBookStale => "ws_mark_and_book_stale",
+            Self::PriceIdle => "ws_price_idle",
+            Self::BookIdle => "ws_book_idle",
+            Self::PriceAndBookIdle => "ws_price_and_book_idle",
+            Self::StreamEnded => "ws_stream_ended",
             Self::LocalSkew => "ws_local_time_skew",
             Self::ServerTimeSkew => "ws_server_time_skew",
             Self::InvalidSnapshot => "ws_invalid_snapshot",
+        }
+    }
+
+    pub(super) const fn is_idle(self) -> bool {
+        matches!(
+            self,
+            Self::PriceIdle | Self::BookIdle | Self::PriceAndBookIdle
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct FeedSnapshotVersion {
+    mark_received_at: Instant,
+    book_received_at: Instant,
+}
+
+impl FeedSnapshotVersion {
+    pub(super) fn both_advanced_from(self, previous: Option<Self>) -> bool {
+        previous.map_or(true, |previous| {
+            self.mark_received_at > previous.mark_received_at
+                && self.book_received_at > previous.book_received_at
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ChannelFreshness {
+    price: Instant,
+    book: Instant,
+}
+
+impl ChannelFreshness {
+    fn new(now: Instant) -> Self {
+        Self {
+            price: now,
+            book: now,
+        }
+    }
+
+    fn next_deadline(self) -> Instant {
+        self.price.min(self.book) + MARKET_FEED_IDLE_AFTER
+    }
+
+    fn idle_issue(self, now: Instant) -> Option<WsSnapshotIssue> {
+        let price_idle = now.saturating_duration_since(self.price) >= MARKET_FEED_IDLE_AFTER;
+        let book_idle = now.saturating_duration_since(self.book) >= MARKET_FEED_IDLE_AFTER;
+        match (price_idle, book_idle) {
+            (true, true) => Some(WsSnapshotIssue::PriceAndBookIdle),
+            (true, false) => Some(WsSnapshotIssue::PriceIdle),
+            (false, true) => Some(WsSnapshotIssue::BookIdle),
+            (false, false) => None,
         }
     }
 }
@@ -128,8 +195,19 @@ fn update_is_newer<T>(previous: Option<&FeedMeta>, update: &WsMarketUpdate<T>) -
             .as_deref()
             .and_then(parse_server_time_millis),
     ),
-        (Some(previous), Some(next)) if next < previous
+        (Some(previous), Some(next)) if next <= previous
     )
+}
+
+fn parse_optional_positive_price(value: Option<&str>) -> Option<Option<f64>> {
+    match value {
+        None => Some(None),
+        Some(value) => value
+            .parse::<f64>()
+            .ok()
+            .filter(|price| price.is_finite() && *price > 0.0)
+            .map(Some),
+    }
 }
 
 fn update_meta<T>(update: &WsMarketUpdate<T>) -> FeedMeta {
@@ -231,15 +309,39 @@ fn coherent_ws_snapshot(
         .map_err(|_| WsSnapshotIssue::InvalidSnapshot)
 }
 
+pub(super) fn ws_snapshot_issue(state: &FeedState, now: Instant) -> Option<WsSnapshotIssue> {
+    coherent_ws_snapshot(state, now)
+        .err()
+        .map(|issue| state.reconnect_issue.unwrap_or(issue))
+}
+
+pub(super) fn fresh_ws_sample(
+    state: &FeedState,
+) -> Option<(f64, Option<f64>, Option<f64>, FeedSnapshotVersion)> {
+    let (mark, best_bid, best_ask) = coherent_ws_snapshot(state, Instant::now()).ok()?;
+    let version = FeedSnapshotVersion {
+        mark_received_at: state.mark_meta.as_ref()?.received_at,
+        book_received_at: state.book_meta.as_ref()?.received_at,
+    };
+    Some((mark, best_bid, best_ask, version))
+}
+
 pub(super) fn fresh_ws_snapshot(state: &FeedState) -> Option<(f64, Option<f64>, Option<f64>)> {
-    coherent_ws_snapshot(state, Instant::now()).ok()
+    fresh_ws_sample(state).map(|(mark, best_bid, best_ask, _)| (mark, best_bid, best_ask))
+}
+
+async fn reset_feed_state(state: &RwLock<FeedState>, issue: WsSnapshotIssue) {
+    *state.write().await = FeedState {
+        reconnect_issue: Some(issue),
+        ..FeedState::default()
+    };
 }
 
 /// Spawn the resident market-feed task: one public WS connection carrying
 /// `price` + `depth_book`, written into a shared cache. The outer loop wraps
 /// the SDK's internal 5-attempt reconnect — when the stream ends (attempts
 /// exhausted or clean close), it rebuilds the connection from scratch, since
-/// subscriptions only take effect when registered before `connect()`.
+/// subscriptions only take effect when registered before `connect_managed()`.
 pub(super) fn spawn_market_feed(
     symbol: String,
     verbose: bool,
@@ -259,61 +361,129 @@ pub(super) fn spawn_market_feed(
                 Ok(ws) => ws,
                 Err(e) => {
                     eprintln!("⚠️  market feed setup failed: {e}; retrying in 10s");
-                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    tokio::time::sleep(MARKET_FEED_REBUILD_DELAY).await;
                     continue;
                 }
             };
             let _ = ws.subscribe("price", Some(&symbol)).await;
             let _ = ws.subscribe("depth_book", Some(&symbol)).await;
-            let mut events = match ws.connect().await {
-                Ok(rx) => rx,
+            let (mut events, connection_handle) = match ws.connect_managed().await {
+                Ok(connection) => connection,
                 Err(e) => {
                     eprintln!("⚠️  market feed connect failed: {e}; retrying in 10s");
-                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    tokio::time::sleep(MARKET_FEED_REBUILD_DELAY).await;
                     continue;
                 }
             };
-            while let Some(msg) = events.recv().await {
-                let changed = match msg {
-                    WsMessage::Price(update)
-                        if update.data.symbol.eq_ignore_ascii_case(&symbol) =>
-                    {
-                        if let Ok(mark) = update.data.mark_price.parse::<f64>() {
-                            let mut s = state_task.write().await;
-                            if update_is_newer(s.mark_meta.as_ref(), &update) {
-                                s.mark = Some(mark);
-                                s.mark_meta = Some(update_meta(&update));
-                                true
-                            } else {
-                                false
+            let mut freshness = ChannelFreshness::new(Instant::now());
+            let rebuild_delay = loop {
+                let idle_deadline = tokio::time::Instant::from_std(freshness.next_deadline());
+                tokio::select! {
+                    message = events.recv() => {
+                        let Some(msg) = message else {
+                            connection_handle.abort();
+                            reset_feed_state(&state_task, WsSnapshotIssue::StreamEnded).await;
+                            seq = seq.saturating_add(1);
+                            let _ = tx.send(seq);
+                            eprintln!("⚠️  market feed stream ended; rebuilding connection in 10s");
+                            break MARKET_FEED_REBUILD_DELAY;
+                        };
+                        match &msg {
+                            WsMessage::Connected => {
+                                *state_task.write().await = FeedState::default();
+                                freshness = ChannelFreshness::new(Instant::now());
+                                seq = seq.saturating_add(1);
+                                let _ = tx.send(seq);
+                                continue;
                             }
-                        } else {
-                            false
+                            WsMessage::Disconnected => {
+                                reset_feed_state(&state_task, WsSnapshotIssue::StreamEnded).await;
+                                seq = seq.saturating_add(1);
+                                let _ = tx.send(seq);
+                                continue;
+                            }
+                            _ => {}
+                        }
+                        let accepted = match msg {
+                            WsMessage::Price(update)
+                                if update.data.symbol.eq_ignore_ascii_case(&symbol) =>
+                            {
+                                let received_at = update.received_at;
+                                if let Ok(mark) = update.data.mark_price.parse::<f64>() {
+                                    if !mark.is_finite() || mark <= 0.0 {
+                                        None
+                                    } else {
+                                        let mut s = state_task.write().await;
+                                        if update_is_newer(s.mark_meta.as_ref(), &update) {
+                                            s.mark = Some(mark);
+                                            s.mark_meta = Some(update_meta(&update));
+                                            if s.book_meta.is_some() {
+                                                s.reconnect_issue = None;
+                                            }
+                                            Some((true, received_at))
+                                        } else {
+                                            None
+                                        }
+                                    }
+                                } else {
+                                    None
+                                }
+                            }
+                            WsMessage::Depth(update)
+                                if update.data.symbol.eq_ignore_ascii_case(&symbol) =>
+                            {
+                                let received_at = update.received_at;
+                                let parsed = (
+                                    parse_optional_positive_price(update.data.best_bid()),
+                                    parse_optional_positive_price(update.data.best_ask()),
+                                );
+                                if let (Some(best_bid), Some(best_ask)) = parsed {
+                                    let mut s = state_task.write().await;
+                                    if update_is_newer(s.book_meta.as_ref(), &update) {
+                                        s.best_bid = best_bid;
+                                        s.best_ask = best_ask;
+                                        s.book_meta = Some(update_meta(&update));
+                                        if s.mark_meta.is_some() {
+                                            s.reconnect_issue = None;
+                                        }
+                                        Some((false, received_at))
+                                    } else {
+                                        None
+                                    }
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => None,
+                        };
+                        if let Some((price, received_at)) = accepted {
+                            if price {
+                                freshness.price = received_at;
+                            } else {
+                                freshness.book = received_at;
+                            }
+                            seq = seq.saturating_add(1);
+                            let _ = tx.send(seq);
                         }
                     }
-                    WsMessage::Depth(update)
-                        if update.data.symbol.eq_ignore_ascii_case(&symbol) =>
-                    {
-                        let mut s = state_task.write().await;
-                        if update_is_newer(s.book_meta.as_ref(), &update) {
-                            s.best_bid = update.data.best_bid().and_then(|v| v.parse().ok());
-                            s.best_ask = update.data.best_ask().and_then(|v| v.parse().ok());
-                            s.book_meta = Some(update_meta(&update));
-                            true
-                        } else {
-                            false
-                        }
+                    _ = tokio::time::sleep_until(idle_deadline) => {
+                        let now = Instant::now();
+                        let Some(issue) = freshness.idle_issue(now) else {
+                            continue;
+                        };
+                        connection_handle.abort();
+                        reset_feed_state(&state_task, issue).await;
+                        seq = seq.saturating_add(1);
+                        let _ = tx.send(seq);
+                        eprintln!(
+                            "⚠️  market feed effective-update watchdog fired (reason={}); rebuilding connection in 1s",
+                            issue.as_str()
+                        );
+                        break MARKET_FEED_IDLE_REBUILD_DELAY;
                     }
-                    _ => false,
-                };
-                if changed {
-                    seq += 1;
-                    let _ = tx.send(seq);
                 }
-            }
-            // Stream ended: SDK reconnects exhausted or server closed.
-            eprintln!("⚠️  market feed stream ended; rebuilding connection in 10s");
-            tokio::time::sleep(Duration::from_secs(10)).await;
+            };
+            tokio::time::sleep(rebuild_delay).await;
         }
     });
 
@@ -344,7 +514,9 @@ pub(super) async fn market_snapshot(
                     ws_snapshot,
                 });
             }
-            Err(issue) => ws_issue = Some(issue.as_str()),
+            Err(issue) => {
+                ws_issue = Some(s.reconnect_issue.unwrap_or(issue).as_str());
+            }
         }
     }
 
@@ -439,6 +611,27 @@ mod tests {
             received_at: now,
         };
         assert!(!update_is_newer(Some(&previous), &regressed_time));
+        let duplicate_time = WsMarketUpdate {
+            data: (),
+            seq: None,
+            server_time: Some("2026-07-14T00:00:10Z".to_string()),
+            envelope_time: Some("2026-07-14T00:00:10Z".to_string()),
+            payload_time: None,
+            received_at: now,
+        };
+        assert!(!update_is_newer(Some(&previous), &duplicate_time));
+    }
+
+    #[test]
+    fn effective_book_update_rejects_invalid_prices_but_accepts_empty_sides() {
+        assert_eq!(parse_optional_positive_price(None), Some(None));
+        assert_eq!(
+            parse_optional_positive_price(Some("100.25")),
+            Some(Some(100.25))
+        );
+        for value in ["0", "-1", "NaN", "not-a-price"] {
+            assert_eq!(parse_optional_positive_price(Some(value)), None);
+        }
     }
 
     #[test]
@@ -454,6 +647,7 @@ mod tests {
                 "2026-07-14T00:00:00Z",
                 now + Duration::from_secs(3),
             )),
+            reconnect_issue: None,
         };
         assert!(coherent_ws_snapshot(&state, now + Duration::from_secs(3)).is_ok());
     }
@@ -467,6 +661,7 @@ mod tests {
             best_bid: Some(99.9),
             best_ask: Some(100.1),
             book_meta: Some(meta(2, "2026-07-14T00:00:03Z", now)),
+            reconnect_issue: None,
         };
         assert!(coherent_ws_snapshot(&state, now).is_ok());
     }
@@ -480,6 +675,7 @@ mod tests {
             best_bid: Some(99.9),
             best_ask: Some(100.1),
             book_meta: Some(meta(2, "2026-07-14T00:00:06Z", now)),
+            reconnect_issue: None,
         };
         assert_eq!(
             coherent_ws_snapshot(&state, now),
@@ -502,6 +698,7 @@ mod tests {
                 payload_time: None,
                 received_at: now + Duration::from_secs(3),
             }),
+            reconnect_issue: None,
         };
         assert!(coherent_ws_snapshot(&state, now + Duration::from_secs(3)).is_ok());
     }
@@ -521,6 +718,7 @@ mod tests {
                 payload_time: None,
                 received_at: now + Duration::from_secs(6),
             }),
+            reconnect_issue: None,
         };
         assert_eq!(
             coherent_ws_snapshot(&state, now),
@@ -543,6 +741,7 @@ mod tests {
             best_bid: Some(99.9),
             best_ask: Some(100.1),
             book_meta: Some(book),
+            reconnect_issue: None,
         };
 
         let diagnostics = ws_snapshot_diagnostics(&state, now);
@@ -572,6 +771,7 @@ mod tests {
             best_bid: Some(99.9),
             best_ask: Some(100.1),
             book_meta: Some(meta(2, "2026-07-14T00:00:00Z", now - WS_STALE_AFTER)),
+            reconnect_issue: None,
         };
         assert_eq!(
             coherent_ws_snapshot(&state, now),
@@ -596,6 +796,65 @@ mod tests {
         assert_eq!(
             coherent_ws_snapshot(&state, now),
             Err(WsSnapshotIssue::MarkStale)
+        );
+    }
+
+    #[test]
+    fn idle_watchdog_tracks_price_and_book_independently() {
+        let now = Instant::now();
+        let mut freshness = ChannelFreshness::new(now);
+        assert_eq!(
+            freshness.idle_issue(now + MARKET_FEED_IDLE_AFTER - Duration::from_millis(1)),
+            None
+        );
+
+        freshness.price = now + Duration::from_secs(10);
+        assert_eq!(
+            freshness.idle_issue(now + MARKET_FEED_IDLE_AFTER),
+            Some(WsSnapshotIssue::BookIdle)
+        );
+
+        freshness.book = now + MARKET_FEED_IDLE_AFTER;
+        assert_eq!(
+            freshness.idle_issue(now + Duration::from_secs(25)),
+            Some(WsSnapshotIssue::PriceIdle)
+        );
+
+        let both_idle = ChannelFreshness::new(now);
+        assert_eq!(
+            both_idle.idle_issue(now + MARKET_FEED_IDLE_AFTER),
+            Some(WsSnapshotIssue::PriceAndBookIdle)
+        );
+    }
+
+    #[test]
+    fn recovery_version_requires_both_channels_to_advance() {
+        let now = Instant::now();
+        let previous = FeedSnapshotVersion {
+            mark_received_at: now,
+            book_received_at: now,
+        };
+        assert!(!FeedSnapshotVersion {
+            mark_received_at: now + Duration::from_secs(1),
+            book_received_at: now,
+        }
+        .both_advanced_from(Some(previous)));
+        assert!(FeedSnapshotVersion {
+            mark_received_at: now + Duration::from_secs(1),
+            book_received_at: now + Duration::from_secs(1),
+        }
+        .both_advanced_from(Some(previous)));
+    }
+
+    #[test]
+    fn reconnect_issue_explains_empty_cache_after_idle_reset() {
+        let state = FeedState {
+            reconnect_issue: Some(WsSnapshotIssue::PriceIdle),
+            ..FeedState::default()
+        };
+        assert_eq!(
+            ws_snapshot_issue(&state, Instant::now()),
+            Some(WsSnapshotIssue::PriceIdle)
         );
     }
 }

--- a/crates/standx-cli/src/commands/maker/market_data.rs
+++ b/crates/standx-cli/src/commands/maker/market_data.rs
@@ -1,0 +1,300 @@
+use super::feed::{fresh_ws_sample, FeedState};
+use super::recovery::cancel_maker_orders_with_retry;
+use crate::cli::OutputFormat;
+use anyhow::Result;
+use standx_maker as maker;
+use standx_sdk::client::StandXClient;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{watch, RwLock};
+
+pub(super) const MARKET_DATA_RECOVERY_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Debug)]
+pub(super) struct MarketDataDegradedError {
+    pub(super) detail: String,
+}
+
+impl std::fmt::Display for MarketDataDegradedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for MarketDataDegradedError {}
+
+pub(super) fn degradation_detail(
+    transition: maker::MarketDataTransition,
+    observation_detail: &str,
+) -> Option<String> {
+    match transition {
+        maker::MarketDataTransition::EnteredDegraded {
+            issue,
+            consecutive,
+            bad_for_ms,
+        } => Some(format!(
+            "market data degraded: issue={} consecutive={} bad_for_ms={bad_for_ms}; {observation_detail}",
+            issue.label(),
+            consecutive,
+        )),
+        _ => None,
+    }
+}
+
+pub(super) struct AcquiredMarketHealth<'a> {
+    pub(super) now_ms: u64,
+    pub(super) source: &'a str,
+    pub(super) fallback_reason: Option<&'a str>,
+    pub(super) mark: f64,
+    pub(super) best_bid: Option<f64>,
+    pub(super) best_ask: Option<f64>,
+    pub(super) max_divergence_bps: f64,
+}
+
+pub(super) fn observe_acquired_market_health(
+    health: &mut maker::MarketDataHealth,
+    acquired: AcquiredMarketHealth<'_>,
+) -> Option<String> {
+    let (observation, detail) = if acquired.source != "ws" {
+        let reason = acquired.fallback_reason.unwrap_or("ws_unavailable");
+        (
+            maker::MarketDataObservation::RestFallback,
+            format!("websocket snapshot unavailable; REST fallback reason={reason}"),
+        )
+    } else if let Some(maker::CycleSkip::MarkMidDivergence { divergence_bps }) = maker::touch_skip(
+        acquired.mark,
+        acquired.best_bid,
+        acquired.best_ask,
+        acquired.max_divergence_bps,
+    ) {
+        (
+            maker::MarketDataObservation::MarkMidDivergence,
+            format!(
+                "mark/mid divergence {divergence_bps:.2}bps exceeds {:.2}bps",
+                acquired.max_divergence_bps,
+            ),
+        )
+    } else {
+        (
+            maker::MarketDataObservation::Coherent,
+            "coherent websocket snapshot".to_string(),
+        )
+    };
+    degradation_detail(health.observe(acquired.now_ms, observation), &detail)
+}
+
+fn recovery_snapshot_observation(
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    max_divergence_bps: f64,
+) -> maker::MarketDataObservation {
+    let (Some(_), Some(_)) = (best_bid, best_ask) else {
+        return maker::MarketDataObservation::InvalidSnapshot;
+    };
+    match maker::touch_skip(mark, best_bid, best_ask, max_divergence_bps) {
+        Some(maker::CycleSkip::MarkMidDivergence { .. }) => {
+            maker::MarketDataObservation::MarkMidDivergence
+        }
+        Some(_) => maker::MarketDataObservation::InvalidSnapshot,
+        None => maker::MarketDataObservation::Coherent,
+    }
+}
+
+async fn wait_until_recovery_ready(
+    feed: &Arc<RwLock<FeedState>>,
+    updates: &mut watch::Receiver<u64>,
+    health: &mut maker::MarketDataHealth,
+    health_started: Instant,
+    max_divergence_bps: f64,
+) -> Result<()> {
+    let mut previous = {
+        let state = feed.read().await;
+        fresh_ws_sample(&state).map(|(_, _, _, version)| version)
+    };
+    loop {
+        updates
+            .changed()
+            .await
+            .map_err(|_| anyhow::anyhow!("market feed task ended during recovery"))?;
+        let sample = {
+            let state = feed.read().await;
+            fresh_ws_sample(&state)
+        };
+        let Some((mark, best_bid, best_ask, version)) = sample else {
+            let now_ms = duration_ms(health_started.elapsed());
+            let _ = health.observe(now_ms, maker::MarketDataObservation::InvalidSnapshot);
+            continue;
+        };
+        if !version.both_advanced_from(previous) {
+            continue;
+        }
+        previous = Some(version);
+        let observation =
+            recovery_snapshot_observation(mark, best_bid, best_ask, max_divergence_bps);
+        let now_ms = duration_ms(health_started.elapsed());
+        if matches!(
+            health.observe(now_ms, observation),
+            maker::MarketDataTransition::RecoveryReady
+        ) {
+            return Ok(());
+        }
+    }
+}
+
+/// Wait for distinct coherent snapshots, then verify the venue book again.
+/// The pure health state stays degraded until both requirements pass.
+pub(super) struct MarketDataRecovery<'a> {
+    pub(super) client: &'a StandXClient,
+    pub(super) symbol: &'a str,
+    pub(super) output_format: OutputFormat,
+    pub(super) live: bool,
+    pub(super) feed: Option<&'a Arc<RwLock<FeedState>>>,
+    pub(super) updates: Option<&'a mut watch::Receiver<u64>>,
+    pub(super) health: &'a mut maker::MarketDataHealth,
+    pub(super) health_started: Instant,
+    pub(super) max_divergence_bps: f64,
+}
+
+pub(super) async fn recover_market_data(recovery: MarketDataRecovery<'_>) -> Result<()> {
+    let feed = recovery
+        .feed
+        .ok_or_else(|| anyhow::anyhow!("market feed unavailable during recovery"))?;
+    let updates = recovery
+        .updates
+        .ok_or_else(|| anyhow::anyhow!("market feed updates unavailable during recovery"))?;
+    loop {
+        wait_until_recovery_ready(
+            feed,
+            updates,
+            recovery.health,
+            recovery.health_started,
+            recovery.max_divergence_bps,
+        )
+        .await?;
+
+        // Cleanup already ran on entry. Verify again after the snapshot streak
+        // so an aborted late placement cannot survive recovery.
+        if recovery.live {
+            cancel_maker_orders_with_retry(
+                recovery.client,
+                recovery.symbol,
+                3,
+                recovery.output_format,
+            )
+            .await?;
+        }
+
+        let latest_is_safe = {
+            let state = feed.read().await;
+            fresh_ws_sample(&state).is_some_and(|(mark, best_bid, best_ask, _)| {
+                recovery_snapshot_observation(mark, best_bid, best_ask, recovery.max_divergence_bps)
+                    == maker::MarketDataObservation::Coherent
+            })
+        };
+        if latest_is_safe
+            && matches!(
+                recovery.health.confirm_recovered(),
+                maker::MarketDataTransition::Recovered
+            )
+        {
+            return Ok(());
+        }
+        let now_ms = duration_ms(recovery.health_started.elapsed());
+        let _ = recovery
+            .health
+            .observe(now_ms, maker::MarketDataObservation::InvalidSnapshot);
+    }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consecutive_rest_fallback_enters_degraded() {
+        let mut health = maker::MarketDataHealth::default();
+        for now_ms in [0, 1_000] {
+            assert!(observe_acquired_market_health(
+                &mut health,
+                AcquiredMarketHealth {
+                    now_ms,
+                    source: "rest",
+                    fallback_reason: Some("ws_mark_and_book_stale"),
+                    mark: 100.0,
+                    best_bid: Some(99.9),
+                    best_ask: Some(100.1),
+                    max_divergence_bps: 10.0,
+                },
+            )
+            .is_none());
+        }
+        let detail = observe_acquired_market_health(
+            &mut health,
+            AcquiredMarketHealth {
+                now_ms: 2_000,
+                source: "rest",
+                fallback_reason: Some("ws_mark_and_book_stale"),
+                mark: 100.0,
+                best_bid: Some(99.9),
+                best_ask: Some(100.1),
+                max_divergence_bps: 10.0,
+            },
+        )
+        .expect("third consecutive REST fallback must degrade");
+        assert!(detail.contains("issue=rest_fallback"));
+        assert!(detail.contains("consecutive=3"));
+        assert!(health.is_degraded());
+    }
+
+    #[test]
+    fn coherent_ws_snapshot_clears_grace() {
+        let mut health = maker::MarketDataHealth::default();
+        let _ = observe_acquired_market_health(
+            &mut health,
+            AcquiredMarketHealth {
+                now_ms: 0,
+                source: "rest",
+                fallback_reason: Some("ws_book_stale"),
+                mark: 100.0,
+                best_bid: Some(99.9),
+                best_ask: Some(100.1),
+                max_divergence_bps: 10.0,
+            },
+        );
+        assert!(observe_acquired_market_health(
+            &mut health,
+            AcquiredMarketHealth {
+                now_ms: 1_000,
+                source: "ws",
+                fallback_reason: None,
+                mark: 100.0,
+                best_bid: Some(99.9),
+                best_ask: Some(100.1),
+                max_divergence_bps: 10.0,
+            },
+        )
+        .is_none());
+        assert!(!health.is_degraded());
+    }
+
+    #[test]
+    fn recovery_snapshot_requires_full_non_divergent_touch() {
+        assert_eq!(
+            recovery_snapshot_observation(100.0, Some(99.9), Some(100.1), 10.0),
+            maker::MarketDataObservation::Coherent
+        );
+        assert_eq!(
+            recovery_snapshot_observation(100.0, Some(100.2), Some(100.3), 10.0),
+            maker::MarketDataObservation::MarkMidDivergence
+        );
+        assert_eq!(
+            recovery_snapshot_observation(100.0, Some(99.9), None, 10.0),
+            maker::MarketDataObservation::InvalidSnapshot
+        );
+    }
+}

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -22,6 +22,7 @@ mod config;
 mod cycle;
 mod feed;
 mod ledger;
+mod market_data;
 mod model;
 mod notify;
 mod output;
@@ -37,7 +38,11 @@ use startup::new_maker_rest_client;
 use startup::{run_startup, LiveSession, MakerStartup};
 
 use cycle::maker_cycle;
-use feed::{fresh_ws_snapshot, market_snapshot, spawn_market_feed};
+use feed::{fresh_ws_snapshot, market_snapshot, spawn_market_feed, ws_snapshot_issue};
+use market_data::{
+    degradation_detail, observe_acquired_market_health, recover_market_data, AcquiredMarketHealth,
+    MarketDataDegradedError, MarketDataRecovery, MARKET_DATA_RECOVERY_TIMEOUT,
+};
 use model::{is_maker_order, position_for_symbol, MakerExit};
 pub use model::{FailSafeShutdown, FAIL_SAFE_EXIT_CODE};
 #[cfg(test)]

--- a/crates/standx-cli/src/commands/maker/model.rs
+++ b/crates/standx-cli/src/commands/maker/model.rs
@@ -2,10 +2,10 @@ use standx_sdk::account_stream::OrderUpdate;
 use standx_sdk::models::{Order, OrderSide, OrderStatus, Position};
 
 /// Process exit code emitted when the maker performs an *intentional*
-/// fail-safe shutdown: the order-response stream was lost, three maker
-/// cycles failed in a row, position reconciliation or an internal accounting
-/// invariant failed, or residual maker-owned orders could not be cancelled on
-/// the way out.
+/// fail-safe shutdown: order-response or market-data recovery failed, three
+/// maker cycles failed in a row, position reconciliation or an internal
+/// accounting invariant failed, or residual maker-owned orders could not be
+/// cancelled on the way out.
 ///
 /// Supervisors must treat this as "stop, do NOT auto-restart, notify a
 /// human" (systemd `RestartPreventExitStatus=`). It is deliberately
@@ -39,6 +39,7 @@ pub(super) enum MakerExit {
     OrderResponse(String),
     ConsecutiveErrors(String),
     PositionReconciliation(String),
+    MarketData(String),
     AccountingInvariant(String),
     StopLoss(String),
 }
@@ -55,6 +56,9 @@ impl MakerExit {
             }
             Self::PositionReconciliation(error) => {
                 format!("fail-safe: position reconciliation failed: {error}")
+            }
+            Self::MarketData(error) => {
+                format!("fail-safe: market data recovery failed: {error}")
             }
             Self::AccountingInvariant(detail) => {
                 format!("fail-safe: accounting invariant failed: {detail}")
@@ -77,6 +81,9 @@ impl MakerExit {
             Self::PositionReconciliation(error) => Some(format!(
                 "maker stopped immediately (fail-safe): position reconciliation failed: {error}"
             )),
+            Self::MarketData(error) => Some(format!(
+                "maker stopped immediately (fail-safe): market data recovery failed: {error}"
+            )),
             Self::AccountingInvariant(detail) => Some(format!(
                 "maker stopped immediately (fail-safe): accounting invariant failed: {detail}"
             )),
@@ -95,8 +102,10 @@ impl From<standx_maker::RuntimeStopReason> for MakerExit {
             standx_maker::RuntimeStopReason::PositionReconciliation(detail) => {
                 Self::PositionReconciliation(detail)
             }
+            standx_maker::RuntimeStopReason::MarketData(detail) => Self::MarketData(detail),
             standx_maker::RuntimeStopReason::CleanupFailure { target, reason } => match target {
                 standx_maker::RecoveryTarget::OrderResponse => Self::OrderResponse(reason),
+                standx_maker::RecoveryTarget::MarketData => Self::MarketData(reason),
                 standx_maker::RecoveryTarget::AccountStream
                 | standx_maker::RecoveryTarget::PositionReconciliation => {
                     Self::PositionReconciliation(reason)
@@ -265,6 +274,10 @@ mod exit_mapping_tests {
             MakerExit::PositionReconciliation(detail) if detail == "boom"
         ));
         assert!(matches!(
+            MakerExit::from(RuntimeStopReason::MarketData("boom".to_string())),
+            MakerExit::MarketData(detail) if detail == "boom"
+        ));
+        assert!(matches!(
             MakerExit::from(RuntimeStopReason::ConsecutiveCycleErrors("boom".to_string())),
             MakerExit::ConsecutiveErrors(detail) if detail == "boom"
         ));
@@ -291,6 +304,13 @@ mod exit_mapping_tests {
                 MakerExit::PositionReconciliation(detail) if detail == "boom"
             ));
         }
+        assert!(matches!(
+            MakerExit::from(RuntimeStopReason::CleanupFailure {
+                target: RecoveryTarget::MarketData,
+                reason: "boom".to_string(),
+            }),
+            MakerExit::MarketData(detail) if detail == "boom"
+        ));
     }
 
     /// Every fail-safe exit must surface a terminal error (only a clean
@@ -302,6 +322,7 @@ mod exit_mapping_tests {
             MakerExit::OrderResponse("boom".to_string()),
             MakerExit::ConsecutiveErrors("boom".to_string()),
             MakerExit::PositionReconciliation("boom".to_string()),
+            MakerExit::MarketData("boom".to_string()),
             MakerExit::AccountingInvariant("boom".to_string()),
             MakerExit::StopLoss("boom".to_string()),
         ] {

--- a/crates/standx-cli/src/commands/maker/runtime.rs
+++ b/crates/standx-cli/src/commands/maker/runtime.rs
@@ -51,7 +51,7 @@ fn mark_request_timeout_stream_unhealthy(
     match timeout.phase.recovery_target() {
         RecoveryTarget::AccountStream => account_stream_health.mark_unhealthy(detail.to_string()),
         RecoveryTarget::OrderResponse => order_response_health.mark_unhealthy(detail.to_string()),
-        RecoveryTarget::PositionReconciliation => {
+        RecoveryTarget::PositionReconciliation | RecoveryTarget::MarketData => {
             unreachable!("request timeout phases never target position reconciliation")
         }
     }
@@ -139,6 +139,7 @@ enum EffectFailureStop {
     CleanupFailure,
     OrderResponse,
     PositionReconciliation,
+    MarketData,
 }
 
 fn effect_failure_stop(
@@ -152,6 +153,7 @@ fn effect_failure_stop(
         EffectFailureStop::PositionReconciliation => {
             RuntimeStopReason::PositionReconciliation(reason)
         }
+        EffectFailureStop::MarketData => RuntimeStopReason::MarketData(reason),
     }
 }
 
@@ -181,7 +183,7 @@ struct RecoveryIo<'a> {
     output_format: OutputFormat,
 }
 
-/// Everything that differs between the three incident flows' freeze/cleanup
+/// Everything that differs between the incident flows' freeze/cleanup
 /// preambles. The `notice` is built entirely by the caller so the risk
 /// payloads stay reviewable string-for-string at the call sites.
 enum FreezeNotice<'a> {
@@ -207,9 +209,12 @@ struct FreezeSpec<'a> {
     /// and reconciliation) or is being replaced (order-response), deciding
     /// whether pending request acks stay correlated across the cleanup.
     continuity: OrderResponseContinuity,
+    /// Live flows cancel and verify venue orders; paper recovery only clears
+    /// its simulated in-memory maker book.
+    cancel_venue_orders: bool,
 }
 
-/// Freeze/cleanup preamble shared by the three incident-recovery flows:
+/// Freeze/cleanup preamble shared by the incident-recovery flows:
 /// report the fault to the runtime, drain the cleanup effect, notify,
 /// cancel every maker order, reset the local book state, and drain the
 /// recovery effect. `Ok` carries the recovery token for the flow-specific
@@ -244,9 +249,12 @@ async fn freeze_and_cleanup_for_recovery(
         FreezeNotice::Risk(notice) => io.notifier.risk(notice, false).await,
         FreezeNotice::RequestTimeout(notice) => io.notifier.request_timeout(notice, false).await,
     }
-    if let Err(error) =
+    let cleanup = if spec.cancel_venue_orders {
         cancel_maker_orders_with_retry(io.client, io.symbol, 3, io.output_format).await
-    {
+    } else {
+        Ok(())
+    };
+    if let Err(error) = cleanup {
         io.runtime_state.handle(MakerEvent::CleanupFailed {
             token: cleanup_token,
             reason: format!(
@@ -278,7 +286,7 @@ async fn freeze_and_cleanup_for_recovery(
     }
 }
 
-/// Everything that differs between the three incident flows' resume tails.
+/// Everything that differs between the incident flows' resume tails.
 /// As with [`FreezeSpec`], the resolved `notice` is built entirely by the
 /// caller.
 struct ResumeSpec<'a> {
@@ -293,7 +301,7 @@ struct ResumeSpec<'a> {
     notice: RiskNotice<'a>,
 }
 
-/// Resume tail shared by the three incident-recovery flows: reset the
+/// Resume tail shared by the incident-recovery flows: reset the
 /// projection to an empty verified book, seed it with the reconciled venue
 /// position, report RecoverySucceeded, and send the resolved notice. The
 /// caller performs its flow-specific final book verification and session
@@ -1286,6 +1294,9 @@ pub(super) async fn run_maker(
         let (state, rx, handle) = spawn_market_feed(symbol.clone(), args.verbose);
         (Some(state), Some(rx), Some(handle))
     };
+    // A cloned watch cursor lets an in-flight cycle react to the feed's idle
+    // reset without consuming the normal cursor used for post-cycle replans.
+    let mut market_watchdog_updates = updates.as_ref().cloned();
 
     // ---- Loop state ----
     let mut cycle: u64 = 0;
@@ -1318,12 +1329,16 @@ pub(super) async fn run_maker(
             .with_account_floors(args.alert_equity_below, args.alert_margin_below);
     let mut last_mark: Option<f64> = None;
     let mut last_src: Option<&'static str> = None;
+    let market_data_health_started = std::time::Instant::now();
+    let mut market_data_health = maker::MarketDataHealth::default();
+    let mut pending_market_data_degradation: Option<String> = None;
     let recovery_clock_started = std::time::Instant::now();
     // One rolling budget shared across abnormal automatic recoveries —
-    // account-stream reconnect, order-response reconnect, and genuine
-    // position/projection mismatch. A normal account event that invalidates an
-    // in-flight cycle still performs cleanup and reconciliation, but is not an
-    // incident: otherwise ordinary fills eventually exhaust the live budget.
+    // market-data recovery, account-stream reconnect, order-response
+    // reconnect, and genuine position/projection mismatch. A normal account
+    // event that invalidates an in-flight cycle still performs cleanup and
+    // reconciliation, but is not an incident: otherwise ordinary fills
+    // eventually exhaust the live budget.
     let mut recovery_breaker = maker::RecoveryCircuitBreaker::new(
         args.recovery_incidents_per_window,
         args.recovery_window_secs,
@@ -1406,6 +1421,156 @@ pub(super) async fn run_maker(
                 }
             }
         }
+        if let Some(detail) = pending_market_data_degradation.take() {
+            let frozen_message = format!("{detail}; placements frozen and maker cleanup starting");
+            let recovery_token = match freeze_and_cleanup_for_recovery(
+                &mut RecoveryIo {
+                    runtime_state: &mut runtime_state,
+                    notifier: &notifier,
+                    client: &client,
+                    session: live_session.as_mut(),
+                    resting: &mut resting,
+                    inventory_exit_pending: &mut inventory_exit_pending,
+                    consecutive_errors: &mut consecutive_errors,
+                    next_cycle_is_recovery: &mut next_cycle_is_recovery,
+                    symbol: &symbol,
+                    cycle,
+                    output_format,
+                },
+                FreezeSpec {
+                    target: RecoveryTarget::MarketData,
+                    // The event is normally already applied at the detection
+                    // site. Re-applying it is intentionally idempotent while
+                    // frozen and lets this preamble remain self-contained.
+                    trigger: MakerEvent::MarketDataDegraded(detail.clone()),
+                    cleanup_effect_stop: EffectFailureStop::CleanupFailure,
+                    recovery_effect_stop: EffectFailureStop::MarketData,
+                    cleanup_failure_prefix: "market data ".to_string(),
+                    cleanup_failed_exit: MakerExit::MarketData,
+                    notice: FreezeNotice::Risk(RiskNotice {
+                        kind: "market_data",
+                        severity: "warning",
+                        event: "degraded_frozen",
+                        message: &frozen_message,
+                        symbol: &symbol,
+                        cycle,
+                        position_before: None,
+                        position_after: Some(ledger.expected_position),
+                        expected: Some(ledger.expected_position),
+                        observed: None,
+                    }),
+                    frozen_note: None,
+                    abort_account_stream_handle: false,
+                    continuity: OrderResponseContinuity::Preserved,
+                    cancel_venue_orders: args.live,
+                },
+            )
+            .await
+            {
+                Ok(token) => token,
+                Err(exit) => break exit,
+            };
+            if args.live {
+                let admission = recovery_breaker.admit(recovery_clock_started.elapsed().as_secs());
+                if !admission.is_admitted() {
+                    break recovery_failed_exit(
+                        &mut runtime_state,
+                        recovery_token,
+                        format!(
+                            "{detail}; {}; refusing further live orders",
+                            recovery_circuit_detail(admission)
+                        ),
+                    );
+                }
+            }
+
+            eprintln!(
+                "⚠️  market data degraded; waiting for {} distinct coherent WS snapshots before re-quoting",
+                maker::MARKET_DATA_COHERENT_SNAPSHOTS_TO_RECOVER
+            );
+            let recovery_result = tokio::select! {
+                _ = ctrl_c_latched(&mut ctrl_c_rx) => {
+                    break 'main stop_requested_exit(
+                        &mut runtime_state,
+                        RuntimeStopReason::CtrlC,
+                    );
+                }
+                result = tokio::time::timeout(
+                    MARKET_DATA_RECOVERY_TIMEOUT,
+                    recover_market_data(MarketDataRecovery {
+                        client: &client,
+                        symbol: &symbol,
+                        output_format,
+                        live: args.live,
+                        feed: feed.as_ref(),
+                        updates: updates.as_mut(),
+                        health: &mut market_data_health,
+                        health_started: market_data_health_started,
+                        max_divergence_bps: args.max_divergence_bps,
+                    }),
+                ) => result,
+            };
+            match recovery_result {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    break recovery_failed_exit(
+                        &mut runtime_state,
+                        recovery_token,
+                        format!("market data recovery failed: {error}"),
+                    );
+                }
+                Err(_) => {
+                    break recovery_failed_exit(
+                        &mut runtime_state,
+                        recovery_token,
+                        format!(
+                            "market data did not produce {} coherent snapshots and a verified empty maker book within {}s",
+                            maker::MARKET_DATA_COHERENT_SNAPSHOTS_TO_RECOVER,
+                            MARKET_DATA_RECOVERY_TIMEOUT.as_secs(),
+                        ),
+                    );
+                }
+            }
+
+            let observed = ledger.expected_position;
+            resume_quoting_after_recovery(
+                &mut RecoveryIo {
+                    runtime_state: &mut runtime_state,
+                    notifier: &notifier,
+                    client: &client,
+                    session: live_session.as_mut(),
+                    resting: &mut resting,
+                    inventory_exit_pending: &mut inventory_exit_pending,
+                    consecutive_errors: &mut consecutive_errors,
+                    next_cycle_is_recovery: &mut next_cycle_is_recovery,
+                    symbol: &symbol,
+                    cycle,
+                    output_format,
+                },
+                ResumeSpec {
+                    recovery_token,
+                    observed,
+                    continuity: OrderResponseContinuity::Preserved,
+                    clear_resting: true,
+                    recovered_note: None,
+                    notice: RiskNotice {
+                        kind: "market_data",
+                        severity: "resolved",
+                        event: "recovered",
+                        message: "market data recovered with consecutive coherent snapshots and a verified empty maker book; quoting may resume",
+                        symbol: &symbol,
+                        cycle,
+                        position_before: None,
+                        position_after: Some(observed),
+                        expected: Some(observed),
+                        observed: Some(observed),
+                    },
+                },
+            )
+            .await;
+            last_src = None;
+            continue 'main;
+        }
         if let Some(session) = live_session.as_mut() {
             if !session.account_stream_health.is_healthy() {
                 let detail = session
@@ -1478,6 +1643,7 @@ pub(super) async fn run_maker(
                         frozen_note: None,
                         abort_account_stream_handle: true,
                         continuity: OrderResponseContinuity::Preserved,
+                        cancel_venue_orders: true,
                     },
                 )
                 .await
@@ -1808,6 +1974,7 @@ pub(super) async fn run_maker(
                         frozen_note: None,
                         abort_account_stream_handle: false,
                         continuity: OrderResponseContinuity::Replaced,
+                        cancel_venue_orders: true,
                     },
                 )
                 .await
@@ -2243,6 +2410,23 @@ pub(super) async fn run_maker(
             let best_ask = market.best_ask;
             let src = market.source;
             let market_fallback_reason = market.fallback_reason;
+            if feed.is_some() {
+                let health_now_ms = duration_ms(market_data_health_started.elapsed());
+                if let Some(detail) = observe_acquired_market_health(
+                    &mut market_data_health,
+                    AcquiredMarketHealth {
+                        now_ms: health_now_ms,
+                        source: src,
+                        fallback_reason: market_fallback_reason,
+                        mark,
+                        best_bid,
+                        best_ask,
+                        max_divergence_bps: args.max_divergence_bps,
+                    },
+                ) {
+                    return Err(anyhow::Error::new(MarketDataDegradedError { detail }));
+                }
+            }
             let result = maker_cycle(
                 CycleRequest {
                     client: &client,
@@ -2309,6 +2493,7 @@ pub(super) async fn run_maker(
         let mut buffered_account: Vec<AccountEvent> = Vec::new();
         let mut buffered_orders: Vec<OrderResponse> = Vec::new();
         let mut cycle_invalidated_by_account = false;
+        let mut cycle_invalidated_by_market: Option<String> = None;
         // Scope the pinned work future so it (and its ledger/pending borrows)
         // is dropped once it resolves, before the buffered events are applied.
         let cycle_result = {
@@ -2323,6 +2508,12 @@ pub(super) async fn run_maker(
                 let order_during_work = async {
                     match cycle_order_responses.as_deref_mut() {
                         Some(receiver) => receiver.recv().await,
+                        None => std::future::pending().await,
+                    }
+                };
+                let market_during_work = async {
+                    match market_watchdog_updates.as_mut() {
+                        Some(receiver) => receiver.changed().await.is_ok(),
                         None => std::future::pending().await,
                     }
                 };
@@ -2363,9 +2554,38 @@ pub(super) async fn run_maker(
                         buffered_orders.push(response);
                     },
                     result = &mut work => break Some(result),
+                    changed = market_during_work => {
+                        if !changed {
+                            market_watchdog_updates = None;
+                            continue;
+                        }
+                        let idle_issue = match feed.as_ref() {
+                            Some(feed) => {
+                                let state = feed.read().await;
+                                ws_snapshot_issue(&state, std::time::Instant::now())
+                                    .filter(|issue| issue.is_idle())
+                            }
+                            None => None,
+                        };
+                        if let Some(issue) = idle_issue {
+                            cycle_invalidated_by_market = Some(format!(
+                                "market feed effective-update watchdog fired during maker cycle: {}",
+                                issue.as_str(),
+                            ));
+                            break None;
+                        }
+                    },
                 }
             }
         };
+        if let Some(detail) = cycle_invalidated_by_market {
+            let now_ms = duration_ms(market_data_health_started.elapsed());
+            let transition =
+                market_data_health.observe(now_ms, maker::MarketDataObservation::FeedIdle);
+            let detail = degradation_detail(transition, &detail).unwrap_or(detail);
+            runtime_state.handle(MakerEvent::MarketDataDegraded(detail.clone()));
+            pending_market_data_degradation = Some(detail);
+        }
         // The buffers are only fed from live-session receivers, so both are
         // empty in paper mode.
         if let Some(session) = live_session.as_mut() {
@@ -2690,6 +2910,12 @@ pub(super) async fn run_maker(
                 }
             }
             Err(e) => {
+                if let Some(degraded) = e.downcast_ref::<MarketDataDegradedError>() {
+                    let detail = degraded.detail.clone();
+                    runtime_state.handle(MakerEvent::MarketDataDegraded(detail.clone()));
+                    pending_market_data_degradation = Some(detail);
+                    continue 'main;
+                }
                 if e.downcast_ref::<ProjectionRegistryError>().is_some() {
                     let detail = format!("order-response correlation failed closed: {e}");
                     if let Some(session) = live_session.as_ref() {
@@ -2748,6 +2974,7 @@ pub(super) async fn run_maker(
                             }),
                             abort_account_stream_handle: false,
                             continuity: OrderResponseContinuity::Preserved,
+                            cancel_venue_orders: true,
                         },
                     )
                     .await
@@ -3126,34 +3353,94 @@ pub(super) async fn run_maker(
                 }
                 ok = update => {
                     if !ok {
-                        // Feed task gone: fall back to plain interval waits.
+                        let now_ms = duration_ms(market_data_health_started.elapsed());
+                        if let Some(detail) = degradation_detail(
+                            market_data_health.observe(
+                                now_ms,
+                                maker::MarketDataObservation::RestFallback,
+                            ),
+                            "market feed task ended",
+                        ) {
+                            runtime_state.handle(MakerEvent::MarketDataDegraded(detail.clone()));
+                            pending_market_data_degradation = Some(detail);
+                            break;
+                        }
+                        // The next interval cycle records another REST
+                        // fallback observation and may cross the bounded grace.
                         updates = None;
                         continue;
                     }
-                    if tokio::time::Instant::now() < min_gap {
-                        continue;
-                    }
-                    let (Some(feed), Some(prev)) = (feed.as_ref(), last_mark) else {
+                    let Some(feed) = feed.as_ref() else {
                         continue;
                     };
                     let resting_for_replan = match live_session.as_ref() {
                         Some(session) => session.projection.resting_quotes(),
                         None => resting.clone(),
                     };
-                    let requires_replan = {
+                    let (observation, observation_detail, requires_replan) = {
                         let s = feed.read().await;
-                        fresh_ws_snapshot(&s).is_some_and(|(mark, best_bid, best_ask)| {
-                            market_update_requires_replan(
-                                prev,
-                                mark,
-                                best_bid,
-                                best_ask,
-                                &resting_for_replan,
-                                cfg.refresh_bps,
-                                args.max_divergence_bps,
-                            )
-                        })
+                        match fresh_ws_snapshot(&s) {
+                            Some((mark, best_bid, best_ask)) => {
+                                let observation = if matches!(
+                                    maker::touch_skip(
+                                        mark,
+                                        best_bid,
+                                        best_ask,
+                                        args.max_divergence_bps,
+                                    ),
+                                    Some(maker::CycleSkip::MarkMidDivergence { .. })
+                                ) {
+                                    maker::MarketDataObservation::MarkMidDivergence
+                                } else {
+                                    maker::MarketDataObservation::Coherent
+                                };
+                                let requires_replan = last_mark.is_some_and(|prev| {
+                                    market_update_requires_replan(
+                                        prev,
+                                        mark,
+                                        best_bid,
+                                        best_ask,
+                                        &resting_for_replan,
+                                        cfg.refresh_bps,
+                                        args.max_divergence_bps,
+                                    )
+                                });
+                                (
+                                    observation,
+                                    "websocket cache update".to_string(),
+                                    requires_replan,
+                                )
+                            }
+                            None => {
+                                let issue = ws_snapshot_issue(&s, std::time::Instant::now());
+                                let observation = if issue.is_some_and(|issue| issue.is_idle()) {
+                                    maker::MarketDataObservation::FeedIdle
+                                } else {
+                                    maker::MarketDataObservation::RestFallback
+                                };
+                                (
+                                    observation,
+                                    format!(
+                                        "websocket cache unavailable: {}",
+                                        issue.map_or("unknown", |issue| issue.as_str())
+                                    ),
+                                    false,
+                                )
+                            }
+                        }
                     };
+                    let now_ms = duration_ms(market_data_health_started.elapsed());
+                    if let Some(detail) = degradation_detail(
+                        market_data_health.observe(now_ms, observation),
+                        &observation_detail,
+                    ) {
+                        runtime_state.handle(MakerEvent::MarketDataDegraded(detail.clone()));
+                        pending_market_data_degradation = Some(detail);
+                        break;
+                    }
+                    if tokio::time::Instant::now() < min_gap {
+                        continue;
+                    }
                     if requires_replan {
                         runtime_state.handle(MakerEvent::MarketChanged);
                         break; // early re-quote cycle
@@ -3312,6 +3599,14 @@ mod tests {
                 "boom".to_string(),
             ),
             RuntimeStopReason::PositionReconciliation("boom".to_string())
+        );
+        assert_eq!(
+            effect_failure_stop(
+                EffectFailureStop::MarketData,
+                RecoveryTarget::MarketData,
+                "boom".to_string(),
+            ),
+            RuntimeStopReason::MarketData("boom".to_string())
         );
     }
 
@@ -4488,6 +4783,7 @@ mod tests {
             frozen_note: None,
             abort_account_stream_handle: false,
             continuity: OrderResponseContinuity::Replaced,
+            cancel_venue_orders: true,
         }
     }
 

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -20,6 +20,7 @@ use standx_sdk::models::OrderSide;
 pub mod account_projection;
 pub mod latency;
 pub mod ledger;
+pub mod market_data;
 pub mod ownership;
 pub mod performance;
 pub mod recovery;
@@ -38,6 +39,10 @@ pub use latency::{
     LatencyRequestOutcome, LatencySummary, OrderLatencyTracker,
 };
 pub use ledger::{LedgerError, LedgerTrade, MakerFill, MakerLedger, TradeSource};
+pub use market_data::{
+    MarketDataHealth, MarketDataObservation, MarketDataTransition, MARKET_DATA_BAD_GRACE_MS,
+    MARKET_DATA_BAD_OBSERVATIONS_TO_DEGRADE, MARKET_DATA_COHERENT_SNAPSHOTS_TO_RECOVER,
+};
 pub use ownership::{
     exit_client_order_id, is_current_run_client_order_id, is_maker_client_order_id,
     open_qty_adopts, pending_covers_slot, position_within_limit, quote_client_order_id, QuoteSlot,

--- a/crates/standx-maker/src/market_data.rs
+++ b/crates/standx-maker/src/market_data.rs
@@ -1,0 +1,303 @@
+//! Pure market-data degradation and recovery policy.
+
+/// Consecutive unhealthy observations tolerated before quoting is frozen.
+pub const MARKET_DATA_BAD_OBSERVATIONS_TO_DEGRADE: u32 = 3;
+/// A sparse sequence of unhealthy observations may not retain quotes beyond
+/// this wall-clock grace period.
+pub const MARKET_DATA_BAD_GRACE_MS: u64 = 15_000;
+/// Distinct coherent snapshots required before recovery may be confirmed.
+pub const MARKET_DATA_COHERENT_SNAPSHOTS_TO_RECOVER: u32 = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MarketDataObservation {
+    Coherent,
+    RestFallback,
+    MarkMidDivergence,
+    InvalidSnapshot,
+    FeedIdle,
+}
+
+impl MarketDataObservation {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Coherent => "coherent",
+            Self::RestFallback => "rest_fallback",
+            Self::MarkMidDivergence => "mark_mid_divergence",
+            Self::InvalidSnapshot => "invalid_snapshot",
+            Self::FeedIdle => "feed_idle",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MarketDataTransition {
+    Healthy,
+    Grace {
+        issue: MarketDataObservation,
+        consecutive: u32,
+        bad_for_ms: u64,
+    },
+    EnteredDegraded {
+        issue: MarketDataObservation,
+        consecutive: u32,
+        bad_for_ms: u64,
+    },
+    Degraded {
+        issue: MarketDataObservation,
+    },
+    Recovering {
+        coherent: u32,
+        required: u32,
+    },
+    RecoveryReady,
+    Recovered,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MarketDataPhase {
+    Healthy,
+    Grace {
+        first_bad_ms: u64,
+        consecutive: u32,
+        issue: MarketDataObservation,
+    },
+    Degraded {
+        issue: MarketDataObservation,
+        coherent: u32,
+    },
+}
+
+/// Stateful policy driven only by normalized observations and a monotonic
+/// elapsed-millisecond clock supplied by the caller.
+#[derive(Debug)]
+pub struct MarketDataHealth {
+    phase: MarketDataPhase,
+    bad_observations_to_degrade: u32,
+    bad_grace_ms: u64,
+    coherent_snapshots_to_recover: u32,
+}
+
+impl Default for MarketDataHealth {
+    fn default() -> Self {
+        Self::new(
+            MARKET_DATA_BAD_OBSERVATIONS_TO_DEGRADE,
+            MARKET_DATA_BAD_GRACE_MS,
+            MARKET_DATA_COHERENT_SNAPSHOTS_TO_RECOVER,
+        )
+    }
+}
+
+impl MarketDataHealth {
+    pub fn new(
+        bad_observations_to_degrade: u32,
+        bad_grace_ms: u64,
+        coherent_snapshots_to_recover: u32,
+    ) -> Self {
+        Self {
+            phase: MarketDataPhase::Healthy,
+            bad_observations_to_degrade: bad_observations_to_degrade.max(1),
+            bad_grace_ms,
+            coherent_snapshots_to_recover: coherent_snapshots_to_recover.max(1),
+        }
+    }
+
+    pub fn is_degraded(&self) -> bool {
+        matches!(self.phase, MarketDataPhase::Degraded { .. })
+    }
+
+    pub fn observe(
+        &mut self,
+        now_ms: u64,
+        observation: MarketDataObservation,
+    ) -> MarketDataTransition {
+        match (self.phase, observation) {
+            (MarketDataPhase::Healthy, MarketDataObservation::Coherent) => {
+                MarketDataTransition::Healthy
+            }
+            (MarketDataPhase::Healthy, issue) => self.begin_bad(now_ms, issue),
+            (MarketDataPhase::Grace { .. }, MarketDataObservation::Coherent) => {
+                self.phase = MarketDataPhase::Healthy;
+                MarketDataTransition::Healthy
+            }
+            (
+                MarketDataPhase::Grace {
+                    first_bad_ms,
+                    consecutive,
+                    ..
+                },
+                issue,
+            ) => {
+                let consecutive = consecutive.saturating_add(1);
+                let bad_for_ms = now_ms.saturating_sub(first_bad_ms);
+                if issue == MarketDataObservation::FeedIdle
+                    || consecutive >= self.bad_observations_to_degrade
+                    || bad_for_ms >= self.bad_grace_ms
+                {
+                    self.phase = MarketDataPhase::Degraded { issue, coherent: 0 };
+                    MarketDataTransition::EnteredDegraded {
+                        issue,
+                        consecutive,
+                        bad_for_ms,
+                    }
+                } else {
+                    self.phase = MarketDataPhase::Grace {
+                        first_bad_ms,
+                        consecutive,
+                        issue,
+                    };
+                    MarketDataTransition::Grace {
+                        issue,
+                        consecutive,
+                        bad_for_ms,
+                    }
+                }
+            }
+            (MarketDataPhase::Degraded { issue, coherent }, MarketDataObservation::Coherent) => {
+                let coherent = coherent.saturating_add(1);
+                self.phase = MarketDataPhase::Degraded { issue, coherent };
+                if coherent >= self.coherent_snapshots_to_recover {
+                    MarketDataTransition::RecoveryReady
+                } else {
+                    MarketDataTransition::Recovering {
+                        coherent,
+                        required: self.coherent_snapshots_to_recover,
+                    }
+                }
+            }
+            (MarketDataPhase::Degraded { .. }, issue) => {
+                self.phase = MarketDataPhase::Degraded { issue, coherent: 0 };
+                MarketDataTransition::Degraded { issue }
+            }
+        }
+    }
+
+    /// Confirms recovery only after the effect executor has independently
+    /// verified the venue maker book is empty and the latest snapshot remains
+    /// safe. Until then the phase stays degraded and placements remain frozen.
+    pub fn confirm_recovered(&mut self) -> MarketDataTransition {
+        match self.phase {
+            MarketDataPhase::Degraded { coherent, .. }
+                if coherent >= self.coherent_snapshots_to_recover =>
+            {
+                self.phase = MarketDataPhase::Healthy;
+                MarketDataTransition::Recovered
+            }
+            MarketDataPhase::Degraded { issue, .. } => MarketDataTransition::Degraded { issue },
+            MarketDataPhase::Healthy | MarketDataPhase::Grace { .. } => {
+                MarketDataTransition::Healthy
+            }
+        }
+    }
+
+    fn begin_bad(&mut self, now_ms: u64, issue: MarketDataObservation) -> MarketDataTransition {
+        if issue == MarketDataObservation::FeedIdle
+            || self.bad_observations_to_degrade == 1
+            || self.bad_grace_ms == 0
+        {
+            self.phase = MarketDataPhase::Degraded { issue, coherent: 0 };
+            return MarketDataTransition::EnteredDegraded {
+                issue,
+                consecutive: 1,
+                bad_for_ms: 0,
+            };
+        }
+        self.phase = MarketDataPhase::Grace {
+            first_bad_ms: now_ms,
+            consecutive: 1,
+            issue,
+        };
+        MarketDataTransition::Grace {
+            issue,
+            consecutive: 1,
+            bad_for_ms: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_bad_snapshot_clears_without_degrading() {
+        let mut health = MarketDataHealth::default();
+        assert!(matches!(
+            health.observe(100, MarketDataObservation::RestFallback),
+            MarketDataTransition::Grace { consecutive: 1, .. }
+        ));
+        assert_eq!(
+            health.observe(200, MarketDataObservation::Coherent),
+            MarketDataTransition::Healthy
+        );
+        assert!(!health.is_degraded());
+    }
+
+    #[test]
+    fn third_bad_observation_or_elapsed_grace_degrades() {
+        let mut health = MarketDataHealth::default();
+        let _ = health.observe(0, MarketDataObservation::RestFallback);
+        let _ = health.observe(1_000, MarketDataObservation::MarkMidDivergence);
+        assert!(matches!(
+            health.observe(2_000, MarketDataObservation::RestFallback),
+            MarketDataTransition::EnteredDegraded { consecutive: 3, .. }
+        ));
+
+        let mut sparse = MarketDataHealth::default();
+        let _ = sparse.observe(0, MarketDataObservation::RestFallback);
+        assert!(matches!(
+            sparse.observe(15_000, MarketDataObservation::RestFallback),
+            MarketDataTransition::EnteredDegraded {
+                consecutive: 2,
+                bad_for_ms: 15_000,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn feed_idle_degrades_immediately() {
+        let mut health = MarketDataHealth::default();
+        assert!(matches!(
+            health.observe(1, MarketDataObservation::FeedIdle),
+            MarketDataTransition::EnteredDegraded {
+                issue: MarketDataObservation::FeedIdle,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn recovery_requires_three_coherent_observations_and_explicit_confirmation() {
+        let mut health = MarketDataHealth::new(1, 15_000, 3);
+        let _ = health.observe(0, MarketDataObservation::RestFallback);
+        assert!(health.is_degraded());
+        assert!(matches!(
+            health.observe(1, MarketDataObservation::Coherent),
+            MarketDataTransition::Recovering { coherent: 1, .. }
+        ));
+        let _ = health.observe(2, MarketDataObservation::Coherent);
+        assert_eq!(
+            health.observe(3, MarketDataObservation::Coherent),
+            MarketDataTransition::RecoveryReady
+        );
+        assert!(health.is_degraded());
+        assert_eq!(health.confirm_recovered(), MarketDataTransition::Recovered);
+        assert!(!health.is_degraded());
+    }
+
+    #[test]
+    fn bad_observation_resets_recovery_streak() {
+        let mut health = MarketDataHealth::new(1, 15_000, 3);
+        let _ = health.observe(0, MarketDataObservation::RestFallback);
+        let _ = health.observe(1, MarketDataObservation::Coherent);
+        let _ = health.observe(2, MarketDataObservation::Coherent);
+        assert!(matches!(
+            health.observe(3, MarketDataObservation::InvalidSnapshot),
+            MarketDataTransition::Degraded { .. }
+        ));
+        assert!(matches!(
+            health.observe(4, MarketDataObservation::Coherent),
+            MarketDataTransition::Recovering { coherent: 1, .. }
+        ));
+    }
+}

--- a/crates/standx-maker/src/runtime.rs
+++ b/crates/standx-maker/src/runtime.rs
@@ -30,6 +30,7 @@ pub enum RecoveryTarget {
     AccountStream,
     OrderResponse,
     PositionReconciliation,
+    MarketData,
 }
 
 impl RecoveryTarget {
@@ -38,6 +39,7 @@ impl RecoveryTarget {
             Self::AccountStream => "account_stream",
             Self::OrderResponse => "order_response",
             Self::PositionReconciliation => "position_reconciliation",
+            Self::MarketData => "market_data",
         }
     }
 }
@@ -71,6 +73,7 @@ pub enum RuntimeStopReason {
     CtrlC,
     OrderResponse(String),
     PositionReconciliation(String),
+    MarketData(String),
     ConsecutiveCycleErrors(String),
     StopLoss(String),
     CleanupFailure {
@@ -85,6 +88,7 @@ impl RuntimeStopReason {
             Self::CtrlC => "Ctrl+C".to_string(),
             Self::OrderResponse(reason)
             | Self::PositionReconciliation(reason)
+            | Self::MarketData(reason)
             | Self::ConsecutiveCycleErrors(reason)
             | Self::StopLoss(reason) => reason.clone(),
             Self::CleanupFailure { reason, .. } => reason.clone(),
@@ -108,6 +112,7 @@ pub enum MakerEvent {
     AccountStreamDisconnected(String),
     OrderResponseDisconnected(String),
     PositionMismatch,
+    MarketDataDegraded(String),
     CleanupCompleted(WorkToken),
     CleanupFailed {
         token: WorkToken,
@@ -257,6 +262,9 @@ impl MakerState {
                 "position mismatch".to_string(),
                 RecoveryTarget::PositionReconciliation,
             ),
+            MakerEvent::MarketDataDegraded(reason) => {
+                self.freeze(reason, RecoveryTarget::MarketData)
+            }
             MakerEvent::CleanupCompleted(token) => {
                 if !self.matches_in_flight(token, WorkKind::Cleanup) {
                     return Vec::new();
@@ -303,6 +311,7 @@ impl MakerState {
                 self.in_flight = None;
                 let stop = match self.recovery_target {
                     Some(RecoveryTarget::OrderResponse) => RuntimeStopReason::OrderResponse(reason),
+                    Some(RecoveryTarget::MarketData) => RuntimeStopReason::MarketData(reason),
                     _ => RuntimeStopReason::PositionReconciliation(reason),
                 };
                 self.stop(stop)
@@ -489,6 +498,10 @@ mod tests {
             (
                 MakerEvent::PositionMismatch,
                 RecoveryTarget::PositionReconciliation,
+            ),
+            (
+                MakerEvent::MarketDataDegraded("feed idle".to_string()),
+                RecoveryTarget::MarketData,
             ),
         ] {
             let mut state = MakerState::starting();
@@ -700,6 +713,7 @@ mod tests {
             RuntimeStopReason::CtrlC,
             RuntimeStopReason::OrderResponse("boom".to_string()),
             RuntimeStopReason::PositionReconciliation("boom".to_string()),
+            RuntimeStopReason::MarketData("boom".to_string()),
             RuntimeStopReason::ConsecutiveCycleErrors("boom".to_string()),
             RuntimeStopReason::StopLoss("boom".to_string()),
             RuntimeStopReason::CleanupFailure {
@@ -861,6 +875,11 @@ mod tests {
                         "recovery failure must stop as PositionReconciliation for {event:?}"
                     )
                 }
+                RecoveryTarget::MarketData => assert_eq!(
+                    stop,
+                    RuntimeStopReason::MarketData("reconnect exhausted".to_string()),
+                    "market-data recovery failure must stop as MarketData for {event:?}"
+                ),
             }
         }
     }

--- a/crates/standx-sdk/src/websocket.rs
+++ b/crates/standx-sdk/src/websocket.rs
@@ -8,11 +8,20 @@ use serde::de::DeserializeOwned;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{mpsc, RwLock};
+use tokio::task::JoinHandle;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 const DEFAULT_WS_URL: &str = "wss://perps.standx.com/ws-stream/v1";
 const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 const RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+
+struct AbortTaskOnDrop(JoinHandle<()>);
+
+impl Drop for AbortTaskOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
 
 /// WebSocket client state
 #[derive(Debug, Clone, PartialEq)]
@@ -198,6 +207,13 @@ impl StandXWebSocket {
 
     /// Connect and start the WebSocket client
     pub async fn connect(&self) -> Result<mpsc::Receiver<WsMessage>> {
+        let (rx, _handle) = self.connect_managed().await?;
+        Ok(rx)
+    }
+
+    /// Connect and return ownership of the background task so a caller with
+    /// its own liveness policy can actively tear down a silent connection.
+    pub async fn connect_managed(&self) -> Result<(mpsc::Receiver<WsMessage>, JoinHandle<()>)> {
         let (tx, rx) = mpsc::channel(100);
 
         let url = self.url.clone();
@@ -207,7 +223,7 @@ impl StandXWebSocket {
         let reconnect_attempts = self.reconnect_attempts.clone();
         let verbose = self.verbose;
 
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             loop {
                 *state.write().await = WsState::Connecting;
 
@@ -236,7 +252,7 @@ impl StandXWebSocket {
             }
         });
 
-        Ok(rx)
+        Ok((rx, handle))
     }
 
     /// Subscribe to a channel
@@ -397,7 +413,7 @@ async fn connect_and_run(
     let heartbeat_write = Arc::new(RwLock::new(write));
     let heartbeat_write_clone = heartbeat_write.clone();
 
-    tokio::spawn(async move {
+    let heartbeat_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
         loop {
             interval.tick().await;
@@ -410,6 +426,10 @@ async fn connect_and_run(
             }
         }
     });
+    // Cancelling the owning connection task (for example, from a market-feed
+    // idle watchdog) must also stop the heartbeat writer that owns the other
+    // half of the socket.
+    let _heartbeat_guard = AbortTaskOnDrop(heartbeat_handle);
 
     // Main message loop
     while let Some(msg) = read.next().await {


### PR DESCRIPTION
## Summary
- Add idle watchdogs and reconnect reasons to the public market feed so stale price/book channels trigger a rebuild instead of waiting for TCP disconnects.
- Introduce market-data recovery in the maker runtime, including a fail-safe stop path, freeze/cleanup flow, and recovery gating before quoting resumes.
- Extend maker exit mapping and tests to cover idle feed detection, recovery versioning, and market-data stop reasons.

## Testing
- Added unit coverage for idle watchdog behavior, snapshot version advancement, reconnect reason propagation, and new exit mappings.
- Not run (not requested).