### PR TITLE
docs: cross-link the docker deployment and record its fixed issues

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -123,3 +123,9 @@ maker service, installs the deadman alert before start, and runs the guarded
 baseline/candidate orchestrator. See
 `docs/19-maker-stage2-live-ab-runbook.md`; do not start it without the exact
 authorization recorded there.
+
+A containerized equivalent of the Stage 2 A/B orchestrator is available at
+[`deploy/docker/`](docker/README.md) (docker-compose, gated behind the `ab`
+profile). Same runbook and authorization gate apply; see that README for the
+systemd→compose mapping and the safety semantics that differ (no
+auto-restart, container-local locks by default).

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -121,3 +121,34 @@ only launches when you pass `--profile ab` explicitly.
   time unless you've bind-mounted a shared lock directory into both (see
   "Locks are container-local by default" above) — with container-local locks,
   nothing stops the two from trading the same symbol concurrently.
+
+## Troubleshooting
+
+Issues hit (and fixed) during the first real rollout, in the order they
+surface:
+
+- **`docker build` fails: `feature \`edition2024\` is required`** — the
+  builder image was pinned below Rust 1.85 (where `edition2024` stabilized),
+  and `Cargo.lock`'s transitive deps now need it. Fixed by pinning the
+  builder to a current `rustN.N-bookworm` tag; if it recurs after a
+  `Cargo.lock` update, bump the Dockerfile's `FROM rust:...` further.
+- **`openobserve alerts error: ... GET /api/{org}/{stream}/alerts returned
+  HTTP 404`** — OpenObserve's alerts API moved to `/api/v2/{org}/alerts`
+  (org-scoped, keyed by `alert_id`) in current builds; this is not a
+  stream-existence problem (creating the stream first does not help — the
+  old endpoint is simply gone). Fixed in `scripts/openobserve_alerts.py`.
+  If you pull a much newer OpenObserve image and this recurs, the API may
+  have moved again — check its own `/api-doc/openapi.json` for the current
+  alerts paths rather than guessing.
+- **`failed to open live lock /run/lock/standx-maker-stage2-ab.lock`** — the
+  container bind-mounted the host's `/run/lock`, which failed to open on some
+  hosts (permission/SELinux denial, host-specific). Fixed by moving to
+  container-local locks under `/opt/standx/var/lock` (see "Locks are
+  container-local by default" above); make sure
+  `/etc/standx/maker-stage2-ab.env` sets `STANDX_MAKER_LOCK_PATH` /
+  `STANDX_STAGE2_AB_LOCK_PATH` there, not under `/run/lock`.
+- **Stale image after a code/script change** — `docker compose run`/`up`
+  reuse an existing local image tag and do **not** rebuild automatically. If
+  a fix doesn't seem to take effect, rebuild explicitly:
+  `docker compose --profile ab build --no-cache` (or add `--build` to the
+  `run`/`up` command).

--- a/docs/18-maker-strategy-roadmap.md
+++ b/docs/18-maker-strategy-roadmap.md
@@ -226,6 +226,13 @@ python3 -m py_compile scripts/openobserve_dashboard.py
 [19-maker-stage2-live-ab-runbook.md](19-maker-stage2-live-ab-runbook.md)，实现证据见
 [maker-strategy-stage-2-v0-implementation-2026-07-16.md](evidence/maker-strategy-stage-2-v0-implementation-2026-07-16.md)。
 
+运维件现有两条部署路径：systemd（`deploy/systemd/standx-maker-stage2-ab.service`）与容器化
+（`deploy/docker/`，docker-compose，同一 runbook 授权门槛）。容器化路径已在 2026-07-16 完成首次
+真实部署联调，修复过三处环境问题（builder 工具链 MSRV、OpenObserve alerts API 版本迁移、
+host `/run/lock` 挂载权限 → 容器本地锁），细节见 `deploy/docker/README.md` 的 Troubleshooting。
+这只解决了部署可用性，不构成 canary 或 live A/B 证据；renewed canary 记录与 A/B 验收仍按本节
+标准和 runbook 执行，需操作员自行完成并记录。
+
 ### 目标
 
 让报价宽度和重报阈值响应短窗波动，同时保持 SIP-5A band、post-only 和 anti-flicker 约束。

--- a/docs/19-maker-stage2-live-ab-runbook.md
+++ b/docs/19-maker-stage2-live-ab-runbook.md
@@ -19,11 +19,18 @@ active inventory exit or automatic flatten.
   `adaptive_spread.enabled` and record both hashes.
 - Install `standx-maker-stage2-ab.service`, `run_maker_stage2_ab.sh`, the
   observed-run/OpenObserve tools, and a root-owned `0600`
-  `/etc/standx/maker-stage2-ab.env`.
+  `/etc/standx/maker-stage2-ab.env`. A containerized alternative to this unit
+  is available at [`deploy/docker/`](../deploy/docker/README.md)
+  (docker-compose, same authorization gate); its lock paths default to a
+  container-local directory rather than `/run/lock` — see that README before
+  using it.
 - Keep both ordinary-maker and A/B environment files on the same
   `/run/lock/standx-maker-live.lock` and
   `/run/lock/standx-maker-stage2-ab.lock` paths. A manual live process that
   cannot open those production locks must fail closed, not select another lock.
+  (This host-shared-lock requirement is specific to the systemd deployment;
+  the docker deployment's container-local locks trade away this guarantee —
+  see its README.)
 - Read current XAG symbol info and fill the three
   `STANDX_BASELINE_*` metadata values in that environment file. Blank or stale
   metadata is a gate failure; the orchestrator refuses to switch arms when


### PR DESCRIPTION
## Summary

Housekeeping after the docker deployment rollout (#309, #311, #312, #313): the docs operators actually read (`docs/19` runbook, `docs/18` roadmap, `deploy/README.md`) never mentioned it — they're all systemd-only. This PR closes that gap and records the three real issues hit during the first rollout so the next person doesn't have to rediscover them.

## Changes

- **`deploy/README.md`** / **`docs/19-maker-stage2-live-ab-runbook.md`**: link to `deploy/docker/README.md` from the existing systemd Stage 2 sections. Noted that the docker deployment's locks are container-local by default (not `/run/lock`), so the runbook's "keep both on the same `/run/lock/...` paths" requirement is systemd-specific.
- **`docs/18-maker-strategy-roadmap.md`**: records that a docker deployment path now exists and was verified end-to-end (2026-07-16) — explicitly **not** claimed as canary or live A/B evidence, since that's still an operator-run, recorded step per the runbook.
- **`deploy/docker/README.md`**: new Troubleshooting section listing the three issues actually hit in production and their fixes:
  1. `docker build` failing on `edition2024` (builder image below Rust 1.85)
  2. OpenObserve deadman alert 404 (alerts API moved to `/api/v2/{org}/alerts` in current builds)
  3. `failed to open live lock /run/lock/...` (host `/run/lock` bind-mount permission/SELinux issue → fixed via container-local locks)

  Plus the stale-image gotcha: `docker compose run`/`up` don't rebuild automatically on a code change.

## Notes for reviewer

Docs-only, no code/runtime changes. Branch created off latest `main` (post #313, merged).