### PR TITLE
deploy(docker): use container-local locks instead of bind-mounting /run/lock

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -52,7 +52,11 @@ RUN set -eu; \
 
 # Credentials come from a read-only mount at $XDG_DATA_HOME/standx/credentials.enc.
 ENV XDG_DATA_HOME=/opt/standx/state
-RUN mkdir -p /opt/standx/state/standx /opt/standx/var/standx
+# var/lock is where STANDX_MAKER_LOCK_PATH / STANDX_STAGE2_AB_LOCK_PATH should
+# point by default — container-local, not the host's /run/lock (see
+# docker-compose.yml). The app also create_dir_all()s the lock's parent at
+# runtime, but this keeps the image's writable layout explicit.
+RUN mkdir -p /opt/standx/state/standx /opt/standx/var/standx /opt/standx/var/lock
 
 COPY deploy/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -22,8 +22,19 @@ recorded and the exact authorization text is in the release record.
    (`~/.local/share/standx/credentials.enc`), mounted read-only.
 3. A root-owned `0600` `/etc/standx/maker-stage2-ab.env` — copy
    [`deploy/systemd/maker-stage2-ab.env.example`](../systemd/maker-stage2-ab.env.example),
-   fill secrets and the three `STANDX_BASELINE_*` metadata values. The in-container
-   paths it already targets (`/opt/standx`, `/run/lock/...`) are correct as-is.
+   fill secrets and the three `STANDX_BASELINE_*` metadata values. The
+   `/opt/standx` paths it targets are correct as-is, but **override the two
+   lock paths** for docker (the example's `/run/lock/...` defaults are for the
+   systemd deployment, which shares them with the host):
+   ```
+   STANDX_MAKER_LOCK_PATH=/opt/standx/var/lock/standx-maker-live.lock
+   STANDX_STAGE2_AB_LOCK_PATH=/opt/standx/var/lock/standx-maker-stage2-ab.lock
+   ```
+   Only keep the `/run/lock/...` defaults (and re-add the `/run/lock` bind
+   mount removed from `docker-compose.yml`) if a host-run
+   `standx-maker.service` / `standx-maker-stage2-ab.service` runs at the same
+   time as this container and must be mutually exclusive with it. See "Do not"
+   below.
 4. The frozen `examples/maker-stage2-xag-{baseline,candidate}.toml` (shipped in
    the image).
 
@@ -64,7 +75,7 @@ only launches when you pass `--profile ab` explicitly.
 | `ExecStart=run_maker_stage2_ab.sh` | entrypoint `exec`s it | unchanged orchestrator |
 | `ExecStartPre=openobserve_alerts.py` | entrypoint, fail-closed | deadman alert installed before any order |
 | `Restart=on-failure` + `RestartPreventExitStatus=75` | `restart: "no"` | **behavior change — see below** |
-| `Conflicts=standx-maker.service` | shared `/run/lock` bind mount | flock keeps host maker + container mutually exclusive |
+| `Conflicts=standx-maker.service` | not enforced by default | see "Changed" below — container uses container-local locks unless you opt in to sharing `/run/lock` |
 | `KillSignal=SIGTERM` / `TimeoutStopSec=90` | `stop_signal` + `stop_grace_period: 120s` | plus a new orchestrator SIGTERM trap |
 | `EnvironmentFile=/etc/standx/maker-stage2-ab.env` | `env_file` | same file |
 | `OnFailure=standx-notify@…` | `STANDX_SUPERVISOR_WEBHOOK` critical post | orchestrator already webhooks on critical stop |
@@ -75,8 +86,6 @@ only launches when you pass `--profile ab` explicitly.
 - Exit 75 critical stop, no automatic flatten, arm invalidation, manifest +
   venue empty-order/empty-position gates between arms — all in the unchanged
   orchestrator.
-- Host-wide single-live-maker guarantee, via the shared `/run/lock` mount and
-  the existing `flock` guard/maker locks.
 - Deadman alert installed before the first live order (fail-closed entrypoint).
 - Clean shutdown: a **new SIGTERM/SIGINT trap** in `run_maker_stage2_ab.sh`
   forwards the signal to the active arm so `docker stop` triggers the normal
@@ -89,15 +98,26 @@ only launches when you pass `--profile ab` explicitly.
   an exit code, so auto-restart would relaunch after a critical stop that may
   have left an open position — unacceptable. Every stop here (critical or
   transient) requires a human to clear per the runbook emergency procedure.
-- **Host networking + root in container** for lock/telemetry/venue parity. This
+- **Host networking + root in container** for telemetry/venue parity. This
   is dedicated-host infra, matching the current host-process deployment; it is
   not isolated the way a bridged, unprivileged container would be.
+- **Locks are container-local by default, not shared with `/run/lock`.**
+  Bind-mounting a system directory like the host's `/run/lock` hit
+  environment-specific failures in practice (permission/SELinux denials on
+  some hosts) for no benefit when nothing else on the host is running a live
+  maker. `STANDX_MAKER_LOCK_PATH` / `STANDX_STAGE2_AB_LOCK_PATH` should point
+  under `/opt/standx/var/lock` (see Prerequisites). **This means the
+  container no longer guarantees mutual exclusion with a host-run
+  `standx-maker.service`.** If you do run one alongside this container, bind
+  mount a shared host lock directory into both and point both deployments'
+  lock env vars at it.
 
 ## Do not
 
 - Do not pass `--controlled-disconnect-after` through this path — it forces a
   fail-safe shutdown, which the orchestrator treats as an arm exiting early
   (critical stop). Run that canary drill manually per the runbook.
