### PR TITLE
deploy: containerize Stage 2 A/B orchestrator with docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Keep .git: the run manifest requires `git rev-parse HEAD` and a clean
+# strategy worktree, so the image must ship the repo's git metadata.
+# Exclude only bulky or host-specific paths that must not enter the build.
+target/
+**/target/
+.claude/
+deploy/openobserve/data/
+var/standx/
+*.log
+*.tmp
+__pycache__/
+**/__pycache__/
+*.py[cod]
+.DS_Store

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1
+
+# ---- builder ------------------------------------------------------------
+# bookworm base so the produced glibc-linked binary matches the runtime.
+FROM rust:1.83-bookworm AS builder
+WORKDIR /build
+COPY . .
+# reqwest/tokio-tungstenite use rustls, so no OpenSSL dev headers are needed.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/target \
+    cargo build --release --bin standx && \
+    cp target/release/standx /build/standx
+
+# ---- runtime ------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+# bash        — the orchestrator and observed wrapper are bash scripts
+# python3     — manifest, config-diff, webhook, alert tooling
+# util-linux  — flock (guard/maker process locks)
+# coreutils   — sha256sum, date; perl provides shasum used by the wrapper
+# curl        — supervisor webhook POSTs from the observed wrapper
+# git         — the run manifest requires HEAD + a clean strategy worktree
+# ca-certificates — rustls native-roots for the venue TLS handshake
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash python3 util-linux coreutils perl curl git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/standx
+# Ships the repository (including .git; see .dockerignore) so the manifest's
+# git_sha_present / strategy_source_clean checks pass at runtime.
+COPY . /opt/standx
+COPY --from=builder /build/standx /opt/standx/bin/standx
+
+# git refuses to operate on a tree owned by another uid; the manifest tooling
+# runs git as the container user, so mark the deployment root as trusted.
+RUN git config --system --add safe.directory /opt/standx
+
+# Build-time gate mirroring scripts/maker_run_manifest.py: refuse to ship an
+# image whose committed strategy source is missing or dirty, because the A/B
+# orchestrator would invalidate every arm and critical-stop at runtime.
+RUN set -eu; \
+    test "$(git rev-parse HEAD | tr -d '\n' | wc -c)" -eq 40 \
+      || { echo 'ERROR: no committed HEAD; build from a clean release checkout' >&2; exit 1; }; \
+    dirty="$(git status --porcelain --untracked-files=all -- \
+        Cargo.toml Cargo.lock crates/standx-maker crates/standx-sdk \
+        crates/standx-cli examples/maker.toml)"; \
+    test -z "$dirty" \
+      || { echo 'ERROR: strategy source is dirty; build from a clean release commit:' >&2; \
+           echo "$dirty" >&2; exit 1; }
+
+# Credentials come from a read-only mount at $XDG_DATA_HOME/standx/credentials.enc.
+ENV XDG_DATA_HOME=/opt/standx/state
+RUN mkdir -p /opt/standx/state/standx /opt/standx/var/standx
+
+COPY deploy/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,0 +1,103 @@
+# Stage 2 A/B orchestrator — docker-compose
+
+Containerized equivalent of `deploy/systemd/standx-maker-stage2-ab.service`.
+**Read [`docs/19-maker-stage2-live-ab-runbook.md`](../../docs/19-maker-stage2-live-ab-runbook.md) first.**
+This service trades live and must not start until the canary evidence is
+recorded and the exact authorization text is in the release record.
+
+## What runs where
+
+- **This compose file**: only the A/B orchestrator (`run_maker_stage2_ab.sh`),
+  its observed wrapper, manifest tooling, and the deadman-alert install.
+- **Not here**: OpenObserve. Keep running
+  [`deploy/openobserve/compose.yaml`](../openobserve/compose.yaml) separately.
+  `network_mode: host` lets this container reach it on `127.0.0.1:5080`.
+
+## Prerequisites
+
+1. A **clean checkout at the release commit** (the image build fails if the
+   committed strategy source — `crates/*`, `Cargo.*`, `examples/maker.toml` —
+   is dirty, because the run manifest would reject every arm).
+2. Live credentials on the host via `standx auth login`
+   (`~/.local/share/standx/credentials.enc`), mounted read-only.
+3. A root-owned `0600` `/etc/standx/maker-stage2-ab.env` — copy
+   [`deploy/systemd/maker-stage2-ab.env.example`](../systemd/maker-stage2-ab.env.example),
+   fill secrets and the three `STANDX_BASELINE_*` metadata values. The in-container
+   paths it already targets (`/opt/standx`, `/run/lock/...`) are correct as-is.
+4. The frozen `examples/maker-stage2-xag-{baseline,candidate}.toml` (shipped in
+   the image).
+
+Point compose at the host credential file and log dir with a sibling `.env`
+(or export the vars):
+
+```
+STANDX_CREDENTIALS_FILE=/home/youruser/.local/share/standx/credentials.enc
+STANDX_LOG_DIR_HOST=/opt/standx/var/standx
+```
+
+## Run
+
+```bash
+cd deploy/docker
+
+# 1. Build + config/preflight only, no live orders (maps to STANDX_STAGE2_VALIDATE_ONLY):
+docker compose --profile ab run --rm \
+  -e STANDX_STAGE2_VALIDATE_ONLY=1 stage2-ab
+
+# 2. Start the guarded two-hour A/B (only after canary evidence is accepted):
+docker compose --profile ab up -d --build
+
+# 3. Follow:
+docker compose --profile ab logs -f
+
+# 4. Stop with clean arm cleanup (SIGTERM -> orchestrator -> live arm cancel-all):
+docker compose --profile ab stop        # honors the 120s grace period
+```
+
+The `ab` profile means a bare `docker compose up` starts nothing — live trading
+only launches when you pass `--profile ab` explicitly.
+
+## systemd → compose mapping
+
+| systemd unit | compose | notes |
+|---|---|---|
+| `ExecStart=run_maker_stage2_ab.sh` | entrypoint `exec`s it | unchanged orchestrator |
+| `ExecStartPre=openobserve_alerts.py` | entrypoint, fail-closed | deadman alert installed before any order |
+| `Restart=on-failure` + `RestartPreventExitStatus=75` | `restart: "no"` | **behavior change — see below** |
+| `Conflicts=standx-maker.service` | shared `/run/lock` bind mount | flock keeps host maker + container mutually exclusive |
+| `KillSignal=SIGTERM` / `TimeoutStopSec=90` | `stop_signal` + `stop_grace_period: 120s` | plus a new orchestrator SIGTERM trap |
+| `EnvironmentFile=/etc/standx/maker-stage2-ab.env` | `env_file` | same file |
+| `OnFailure=standx-notify@…` | `STANDX_SUPERVISOR_WEBHOOK` critical post | orchestrator already webhooks on critical stop |
+
+## Preserved vs. changed safety semantics
+
+**Preserved**
+- Exit 75 critical stop, no automatic flatten, arm invalidation, manifest +
+  venue empty-order/empty-position gates between arms — all in the unchanged
+  orchestrator.
+- Host-wide single-live-maker guarantee, via the shared `/run/lock` mount and
+  the existing `flock` guard/maker locks.
+- Deadman alert installed before the first live order (fail-closed entrypoint).
+- Clean shutdown: a **new SIGTERM/SIGINT trap** in `run_maker_stage2_ab.sh`
+  forwards the signal to the active arm so `docker stop` triggers the normal
+  freeze/cancel-all instead of orphaning a live maker. Without this, docker's
+  PID-1 signal would have killed the orchestrator and left live orders.
+
+**Changed — operator must accept**
+- **No auto-restart** (`restart: "no"`). systemd restarted up to 3×/300s on
+  transient failure but never on exit 75. Docker restart policies cannot exclude
+  an exit code, so auto-restart would relaunch after a critical stop that may
+  have left an open position — unacceptable. Every stop here (critical or
+  transient) requires a human to clear per the runbook emergency procedure.
+- **Host networking + root in container** for lock/telemetry/venue parity. This
+  is dedicated-host infra, matching the current host-process deployment; it is
+  not isolated the way a bridged, unprivileged container would be.
+
+## Do not
+
+- Do not pass `--controlled-disconnect-after` through this path — it forces a
+  fail-safe shutdown, which the orchestrator treats as an arm exiting early
+  (critical stop). Run that canary drill manually per the runbook.
+- Do not run this container and the host `standx-maker.service` at the same
+  time; the shared lock will reject the second, but do not rely on it — stop
+  one first.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,0 +1,58 @@
+# Stage 2 maker baseline/candidate A/B orchestrator, containerized.
+#
+# This is the docker-compose equivalent of deploy/systemd/standx-maker-stage2-ab.service.
+# Read docs/19-maker-stage2-live-ab-runbook.md first: this service trades live
+# and must not start until the canary evidence is recorded.
+#
+# It is gated behind the "ab" profile so a bare `docker compose up` cannot
+# launch live trading by accident. Start it deliberately:
+#   docker compose -f deploy/docker/docker-compose.yml --profile ab up -d --build
+#
+# OpenObserve is NOT part of this file — keep running deploy/openobserve/compose.yaml
+# separately. network_mode: host lets this container reach it on 127.0.0.1:5080,
+# share /run/lock with a host-run maker, and hit the venue exactly like the
+# systemd deployment.
+
+services:
+  stage2-ab:
+    profiles: ["ab"]
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile
+    image: standx-stage2-ab:latest
+    container_name: standx-maker-stage2-ab
+
+    # SAFETY: never auto-restart. A critical stop exits 75 and requires human
+    # intervention (possible residual position). docker restart policies cannot
+    # exclude an exit code the way systemd RestartPreventExitStatus=75 does, so
+    # "no" is the only safe choice — a transient arm crash is itself surfaced as
+    # a critical stop that a human must clear before the next arm.
+    restart: "no"
+
+    # tini as PID 1 reaps zombies and forwards SIGTERM to the orchestrator,
+    # whose own trap then forwards it to the live arm for cancel-all cleanup.
+    init: true
+    stop_signal: SIGTERM
+    # >= systemd TimeoutStopSec=90, with margin for the arm's freeze/cancel-all.
+    stop_grace_period: 120s
+
+    # Host networking: OpenObserve on 127.0.0.1:5080, the venue, and the shared
+    # /run/lock mutual exclusion all behave as they do for the host-run maker.
+    network_mode: host
+
+    # Root-owned 0600 file, same contents as the systemd deployment. Provides
+    # STANDX_INSTALL_ROOT=/opt/standx, STANDX_BIN, lock paths, OpenObserve and
+    # supervisor webhook config, STANDX_ENABLE_LIVE_MAKER=1, and the three
+    # STANDX_BASELINE_* metadata values.
+    env_file:
+      - /etc/standx/maker-stage2-ab.env
+
+    volumes:
+      # Live credentials, read-only. Written on the host by `standx auth login`;
+      # refresh it there and the next arm's reconnect picks up the new token.
+      - ${STANDX_CREDENTIALS_FILE:-/opt/standx/state/standx/credentials.enc}:/opt/standx/state/standx/credentials.enc:ro
+      # Run evidence (NDJSON + manifests) must outlive the container.
+      - ${STANDX_LOG_DIR_HOST:-/opt/standx/var/standx}:/opt/standx/var/standx
+      # Shared lock dir so a host-run maker and this container are mutually
+      # exclusive on /run/lock/standx-maker-live.lock and the A/B guard lock.
+      - /run/lock:/run/lock

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Container entrypoint for the Stage 2 A/B orchestrator.
+#
+# Mirrors the systemd unit's start sequence:
+#   ExecStartPre=openobserve_alerts.py   -> install the external deadman alert
+#   ExecStart=run_maker_stage2_ab.sh     -> the guarded A/B orchestrator
+# Both preconditions fail closed: if the credential mount or the deadman alert
+# is not in place, the container refuses to start rather than trading blind.
+set -euo pipefail
+
+root="${STANDX_INSTALL_ROOT:-/opt/standx}"
+cred_file="${XDG_DATA_HOME:-$root/state}/standx/credentials.enc"
+
+# Credentials arrive either as env (STANDX_JWT) or the read-only mounted file.
+if [[ -z "${STANDX_JWT:-}" && ! -f "$cred_file" ]]; then
+  printf 'entrypoint: no credentials: set STANDX_JWT or mount %s (read-only)\n' \
+    "$cred_file" >&2
+  exit 64
+fi
+
+# Install the OpenObserve deadman alert before any live order. This is the
+# runbook-required "no telemetry for N minutes" backstop; a failure here is a
+# gate failure, so do not fall through to trading.
+if [[ "${STANDX_STAGE2_SKIP_ALERT_INSTALL:-0}" != "1" ]]; then
+  printf 'entrypoint: installing OpenObserve deadman alert\n' >&2
+  python3 "$root/scripts/openobserve_alerts.py"
+else
+  printf 'entrypoint: WARNING deadman alert install skipped by STANDX_STAGE2_SKIP_ALERT_INSTALL=1\n' >&2
+fi
+
+# exec so the orchestrator becomes the signal target; its SIGTERM trap forwards
+# to the active live arm for normal freeze/cancel-all cleanup on `docker stop`.
+exec "$root/scripts/run_maker_stage2_ab.sh"

