### PR TITLE
Route accounting-invariant shutdown through the core reducer

### DIFF
--- a/crates/standx-cli/src/commands/maker/model.rs
+++ b/crates/standx-cli/src/commands/maker/model.rs
@@ -115,6 +115,9 @@ impl From<standx_maker::RuntimeStopReason> for MakerExit {
                 Self::ConsecutiveErrors(detail)
             }
             standx_maker::RuntimeStopReason::StopLoss(detail) => Self::StopLoss(detail),
+            standx_maker::RuntimeStopReason::AccountingInvariant(detail) => {
+                Self::AccountingInvariant(detail)
+            }
         }
     }
 }
@@ -284,6 +287,10 @@ mod exit_mapping_tests {
         assert!(matches!(
             MakerExit::from(RuntimeStopReason::StopLoss("boom".to_string())),
             MakerExit::StopLoss(detail) if detail == "boom"
+        ));
+        assert!(matches!(
+            MakerExit::from(RuntimeStopReason::AccountingInvariant("boom".to_string())),
+            MakerExit::AccountingInvariant(detail) if detail == "boom"
         ));
         assert!(matches!(
             MakerExit::from(RuntimeStopReason::CleanupFailure {

--- a/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
@@ -465,7 +465,7 @@ impl MakerRuntime {
                 }
             }
             if args.live {
-                if let Some(exit) = accounting_invariant_exit(
+                if let Some(detail) = accounting_invariant_exit(
                     notifier,
                     symbol,
                     cycle,
@@ -475,7 +475,10 @@ impl MakerRuntime {
                 )
                 .await
                 {
-                    break 'execute exit;
+                    break 'execute stop_requested_exit(
+                        &mut self.recovery.runtime_state,
+                        RuntimeStopReason::AccountingInvariant(detail),
+                    );
                 }
             }
 

--- a/crates/standx-cli/src/commands/maker/runtime/recovery_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/recovery_flow.rs
@@ -326,7 +326,7 @@ pub(super) async fn accounting_invariant_exit(
     expected_position: f64,
     stats_position: f64,
     qty_tolerance: f64,
-) -> Option<MakerExit> {
+) -> Option<String> {
     if !accounting_position_mismatch(expected_position, stats_position, qty_tolerance) {
         return None;
     }
@@ -350,7 +350,7 @@ pub(super) async fn accounting_invariant_exit(
             true,
         )
         .await;
-    Some(MakerExit::AccountingInvariant(detail))
+    Some(detail)
 }
 
 pub(super) fn next_market_transport_deadline(
@@ -1541,7 +1541,7 @@ impl MakerRuntime {
                 self.recovery.account_position_mismatch = None;
             }
             if args.live {
-                if let Some(exit) = accounting_invariant_exit(
+                if let Some(detail) = accounting_invariant_exit(
                     notifier,
                     symbol,
                     cycle,
@@ -1551,7 +1551,10 @@ impl MakerRuntime {
                 )
                 .await
                 {
-                    break 'phase exit;
+                    break 'phase stop_requested_exit(
+                        &mut self.recovery.runtime_state,
+                        RuntimeStopReason::AccountingInvariant(detail),
+                    );
                 }
             }
             return LoopDirective::Proceed;

--- a/crates/standx-cli/src/commands/maker/runtime/tests/account_events.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/tests/account_events.rs
@@ -287,7 +287,7 @@ async fn accounting_invariant_mismatch_becomes_fail_safe_exit() {
     assert!(
         accounting_invariant_exit(&notifier, "XAG-USD", 1396, 0.0, -0.2, 0.0005,)
             .await
-            .is_some_and(|exit| matches!(exit, MakerExit::AccountingInvariant(_)))
+            .is_some_and(|detail| detail.contains("differs from ledger expected"))
     );
     assert!(
         accounting_invariant_exit(&notifier, "XAG-USD", 1396, 0.0, 0.00049, 0.0005,)

--- a/crates/standx-maker/src/runtime.rs
+++ b/crates/standx-maker/src/runtime.rs
@@ -76,6 +76,7 @@ pub enum RuntimeStopReason {
     MarketData(String),
     ConsecutiveCycleErrors(String),
     StopLoss(String),
+    AccountingInvariant(String),
     CleanupFailure {
         target: RecoveryTarget,
         reason: String,
@@ -90,7 +91,8 @@ impl RuntimeStopReason {
             | Self::PositionReconciliation(reason)
             | Self::MarketData(reason)
             | Self::ConsecutiveCycleErrors(reason)
-            | Self::StopLoss(reason) => reason.clone(),
+            | Self::StopLoss(reason)
+            | Self::AccountingInvariant(reason) => reason.clone(),
             Self::CleanupFailure { reason, .. } => reason.clone(),
         }
     }
@@ -716,6 +718,7 @@ mod tests {
             RuntimeStopReason::MarketData("boom".to_string()),
             RuntimeStopReason::ConsecutiveCycleErrors("boom".to_string()),
             RuntimeStopReason::StopLoss("boom".to_string()),
+            RuntimeStopReason::AccountingInvariant("boom".to_string()),
             RuntimeStopReason::CleanupFailure {
                 target: RecoveryTarget::OrderResponse,
                 reason: "boom".to_string(),
@@ -780,6 +783,31 @@ mod tests {
                 "{event:?} must not leave stale effects behind cleanup"
             );
         }
+    }
+
+    #[test]
+    fn accounting_invariant_stop_clears_queued_cycle() {
+        let mut state = MakerState::starting();
+        // Leave StartupReady's RunCycle effect *undrained* so the test proves
+        // an accounting-invariant stop clears stale queued work instead of
+        // leaving a placement effect behind the abort/stop pair.
+        state.handle(MakerEvent::StartupReady);
+        let queued = match state.pending_effect() {
+            Some(MakerEffect::RunCycle(token)) => *token,
+            effect => panic!("expected queued cycle, got {effect:?}"),
+        };
+        let reason = RuntimeStopReason::AccountingInvariant("boom".to_string());
+        state.handle(MakerEvent::StopRequested(reason.clone()));
+        assert_eq!(
+            state.next_effect(),
+            Some(MakerEffect::AbortInFlight(queued))
+        );
+        assert_eq!(state.next_effect(), Some(MakerEffect::Stop(reason)));
+        assert_eq!(
+            state.next_effect(),
+            None,
+            "queued RunCycle must not survive the accounting-invariant stop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

The accounting-invariant fail-safe (ledger expected position vs stats position beyond tolerance) was the **last shutdown path that bypassed the core reducer**. The CLI built a `MakerExit::AccountingInvariant` directly and exited, so the runtime never sealed into `Stopping`, never aborted in-flight work, and never cleared queued effects — a late-arriving event could still enqueue new work. Stop-loss and the recently-landed market-data shutdown already go through the typed `StopRequested` path; this closes the last inconsistency.

This makes accounting-invariant shutdown **isomorphic with stop-loss**: the core gains a typed stop reason and the CLI drives shutdown through the reducer.

## Changes

**Core (`standx-maker/src/runtime.rs`)**
- Add `RuntimeStopReason::AccountingInvariant(String)`; fold it into the shared `detail()` or-branch and the `stop_reasons()` conformance table, so `stop_requested_passes_the_reason_through_and_seals_the_runtime` automatically covers the new variant's sealing.
- Add `accounting_invariant_stop_clears_queued_cycle`: leaves an undrained `RunCycle`, fires `StopRequested(AccountingInvariant)`, and asserts the effect sequence is exactly `AbortInFlight → Stop` with nothing left behind (the queued placement is cleared).

**CLI**
- `model.rs`: map the new reason in `From<RuntimeStopReason> for MakerExit` and add the assertion to the exhaustive mapping test. `terminal_error()` / `lifecycle_reason()` are unchanged — **exit code 75 (fail-safe) and the operator-facing wording are preserved**.
- `recovery_flow.rs`: `accounting_invariant_exit` now returns `Option<String>` (the mismatch detail) and still sends the `kind=accounting_invariant, severity=critical` notification. Its `accounting_invariant_phase` call site routes the detail through the existing `stop_requested_exit(..)` helper so the reducer performs the seal / drain / abort.
- `cycle_flow.rs`: same rewire at the cycle-execution call site.
- `tests/account_events.rs`: update `accounting_invariant_mismatch_becomes_fail_safe_exit` to assert on the returned detail string.

## Reviewer notes
- No production code constructs `MakerExit::AccountingInvariant` anymore — it is produced solely via the `From` mapping (`reason.into()` inside `take_stop_effect`). The three remaining source references are model unit tests exercising `MakerExit`'s own methods.
- Out of scope (intentionally): the ad-hoc "residual cleanup failed" handling in `lifecycle.rs`, which runs after the main loop exits and the reducer is already sealed — routing it through the state machine would be meaningless.
- Verified: `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo test -p standx-maker -p standx-cli` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)