### PR TITLE
alerts: migrate deadman install to OpenObserve v2 alerts API

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -11,6 +11,14 @@ set -euo pipefail
 root="${STANDX_INSTALL_ROOT:-/opt/standx}"
 cred_file="${XDG_DATA_HOME:-$root/state}/standx/credentials.enc"
 
+# Validate-only is a pure offline config/preflight check (symbol, config
+# byte-equality, hashes) — no credentials, no OpenObserve, no live orders. Skip
+# the live-only preconditions and hand straight to the orchestrator, which
+# validates and exits 0.
+if [[ "${STANDX_STAGE2_VALIDATE_ONLY:-0}" == "1" ]]; then
+  exec "$root/scripts/run_maker_stage2_ab.sh"
+fi
+
 # Credentials arrive either as env (STANDX_JWT) or the read-only mounted file.
 if [[ -z "${STANDX_JWT:-}" && ! -f "$cred_file" ]]; then
   printf 'entrypoint: no credentials: set STANDX_JWT or mount %s (read-only)\n' \

--- a/scripts/openobserve_alerts.py
+++ b/scripts/openobserve_alerts.py
@@ -180,11 +180,29 @@ class OpenObserve:
         self.json_request("POST", base, payload)
         return "created"
 
+    def _find_alert_id(self, base: str, name: str) -> str | None:
+        listing = self.json_request("GET", base)
+        items = listing.get("list", []) if isinstance(listing, dict) else []
+        if not isinstance(items, list):
+            return None
+        return next(
+            (
+                item.get("alert_id")
+                for item in items
+                if isinstance(item, dict) and item.get("name") == name
+            ),
+            None,
+        )
+
     def upsert_alert(self, alert: dict[str, Any]) -> str:
-        stream = parse.quote(self.stream, safe="")
-        base = f"/api/{self._org()}/{stream}/alerts"
-        if self._exists(base, ALERT_NAME):
-            self.json_request("PUT", f"{base}/{parse.quote(ALERT_NAME, safe='')}", alert)
+        # Alerts moved to the v2 API (OpenObserve >= ~0.14): org-scoped, keyed
+        # by alert_id rather than name, with stream_name as a body field
+        # instead of a path segment. The old stream-scoped v1 path
+        # (/api/{org}/{stream}/alerts) 404s on current OpenObserve builds.
+        base = f"/api/v2/{self._org()}/alerts"
+        alert_id = self._find_alert_id(base, ALERT_NAME)
+        if alert_id:
+            self.json_request("PUT", f"{base}/{parse.quote(alert_id, safe='')}", alert)
             return "updated"
         self.json_request("POST", base, alert)
         return "created"


### PR DESCRIPTION
## Summary

Fixes the deploy-blocking error reported when actually running the docker-compose Stage 2 A/B stack:

```
entrypoint: installing OpenObserve deadman alert
openobserve alerts error: OpenObserve GET /api/default/standx_maker/alerts returned HTTP 404
```

## Root cause (verified against a live instance, not guessed)

Spun up a throwaway `public.ecr.aws/zinclabs/openobserve:latest` container (resolves to v0.91.1) and reproduced the exact 404 from `scripts/openobserve_alerts.py`. Ruled out "stream doesn't exist yet" by creating the stream via a real ingest and retrying — still 404. Pulled the instance's own `/api-doc/openapi.json` and confirmed: **alerts moved entirely to `/api/v2/{org_id}/alerts`**, keyed by `alert_id` (not name), with `stream_name` as a body field instead of a path segment. The v1 path this script used (`/api/{org}/{stream}/alerts`) doesn't exist in this build at all — it's not a "create the stream first" problem, the endpoint is gone. Templates (`/api/{org}/alerts/templates`) and destinations (`/api/{org}/alerts/destinations`) are unaffected — those v1 paths are still current.

## Changes

- **`scripts/openobserve_alerts.py`**: `upsert_alert()` now targets `/api/v2/{org}/alerts`; added `_find_alert_id()` to list and match by `name`, then `PUT /api/v2/{org}/alerts/{alert_id}` to update (v2 has no name-based route) or `POST` to create.
- **`deploy/docker/entrypoint.sh`**: `STANDX_STAGE2_VALIDATE_ONLY=1` now skips credentials and the alert install entirely, exec'ing straight into the orchestrator's offline validate-only branch. That mode does no live I/O (symbol check, config byte-equality, hashes) and shouldn't require OpenObserve or credentials to be configured — this is what let the reported error surface even during a pure config dry run.

## Testing

Verified end-to-end against a live OpenObserve v0.91.1 container (real HTTP calls, not mocked):
- **Create path**: ran the fixed script fresh — template/destination/alert all report `action: created`; confirmed the alert via `GET /api/v2/default/alerts`.
- **Update path (idempotency)**: re-ran the script — all three report `action: updated`, and the alert list still contains exactly one entry (no duplicate created).
- `python3 -m py_compile` and `bash -n` both pass.

## Reviewer notes

This branch was created directly off latest `main` (post #309/#310/#311, all merged) rather than continuing the old `deploy/stage2-ab-docker-compose`/`deploy/stage2-ab-docker-followups` branches, since those PRs already merged in the interim.