-- Do not run this container and the host `standx-maker.service` at the same
-  time; the shared lock will reject the second, but do not rely on it — stop
-  one first.
+- Do not run this container and a host `standx-maker.service` at the same
+  time unless you've bind-mounted a shared lock directory into both (see
+  "Locks are container-local by default" above) — with container-local locks,
+  nothing stops the two from trading the same symbol concurrently.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -9,9 +9,15 @@
 #   docker compose -f deploy/docker/docker-compose.yml --profile ab up -d --build
 #
 # OpenObserve is NOT part of this file — keep running deploy/openobserve/compose.yaml
-# separately. network_mode: host lets this container reach it on 127.0.0.1:5080,
-# share /run/lock with a host-run maker, and hit the venue exactly like the
-# systemd deployment.
+# separately. network_mode: host lets this container reach it on 127.0.0.1:5080
+# and hit the venue exactly like the systemd deployment.
+#
+# Locks are container-local (STANDX_MAKER_LOCK_PATH / STANDX_STAGE2_AB_LOCK_PATH
+# in /etc/standx/maker-stage2-ab.env should point under /opt/standx/var/lock),
+# not shared with the host's /run/lock. This assumes no host-run
+# standx-maker.service / standx-maker-stage2-ab.service runs at the same time
+# as this container — if you do run one, point both deployments at the same
+# bind-mounted lock directory instead of the container-local default.
 
 services:
   stage2-ab:
@@ -36,8 +42,8 @@ services:
     # >= systemd TimeoutStopSec=90, with margin for the arm's freeze/cancel-all.
     stop_grace_period: 120s
 
-    # Host networking: OpenObserve on 127.0.0.1:5080, the venue, and the shared
-    # /run/lock mutual exclusion all behave as they do for the host-run maker.
+    # Host networking: OpenObserve on 127.0.0.1:5080 and the venue behave as
+    # they do for the host-run maker.
     network_mode: host
 
     # Root-owned 0600 file, same contents as the systemd deployment. Provides
@@ -53,6 +59,3 @@ services:
       - ${STANDX_CREDENTIALS_FILE:-/opt/standx/state/standx/credentials.enc}:/opt/standx/state/standx/credentials.enc:ro
       # Run evidence (NDJSON + manifests) must outlive the container.
       - ${STANDX_LOG_DIR_HOST:-/opt/standx/var/standx}:/opt/standx/var/standx
-      # Shared lock dir so a host-run maker and this container are mutually
-      # exclusive on /run/lock/standx-maker-live.lock and the A/B guard lock.
-      - /run/lock:/run/lock


### PR DESCRIPTION
## Summary

Fixes the deploy-blocking error hit while running the canary on a real docker deployment (no host-run `standx-maker.service` in the picture):

```
{"error":{"error_type":"UNKNOWN_ERROR","message":"failed to open live lock /run/lock/standx-maker-stage2-ab.lock"}}
```

## Root cause

`docker-compose.yml` bind-mounted the host's `/run/lock` into the container so a container-run maker and a host-run `standx-maker.service` could share the same `flock` guard/maker locks. On the operator's host this bind mount hit a permission failure opening a file under it — most likely SELinux or host-specific `/run/lock` permissions, though the exact denial wasn't captured. Since this deployment runs docker-only (no host-run maker to be mutually exclusive with), sharing `/run/lock` was buying a guarantee that isn't needed here, at the cost of depending on host system-directory permissions the container can't control.

## Fix

- **`docker-compose.yml`**: removed the `/run/lock:/run/lock` volume entirely.
- **`Dockerfile`**: added `/opt/standx/var/lock` to the image's writable layout (the app also `create_dir_all()`s the lock's parent at runtime, so this isn't strictly required, but keeps the layout explicit).
- **`README.md`**: documents that `STANDX_MAKER_LOCK_PATH` / `STANDX_STAGE2_AB_LOCK_PATH` must be overridden to `/opt/standx/var/lock/...` when using the shared `deploy/systemd/maker-stage2-ab.env.example` template for docker (its `/run/lock` defaults are correct for the systemd deployment, not this one). Also documents the trade-off explicitly: **this container no longer guarantees mutual exclusion with a host-run maker**; anyone who does run one alongside this container needs to bind-mount a shared lock directory into both and point both deployments' lock vars at it.

## Testing

Built the image and ran the exact failing command with the new container-local lock paths and **no** `/run/lock` mount at all:

```
docker run --rm --network host \
  -e STANDX_MAKER_LOCK_PATH=/opt/standx/var/lock/standx-maker-live.lock \
  -e STANDX_STAGE2_AB_LOCK_PATH=/opt/standx/var/lock/standx-maker-stage2-ab.lock \
  -e STANDX_ENABLE_LIVE_MAKER=1 \
  --entrypoint /opt/standx/bin/standx standx-stage2-ab:test \
  --output json maker ws-command-canary XAG-USD
```

Result: gets past `LiveProcessLock::acquire()` entirely — the process now fails only at `Authentication required` (expected, no credentials mounted in this throwaway test), confirming the reported "failed to open live lock" error is gone. `docker compose ... config` still validates.

## Reviewer notes

Branch created directly off latest `main` (post #309–#312, all merged).