### PR TITLE
Require both stale channels and grace before degrading market data

### DIFF
--- a/crates/standx-cli/src/commands/maker/feed.rs
+++ b/crates/standx-cli/src/commands/maker/feed.rs
@@ -326,10 +326,6 @@ pub(super) fn fresh_ws_sample(
     Some((mark, best_bid, best_ask, version))
 }
 
-pub(super) fn fresh_ws_snapshot(state: &FeedState) -> Option<(f64, Option<f64>, Option<f64>)> {
-    fresh_ws_sample(state).map(|(mark, best_bid, best_ask, _)| (mark, best_bid, best_ask))
-}
-
 async fn reset_feed_state(state: &RwLock<FeedState>, issue: WsSnapshotIssue) {
     *state.write().await = FeedState {
         reconnect_issue: Some(issue),
@@ -828,17 +824,19 @@ mod tests {
     }
 
     #[test]
-    fn recovery_version_requires_both_channels_to_advance() {
+    fn snapshot_version_requires_both_channels_to_advance() {
         let now = Instant::now();
         let previous = FeedSnapshotVersion {
             mark_received_at: now,
             book_received_at: now,
         };
-        assert!(!FeedSnapshotVersion {
-            mark_received_at: now + Duration::from_secs(1),
-            book_received_at: now,
+        for offset in 1..=3 {
+            assert!(!FeedSnapshotVersion {
+                mark_received_at: now,
+                book_received_at: now + Duration::from_millis(offset * 100),
+            }
+            .both_advanced_from(Some(previous)));
         }
-        .both_advanced_from(Some(previous)));
         assert!(FeedSnapshotVersion {
             mark_received_at: now + Duration::from_secs(1),
             book_received_at: now + Duration::from_secs(1),

--- a/crates/standx-cli/src/commands/maker/market_data.rs
+++ b/crates/standx-cli/src/commands/maker/market_data.rs
@@ -216,7 +216,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn consecutive_rest_fallback_enters_degraded() {
+    fn sustained_rest_fallback_enters_degraded_after_grace() {
         let mut health = maker::MarketDataHealth::default();
         for now_ms in [0, 1_000] {
             assert!(observe_acquired_market_health(
@@ -236,7 +236,7 @@ mod tests {
         let detail = observe_acquired_market_health(
             &mut health,
             AcquiredMarketHealth {
-                now_ms: 2_000,
+                now_ms: maker::MARKET_DATA_BAD_GRACE_MS,
                 source: "rest",
                 fallback_reason: Some("ws_mark_and_book_stale"),
                 mark: 100.0,
@@ -245,7 +245,7 @@ mod tests {
                 max_divergence_bps: 10.0,
             },
         )
-        .expect("third consecutive REST fallback must degrade");
+        .expect("third sustained REST fallback after the grace must degrade");
         assert!(detail.contains("issue=rest_fallback"));
         assert!(detail.contains("consecutive=3"));
         assert!(health.is_degraded());

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -37,7 +37,7 @@ use startup::new_maker_rest_client;
 use startup::{run_startup, LiveSession, MakerStartup};
 
 use cycle::maker_cycle;
-use feed::{fresh_ws_snapshot, market_snapshot, spawn_market_feed, ws_snapshot_issue};
+use feed::{fresh_ws_sample, market_snapshot, spawn_market_feed, ws_snapshot_issue};
 use market_data::{
     degradation_detail, observe_acquired_market_health, recover_market_data, AcquiredMarketHealth,
     MarketDataDegradedError, MarketDataRecovery, MARKET_DATA_RECOVERY_TIMEOUT,

--- a/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
@@ -1107,6 +1107,16 @@ impl MakerRuntime {
             // this a bounded safety replan rather than a per-tick cancel loop.
             let deadline = tokio::time::Instant::now() + Duration::from_secs(args.interval);
             let min_gap = tokio::time::Instant::now() + Duration::from_secs(1);
+            // Price and book are published independently. Start from the
+            // current pair so repeated updates from only one channel cannot
+            // be miscounted as multiple distinct health observations.
+            let mut health_version = match feed.as_ref() {
+                Some(feed) => {
+                    let state = feed.read().await;
+                    fresh_ws_sample(&state).map(|(_, _, _, version)| version)
+                }
+                None => None,
+            };
             loop {
                 let request_deadline = self.live_session.as_ref().and_then(|session| {
                     session
@@ -1231,8 +1241,8 @@ impl MakerRuntime {
                         };
                         let (observation, observation_detail, requires_replan) = {
                             let s = feed.read().await;
-                            match fresh_ws_snapshot(&s) {
-                                Some((mark, best_bid, best_ask)) => {
+                            match fresh_ws_sample(&s) {
+                                Some((mark, best_bid, best_ask, version)) => {
                                     let observation = if matches!(
                                         maker::touch_skip(
                                             mark,
@@ -1257,6 +1267,12 @@ impl MakerRuntime {
                                             args.max_divergence_bps,
                                         )
                                     });
+                                    let observation = if version.both_advanced_from(health_version) {
+                                        health_version = Some(version);
+                                        Some(observation)
+                                    } else {
+                                        None
+                                    };
                                     (
                                         observation,
                                         "websocket cache update".to_string(),
@@ -1271,7 +1287,7 @@ impl MakerRuntime {
                                         maker::MarketDataObservation::RestFallback
                                     };
                                     (
-                                        observation,
+                                        Some(observation),
                                         format!(
                                             "websocket cache unavailable: {}",
                                             issue.map_or("unknown", |issue| issue.as_str())
@@ -1281,14 +1297,16 @@ impl MakerRuntime {
                                 }
                             }
                         };
-                        let now_ms = duration_ms(market_data_health_started.elapsed());
-                        if let Some(detail) = degradation_detail(
-                            self.market.health.observe(now_ms, observation),
-                            &observation_detail,
-                        ) {
-                            self.recovery.runtime_state.handle(MakerEvent::MarketDataDegraded(detail.clone()));
-                            self.market.pending_degradation = Some(detail);
-                            break;
+                        if let Some(observation) = observation {
+                            let now_ms = duration_ms(market_data_health_started.elapsed());
+                            if let Some(detail) = degradation_detail(
+                                self.market.health.observe(now_ms, observation),
+                                &observation_detail,
+                            ) {
+                                self.recovery.runtime_state.handle(MakerEvent::MarketDataDegraded(detail.clone()));
+                                self.market.pending_degradation = Some(detail);
+                                break;
+                            }
                         }
                         if tokio::time::Instant::now() < min_gap {
                             continue;

--- a/crates/standx-maker/src/market_data.rs
+++ b/crates/standx-maker/src/market_data.rs
@@ -1,9 +1,8 @@
 //! Pure market-data degradation and recovery policy.
 
-/// Consecutive unhealthy observations tolerated before quoting is frozen.
+/// Consecutive unhealthy observations required before quoting may be frozen.
 pub const MARKET_DATA_BAD_OBSERVATIONS_TO_DEGRADE: u32 = 3;
-/// A sparse sequence of unhealthy observations may not retain quotes beyond
-/// this wall-clock grace period.
+/// Unhealthy observations must also persist for this wall-clock grace period.
 pub const MARKET_DATA_BAD_GRACE_MS: u64 = 15_000;
 /// Distinct coherent snapshots required before recovery may be confirmed.
 pub const MARKET_DATA_COHERENT_SNAPSHOTS_TO_RECOVER: u32 = 3;
@@ -130,8 +129,8 @@ impl MarketDataHealth {
                 let consecutive = consecutive.saturating_add(1);
                 let bad_for_ms = now_ms.saturating_sub(first_bad_ms);
                 if issue == MarketDataObservation::FeedIdle
-                    || consecutive >= self.bad_observations_to_degrade
-                    || bad_for_ms >= self.bad_grace_ms
+                    || (consecutive >= self.bad_observations_to_degrade
+                        && bad_for_ms >= self.bad_grace_ms)
                 {
                     self.phase = MarketDataPhase::Degraded { issue, coherent: 0 };
                     MarketDataTransition::EnteredDegraded {
@@ -191,8 +190,7 @@ impl MarketDataHealth {
 
     fn begin_bad(&mut self, now_ms: u64, issue: MarketDataObservation) -> MarketDataTransition {
         if issue == MarketDataObservation::FeedIdle
-            || self.bad_observations_to_degrade == 1
-            || self.bad_grace_ms == 0
+            || (self.bad_observations_to_degrade == 1 && self.bad_grace_ms == 0)
         {
             self.phase = MarketDataPhase::Degraded { issue, coherent: 0 };
             return MarketDataTransition::EnteredDegraded {
@@ -233,25 +231,55 @@ mod tests {
     }
 
     #[test]
-    fn third_bad_observation_or_elapsed_grace_degrades() {
+    fn bad_observations_require_count_and_elapsed_grace_to_degrade() {
         let mut health = MarketDataHealth::default();
         let _ = health.observe(0, MarketDataObservation::RestFallback);
         let _ = health.observe(1_000, MarketDataObservation::MarkMidDivergence);
         assert!(matches!(
             health.observe(2_000, MarketDataObservation::RestFallback),
-            MarketDataTransition::EnteredDegraded { consecutive: 3, .. }
+            MarketDataTransition::Grace {
+                consecutive: 3,
+                bad_for_ms: 2_000,
+                ..
+            }
+        ));
+        assert!(!health.is_degraded());
+        assert!(matches!(
+            health.observe(15_000, MarketDataObservation::RestFallback),
+            MarketDataTransition::EnteredDegraded {
+                consecutive: 4,
+                bad_for_ms: 15_000,
+                ..
+            }
         ));
 
         let mut sparse = MarketDataHealth::default();
         let _ = sparse.observe(0, MarketDataObservation::RestFallback);
         assert!(matches!(
             sparse.observe(15_000, MarketDataObservation::RestFallback),
-            MarketDataTransition::EnteredDegraded {
+            MarketDataTransition::Grace {
                 consecutive: 2,
                 bad_for_ms: 15_000,
                 ..
             }
         ));
+        assert!(!sparse.is_degraded());
+    }
+
+    #[test]
+    fn rapid_divergence_updates_do_not_bypass_grace() {
+        let mut health = MarketDataHealth::default();
+        let _ = health.observe(0, MarketDataObservation::MarkMidDivergence);
+        let _ = health.observe(100, MarketDataObservation::MarkMidDivergence);
+        assert!(matches!(
+            health.observe(251, MarketDataObservation::MarkMidDivergence),
+            MarketDataTransition::Grace {
+                consecutive: 3,
+                bad_for_ms: 251,
+                ..
+            }
+        ));
+        assert!(!health.is_degraded());
     }
 
     #[test]
@@ -268,7 +296,7 @@ mod tests {
 
     #[test]
     fn recovery_requires_three_coherent_observations_and_explicit_confirmation() {
-        let mut health = MarketDataHealth::new(1, 15_000, 3);
+        let mut health = MarketDataHealth::new(1, 0, 3);
         let _ = health.observe(0, MarketDataObservation::RestFallback);
         assert!(health.is_degraded());
         assert!(matches!(
@@ -287,7 +315,7 @@ mod tests {
 
     #[test]
     fn bad_observation_resets_recovery_streak() {
-        let mut health = MarketDataHealth::new(1, 15_000, 3);
+        let mut health = MarketDataHealth::new(1, 0, 3);
         let _ = health.observe(0, MarketDataObservation::RestFallback);
         let _ = health.observe(1, MarketDataObservation::Coherent);
         let _ = health.observe(2, MarketDataObservation::Coherent);


### PR DESCRIPTION
## Summary
- Gate market-data degradation on both the unhealthy observation count and the wall-clock grace period.
- Ignore repeated websocket updates unless both price and book advance together, preventing one-channel churn from inflating health counts.
- Update tests to cover the new grace-bound degradation behavior and snapshot version gating.

## Testing
- Added and updated unit tests for market-data degradation, rapid divergence updates, and websocket snapshot version advancement.
- Not run (not requested)