### PR TITLE
stage2 A/B: extend arm to next natural flat instead of critical-stopping

### DIFF
--- a/deploy/systemd/maker-stage2-ab.env.example
+++ b/deploy/systemd/maker-stage2-ab.env.example
@@ -5,6 +5,11 @@ STANDX_SYMBOL=XAG-USD
 STANDX_STAGE2_BASELINE_CONFIG=/opt/standx/examples/maker-stage2-xag-baseline.toml
 STANDX_STAGE2_CANDIDATE_CONFIG=/opt/standx/examples/maker-stage2-xag-candidate.toml
 STANDX_STAGE2_POLL_SECONDS=15
+# Hard cap (seconds, from arm start) for an arm that stays non-flat past its
+# 2h minimum. Below this the arm extends and switches at the next natural
+# flat; past it the arm is invalidated and the service critical-stops (exit
+# 75, no auto-flatten). Default 21600 (6h). Must exceed the 7200s arm minimum.
+STANDX_STAGE2_ARM_MAX_SECONDS=21600
 STANDX_STAGE2_AB_LOCK_PATH=/run/lock/standx-maker-stage2-ab.lock
 STANDX_MAKER_LOCK_PATH=/run/lock/standx-maker-live.lock
 STANDX_LOG_DIR=/opt/standx/var/standx

