### PR TITLE
deploy(docker): fix builder toolchain and deadman alert format

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -2,7 +2,10 @@
 
 # ---- builder ------------------------------------------------------------
 # bookworm base so the produced glibc-linked binary matches the runtime.
-FROM rust:1.83-bookworm AS builder
+# Cargo.lock pulls transitive deps requiring the `edition2024` feature
+# (stabilized in Rust 1.85); 1.83 fails with "feature `edition2024` is
+# required". Pinned to the version verified locally (rustc --version).
+FROM rust:1.93.1-bookworm AS builder
 WORKDIR /build
 COPY . .
 # reqwest/tokio-tungstenite use rustls, so no OpenSSL dev headers are needed.

--- a/scripts/openobserve_alerts.py
+++ b/scripts/openobserve_alerts.py
@@ -14,7 +14,9 @@ Environment (shares the dashboard script's OpenObserve variables):
 - ``OPENOBSERVE_ORG``           default ``default``
 - ``OPENOBSERVE_STREAM``        default ``standx_maker``
 - ``OPENOBSERVE_USER`` / ``OPENOBSERVE_PASSWORD``   required (Basic auth)
-- ``OPENOBSERVE_ALERT_WEBHOOK`` required; webhook the alert POSTs to
+- ``OPENOBSERVE_ALERT_WEBHOOK`` required; Feishu (Lark) custom-bot webhook the
+  alert POSTs to. The template body is Feishu msg_type=text, so a Slack or
+  generic ``{"text": ...}`` endpoint will reject it.
 - ``OPENOBSERVE_ALERT_MINUTES`` default ``3``; deadman window in minutes
 """
 
@@ -34,17 +36,18 @@ TEMPLATE_NAME = "standx_maker_deadman_template"
 DESTINATION_NAME = "standx_maker_deadman_webhook"
 NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
-# Slack/Feishu-agnostic text payload. OpenObserve substitutes the {var}
-# placeholders at send time; keep it plain text so generic webhooks accept it.
+# Feishu (Lark) custom-bot text payload. OpenObserve substitutes the {var}
+# placeholders at send time; the JSON structure braces are left untouched
+# because only recognized variable names are replaced. Feishu requires the
+# msg_type/content envelope rather than a bare {"text": ...} body.
+_DEADMAN_TEXT = (
+    "\U0001f6d1 StandX maker DEADMAN: no cycle_summary in the "
+    "{stream_name} stream for the deadman window. The maker may have "
+    "died silently (SIGKILL/OOM/panic/host down) and could be leaving "
+    "resting orders on the venue. Alert: {alert_name} org: {org_name}"
+)
 TEMPLATE_BODY = json.dumps(
-    {
-        "text": (
-            "\U0001f6d1 StandX maker DEADMAN: no cycle_summary in the "
-            "{stream_name} stream for the deadman window. The maker may have "
-            "died silently (SIGKILL/OOM/panic/host down) and could be leaving "
-            "resting orders on the venue. Alert: {alert_name} org: {org_name}"
-        )
-    }
+    {"msg_type": "text", "content": {"text": _DEADMAN_TEXT}}
 )
 
 


### PR DESCRIPTION
## Summary

Two follow-ups to the Stage 2 A/B docker-compose deployment (#309, already merged), found while actually running it:

1. **Fix the `docker build` failure** — `rust:1.83-bookworm` can't build the workspace: `feature \`edition2024\` is required` (transitive deps in `Cargo.lock` now need edition2024, stabilized in Rust 1.85). Bumped the builder image to `1.93.1-bookworm`, matching the toolchain verified locally.
2. **Fix the OpenObserve deadman alert format for Feishu** — the alert destination's template body was Slack-shaped (`{"text": ...}`). Feishu (Lark) custom bots require the `{"msg_type":"text","content":{"text":...}}` envelope and reject the old shape. Since the operator's `OPENOBSERVE_ALERT_WEBHOOK` is a Feishu bot, switched the template to that format. The `{stream_name}`/`{alert_name}`/`{org_name}` placeholders are unchanged — OpenObserve only substitutes recognized variable names, so the JSON structure is untouched.

Both changes affect fail-closed gates: the toolchain fix is required just to produce a runnable image; the alert-format fix is required for the docker entrypoint's (and the systemd unit's `ExecStartPre`) deadman-alert install to actually reach the operator's receiver.

## Testing

- **Toolchain fix**: ran the actual `docker build` end-to-end (a real daemon was available this time, unlike the original PR). It completed successfully, including the build-time git gate that fails the build if the committed strategy source (`crates/*`, `Cargo.*`, `examples/maker.toml`) is dirty. Then ran the resulting binary: `standx --version` reports `0.8.0`, and `maker run --help` shows the PR #308 `--adaptive-spread` flag, confirming the image is built from current source. Test image removed after verification.
- **Alert format fix**: rendered `TEMPLATE_BODY` and confirmed it parses as valid JSON in the Feishu `msg_type`/`content` shape, with all three placeholders intact. `python3 -m py_compile` passes.

## Notes for reviewer

Branch was rebased onto latest `main` (which already contains #309 and #310, both merged); the first commit of the original branch was auto-skipped by `git rebase` as already applied, so this PR carries only the two new commits.