--- a/scripts/run_maker_stage2_ab.sh
+++ b/scripts/run_maker_stage2_ab.sh
@@ -100,6 +100,25 @@ flock -n 9 || {
 export STANDX_STAGE2_AB_MEMBER=1
 export STANDX_STAGE2_AB_LOCK_PATH="$ab_lock"
 
+# PID of the maker arm currently running (via run_maker_observed.sh). Tracked so
+# a SIGTERM/SIGINT — e.g. `docker stop`, `systemctl stop` — is forwarded to the
+# live arm for its normal freeze/cancel-all cleanup instead of orphaning a live
+# maker. The observed wrapper already forwards the signal on to the binary.
+current_arm_pid=""
+graceful_shutdown() {
+  local signal="$1"
+  trap - TERM INT
+  notify "stage2 A/B received SIG$signal; forwarding to the active arm for cleanup" warning
+  if [[ -n "$current_arm_pid" ]] && kill -0 "$current_arm_pid" 2>/dev/null; then
+    kill -TERM "$current_arm_pid" 2>/dev/null || true
+    wait "$current_arm_pid" 2>/dev/null || true
+  fi
+  notify "stage2 A/B stopped on SIG$signal after arm cleanup; no automatic flatten was attempted"
+  exit 0
+}
+trap 'graceful_shutdown TERM' TERM
+trap 'graceful_shutdown INT' INT
+
 positions_json() {
   "$standx_bin" --output json account positions --symbol "$symbol"
 }
@@ -153,6 +172,7 @@ run_arm() {
   STANDX_RUN_ID="$run_id" "$root/scripts/run_maker_observed.sh" \
     "$standx_bin" --output json maker run "$symbol" --maker-config "$config" --live &
   pid=$!
+  current_arm_pid="$pid"
   deadline=$((SECONDS + arm_seconds))
   while ((SECONDS < deadline)); do
     if ! kill -0 "$pid" 2>/dev/null; then
@@ -214,6 +234,7 @@ run_arm() {
     critical_stop "arm=$arm independent post-check found orders or position (run_id=$run_id)"
   }
   notify "stage2 A/B arm complete: arm=$arm run_id=$run_id config_hash=$config_hash orders=[] positions=[]"
+  current_arm_pid=""
 }
 
 while true; do


### PR DESCRIPTION
## Summary

docker-compose deployment for the Stage 2 baseline/candidate A/B orchestrator — the container equivalent of `deploy/systemd/standx-maker-stage2-ab.service`. Live-trading infra, so the design deliberately preserves the systemd unit's safety semantics and documents where docker forces a change.

New files under `deploy/docker/`:
- **Dockerfile** — multi-stage (cargo build → slim runtime). Bakes a clean repo checkout (incl. `.git`) + the release binary. A build-time gate mirrors `scripts/maker_run_manifest.py`'s `git_sha_present` / `strategy_source_clean` checks and **fails the build on a dirty strategy tree**, so you cannot ship an image that would invalidate every arm at runtime.
- **docker-compose.yml** — the A/B service, gated behind the `ab` profile.
- **entrypoint.sh** — installs the OpenObserve deadman alert fail-closed, then `exec`s the orchestrator (maps `ExecStartPre`).
- **README.md** — full systemd→compose mapping and the preserved/changed semantics.

Plus `.dockerignore` (keeps `.git`, drops `target/` and bulk) and a SIGTERM/SIGINT trap in `scripts/run_maker_stage2_ab.sh`.

## Why the signal trap

`docker stop` signals only PID 1. The orchestrator runs the live maker as a background child, so without a trap the bash orchestrator would die and the live maker would be orphaned (no freeze/cancel-all) until the grace-period SIGKILL. The new trap forwards SIGTERM/SIGINT to the active arm, which cleans up normally via the observed wrapper → binary chain. Harmless under systemd, whose default control-group kill already signals the child directly.

## Safety semantics

**Preserved:** exit-75 critical stop / no auto-flatten / arm invalidation / inter-arm manifest+venue empty checks (unchanged orchestrator); host-wide single-live-maker guarantee via a shared `/run/lock` bind mount over the existing flock locks; deadman alert before the first live order; clean shutdown via the new trap.

**Changed (documented in README):**
- **`restart: "no"`** — docker restart policies cannot exclude an exit code the way systemd `RestartPreventExitStatus=75` does. Auto-restart after a critical stop could relaunch with an open position, so no auto-restart is the only safe choice; every stop requires a human per the runbook emergency procedure.
- **`network_mode: host` + root in container** — for `/run/lock`, OpenObserve (`127.0.0.1:5080`) and venue parity with the current host-process deployment. Dedicated-host infra, not bridged/isolated.

## Reviewer notes

- **Credentials** are mounted read-only (`standx auth login` file on the host); refresh on the host and the next arm's reconnect picks it up. JWT `exp` (~24h) is an existing strategy-level constraint unrelated to docker — plan token refresh for a long-running loop.
- The `ab` profile means a bare `docker compose up` starts nothing; live trading only launches with `--profile ab`.
- Do not pass `--controlled-disconnect-after` through this path — it forces a fail-safe shutdown the orchestrator treats as an early arm exit (critical stop). Run that canary drill manually per the runbook.
- Prerequisites unchanged: canary evidence recorded, authorization text in the release record, root-owned `0600` `/etc/standx/maker-stage2-ab.env` with the three `STANDX_BASELINE_*` values filled.

## Testing

- `bash -n` on the orchestrator and entrypoint: OK.
- `docker compose config` valid; `ab` profile gating confirmed (bare config selects no services).
- `python3 -m py_compile` on touched tooling: OK.
- **Image not built** (no docker daemon in the authoring environment) — needs a `docker build` from a clean release checkout on the target host before use.