--- a/docs/19-maker-stage2-live-ab-runbook.md
+++ b/docs/19-maker-stage2-live-ab-runbook.md
@@ -135,12 +135,19 @@ journalctl -u standx-maker-stage2-ab.service -f
 ```
 
 The orchestrator alternates baseline then candidate. Each arm has a unique
-`run_id/config_hash`, runs for two hours, and switches only from a flat
-position after normal maker cleanup, manifest validation, and independent
-empty-order/empty-position checks. A non-flat arm gets up to 30 extra minutes
-to return naturally to zero. If it does not, the arm is invalid, a critical
-webhook is sent, and the service exits 75 without flattening or restarting.
-Fail-safe exit, invalid manifest or failed post-check also blocks the next arm.
+`run_id/config_hash`, runs for a two-hour **minimum**, and switches only from a
+flat position after normal maker cleanup, manifest validation, and independent
+empty-order/empty-position checks. A non-flat position at the two-hour mark is a
+normal trending-market outcome, not a safety failure: the healthy maker keeps
+running and quoting (inventory bounded by `max_position`, downside by
+`stop_loss`) and the arm switches at the next natural flat. A warning webhook
+fires every 30 minutes while an arm is extended past two hours. Only an arm that
+stays non-flat past the hard cap (`STANDX_STAGE2_ARM_MAX_SECONDS`, default six
+hours from arm start) is invalidated with a critical webhook and exit 75 —
+never with an automatic flatten. Fail-safe exit, invalid manifest, failed
+post-check, a failed venue position query, or a maker that dies mid-wait also
+block the next arm. Because arms can run longer than two hours, acceptance
+balances **quote-hours** per regime rather than assuming equal wall-clock.
 
 Keep the Stage 2 state `live_ab` until valid, market-matched quote-hours include
 at least one calm and one trend window. Acceptance requires net PnL at least

--- a/scripts/run_maker_stage2_ab.sh
+++ b/scripts/run_maker_stage2_ab.sh
@@ -7,6 +7,14 @@ baseline_config="${STANDX_STAGE2_BASELINE_CONFIG:-$root/examples/maker-stage2-xa
 candidate_config="${STANDX_STAGE2_CANDIDATE_CONFIG:-$root/examples/maker-stage2-xag-candidate.toml}"
 symbol="${STANDX_SYMBOL:-XAG-USD}"
 arm_seconds=7200
+# Minimum arm length is arm_seconds. A non-flat position at that mark is a
+# normal trending-market outcome, not a safety failure, so the arm is extended
+# and switches at the next natural flat instead of critical-stopping. Only an
+# arm that stays non-flat past arm_max_seconds (the hard cap, counted from arm
+# start and inclusive of arm_seconds) escalates to critical_stop. While
+# extending, a warning fires every flat_grace_seconds so a long-running arm is
+# visible.
+arm_max_seconds="${STANDX_STAGE2_ARM_MAX_SECONDS:-21600}"
 flat_grace_seconds=1800
 poll_seconds="${STANDX_STAGE2_POLL_SECONDS:-15}"
 log_dir="${STANDX_LOG_DIR:-$root/var/standx}"
@@ -59,12 +67,17 @@ critical_stop() {
   exit 75
 }
 
-for value in "$poll_seconds"; do
+for value in "$poll_seconds" "$arm_max_seconds"; do
   [[ "$value" =~ ^[1-9][0-9]*$ ]] || {
     printf 'stage2 A/B durations must be positive integers\n' >&2
     exit 64
   }
 done
+((arm_max_seconds > arm_seconds)) || {
+  printf 'stage2 A/B arm_max_seconds (%s) must exceed arm_seconds (%s)\n' \
+    "$arm_max_seconds" "$arm_seconds" >&2
+  exit 64
+}
 [[ "$symbol" == "XAG-USD" ]] || {
   printf 'stage2 A/B is frozen to XAG-USD\n' >&2
   exit 64
@@ -159,7 +172,8 @@ notify "stage2 A/B preflight verified: orders=[] positions=[]"
 run_arm() {
   local arm="$1"
   local config="$2"
-  local config_hash run_id manifest pid status deadline grace_deadline position_status
+  local config_hash run_id manifest pid status arm_start deadline position_status
+  local hard_deadline next_extension_notice extending
   config_hash="$(sha256sum "$config" | awk '{print $1}')"
   run_id="stage2-${arm}-$(date -u +%Y%m%dT%H%M%SZ)-${config_hash:0:12}"
   manifest="$log_dir/$run_id.manifest.json"
@@ -173,7 +187,8 @@ run_arm() {
     "$standx_bin" --output json maker run "$symbol" --maker-config "$config" --live &
   pid=$!
   current_arm_pid="$pid"
-  deadline=$((SECONDS + arm_seconds))
+  arm_start=$SECONDS
+  deadline=$((arm_start + arm_seconds))
   while ((SECONDS < deadline)); do
     if ! kill -0 "$pid" 2>/dev/null; then
       wait "$pid"
@@ -184,7 +199,15 @@ run_arm() {
     sleep "$poll_seconds"
   done
 
-  grace_deadline=$((SECONDS + flat_grace_seconds))
+  # Past the arm_seconds minimum: switch at the next natural flat. Staying
+  # non-flat is a normal trending-market outcome, so the healthy maker keeps
+  # running and quoting (inventory bounded by max_position, downside by
+  # stop_loss) until it flattens — not a critical_stop. Escalate only on a
+  # genuinely unsafe state (position query fails, maker dies) or when the arm
+  # stays non-flat past the arm_max_seconds hard cap.
+  hard_deadline=$((arm_start + arm_max_seconds))
+  next_extension_notice=$SECONDS
+  extending=0
   while true; do
     position_state
     position_status=$?
@@ -203,14 +226,22 @@ run_arm() {
       invalidate_arm "arm exited while awaiting natural flat"
       critical_stop "arm=$arm exited while waiting for natural flat (status=$status run_id=$run_id)"
     fi
-    if ((SECONDS >= grace_deadline)); then
+    if ((SECONDS >= hard_deadline)); then
       kill -TERM "$pid" 2>/dev/null || true
       wait "$pid" 2>/dev/null || true
-      invalidate_arm "position remained nonzero beyond flat grace"
-      critical_stop "arm=$arm remained non-flat for ${flat_grace_seconds}s (run_id=$run_id invalid)"
+      invalidate_arm "position stayed nonzero past the hard arm cap"
+      critical_stop "arm=$arm stayed non-flat past ${arm_max_seconds}s hard cap (run_id=$run_id invalid)"
+    fi
+    if ((SECONDS >= next_extension_notice)); then
+      extending=1
+      notify "stage2 A/B arm=$arm past its ${arm_seconds}s window but not flat; extending and will switch at the next natural flat (hard cap ${arm_max_seconds}s, run_id=$run_id)" warning
+      next_extension_notice=$((SECONDS + flat_grace_seconds))
     fi
     sleep "$poll_seconds"
   done
+  if ((extending == 1)); then
+    notify "stage2 A/B arm=$arm reached natural flat after extension; proceeding to switch (run_id=$run_id)"
+  fi
 
   kill -TERM "$pid" 2>/dev/null || true
   wait "$pid"


### PR DESCRIPTION
## Problem

First live A/B run hit this: the baseline arm (static strategy, `inventory_exit` disabled) drifted to `-0.03` in a trending market and never returned to flat within the 30-minute grace window, so the orchestrator invalidated the arm, sent a critical webhook, exited 75, and blocked the A/B — requiring manual position handling.

This is **structural, not a tuning problem**. A passive maker with no active flatten has no bounded-time guarantee of returning to flat in a one-sided market (the reducing side simply doesn't fill when price keeps moving away), while the switch protocol demanded *exactly flat* at a hard 30-minute clock. Every sustained trend trips it. The `-0.03` was only 15% of `max_position` — inventory wasn't running away; the rigid "flat at a fixed clock boundary" requirement was the issue.

## Fix

Orchestrator-only. **No strategy change, no auto-flatten, no new authorization, no change to the "never automatically flatten" posture.**

`arm_seconds` (2h) becomes a **minimum**. A non-flat position at that mark is treated as a normal market outcome: the healthy maker keeps running and quoting — inventory still bounded by `max_position`, downside by `stop_loss` (both already-accepted per-arm risk) — and the arm switches at the **next natural flat**. A warning webhook fires every `flat_grace_seconds` (30m) while extended so a long-running arm stays visible. Only an arm still non-flat past a hard cap (`STANDX_STAGE2_ARM_MAX_SECONDS`, default 6h from arm start) is invalidated and critical-stops (exit 75). The genuinely-unsafe escalations — position query fails, maker dies mid-wait — are unchanged.

Because arms can now exceed 2h, acceptance balances **quote-hours per regime** rather than assuming equal wall-clock (already the roadmap's stated methodology).

## Why not the alternatives

- **Auto reduce-only flatten at the boundary**: cleanest for A/B methodology but reverses the deliberate "never auto-flatten" decision and needs new authorization — rejected for Stage 2.
- **Enable active inventory exit**: a Stage 5 feature, explicitly out of the current authorization, and would contaminate the adaptive-spread experiment.
- **Tune skew / max_position / grace**: palliative — no amount of skew flattens in a genuine trend; a longer grace just delays the same critical-stop.

## Testing

No bash test harness exists in-repo for the orchestrator, so I extracted the **real** `run_arm()` into a stubbed harness (controllable `position_state` queue + simulated clock via a stubbed `sleep`) and drove four scenarios:

| scenario | outcome |
|---|---|
| flat immediately at 2h | normal switch, no extension |
| non-flat then flattens before hard cap | extends (warnings fire), then switches — **no critical-stop** |
| never flat | extends to hard cap, then critical-stop |
| position query error mid-wait | critical-stop (unsafe path preserved) |

Confirmed the extend-then-switch case emits the extension warnings and the "reached natural flat after extension" notice and completes the switch. `bash -n` passes.

## Docs

- `docs/19-maker-stage2-live-ab-runbook.md`: the "Two-hour automatic A/B" section rewritten for the 2h-minimum + extend-to-flat + hard-cap behavior and quote-hour balancing.
- `deploy/systemd/maker-stage2-ab.env.example`: documents `STANDX_STAGE2_ARM_MAX_SECONDS`.

## Reviewer notes

Branch off latest `main`. This changes unattended live-trading behavior; the direction (extend-to-flat, fall back to critical-stop at a hard cap) was chosen deliberately over auto-flatten. Note that in a persistent trend one arm can accumulate more quote-hours than the other until the trend ends — that's expected and handled in post-hoc analysis, bounded by the hard cap.