### PR TITLE
stage2 A/B: wind-down arm switching + HYPE-USD preparation

### DIFF
--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -210,6 +210,8 @@ pub(super) async fn maker_cycle(
         max_divergence_bps,
         inventory_exit_pct,
         inventory_exit_qty,
+        wind_down,
+        qty_tolerance,
         session_started_at,
         run_order_prefix,
         starting_position,
@@ -531,6 +533,8 @@ pub(super) async fn maker_cycle(
             active_exit_enabled: live,
             inventory_exit_pct,
             inventory_exit_qty,
+            wind_down,
+            qty_tolerance,
         },
         halted,
     );

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -545,15 +545,16 @@ pub(super) async fn maker_cycle(
     if raw_inventory_exit.is_none() {
         *inventory_exit_pending = false;
     }
-    if raw_inventory_exit.is_some() && *inventory_exit_pending {
-        return Err(anyhow::anyhow!(
-            "inventory exit is still awaiting venue confirmation; refusing to submit another"
-        ));
-    }
+    // A still-unconfirmed exit must never be duplicated, but waiting for its
+    // venue confirmation is a normal cycle outcome rather than a failure:
+    // suppress all new order work for this cycle and let the cycle complete
+    // so the cycle_summary sequence stays gap-free for run-manifest
+    // validation.
+    let exit_awaiting_confirmation = raw_inventory_exit.is_some() && *inventory_exit_pending;
 
     let create_orders_allowed = market_data_mode == maker::MarketDataMode::Active
         && order_creation_allowed(live, rest_position_recheck_pending);
-    let inventory_exit = if create_orders_allowed {
+    let inventory_exit = if create_orders_allowed && !exit_awaiting_confirmation {
         plan.inventory_exit
     } else {
         None
@@ -566,6 +567,9 @@ pub(super) async fn maker_cycle(
         .actions
         .into_iter()
         .filter(|action| match action {
+            // While awaiting exit confirmation this cycle performs no order
+            // work at all: no duplicate exit, no quote churn.
+            _ if exit_awaiting_confirmation => false,
             Action::Place(_) if !create_orders_allowed => false,
             Action::Place(q)
                 if live

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -131,6 +131,11 @@ pub(super) struct CycleRequest<'a> {
     pub(super) max_divergence_bps: f64,
     pub(super) inventory_exit_pct: f64,
     pub(super) inventory_exit_qty: f64,
+    /// Latched supervisor wind-down request (SIGUSR1 from the A/B
+    /// orchestrator): stop quoting and flatten via reduce-only exits.
+    pub(super) wind_down: bool,
+    /// Venue-quantity tolerance; positions at or below it count as flat.
+    pub(super) qty_tolerance: f64,
     pub(super) session_started_at: i64,
     pub(super) run_order_prefix: &'a str,
     pub(super) starting_position: f64,

--- a/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
@@ -641,6 +641,30 @@ impl MakerRuntime {
                                 false,
                             )
                         .await;
+                    } else if exit_pending_before && exit_pending_after {
+                        // The in-flight exit is still awaiting venue
+                        // confirmation. The cycle itself now completes
+                        // normally (cycle_summary stays gap-free for
+                        // run-manifest validation); keep the historical
+                        // notification wording so downstream consumers see
+                        // the same contract as the pre-fix refused cycle.
+                        notifier
+                            .risk(
+                                RiskNotice {
+                                    kind: "inventory_exit",
+                                    severity: "warning",
+                                    event: "failed",
+                                    message: "inventory exit cycle failed: inventory exit is still awaiting venue confirmation; refusing to submit another",
+                                    symbol,
+                                    cycle,
+                                    position_before: None,
+                                    position_after: Some(self.loop_state.ledger.expected_position),
+                                    expected: Some(self.loop_state.ledger.expected_position),
+                                    observed: None,
+                                },
+                                false,
+                            )
+                        .await;
                     }
                     if !args.no_ws && self.market.last_src != Some(src) {
                         match src {

--- a/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
@@ -103,6 +103,19 @@ impl MakerRuntime {
             let breaker_halted_before = self.loop_state.breaker.halted();
             let recovery_cycle = self.loop_state.next_cycle_is_recovery;
             let market_paused_before_cycle = self.market.health.is_degraded();
+            // Latch a supervisor wind-down request (SIGUSR1). Once set, the
+            // planner stops quoting and flattens via reduce-only exits.
+            if !self.loop_state.wind_down && *self.wind_down_rx.borrow_and_update() {
+                self.loop_state.wind_down = true;
+                notifier
+                    .lifecycle(
+                        "wind_down",
+                        "wind-down requested: quoting stopped, flattening via reduce-only exits",
+                        symbol,
+                        false,
+                    )
+                    .await;
+            }
             let cycle_work_token = match take_cycle_work(&mut self.recovery.runtime_state) {
                 Ok(Some(token)) => token,
                 Ok(None) => return Err(LoopDirective::Restart),
@@ -215,6 +228,8 @@ impl MakerRuntime {
                         max_divergence_bps: args.max_divergence_bps,
                         inventory_exit_pct: args.inventory_exit_pct,
                         inventory_exit_qty: args.inventory_exit_qty,
+                        wind_down: self.loop_state.wind_down,
+                        qty_tolerance,
                         session_started_at,
                         run_order_prefix,
                         starting_position,

--- a/crates/standx-cli/src/commands/maker/runtime/state.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/state.rs
@@ -29,6 +29,9 @@ pub(super) struct RuntimeCounters {
 pub(super) struct RuntimeLoopState {
     pub(super) resting: Vec<RestingQuote>,
     pub(super) inventory_exit_pending: bool,
+    /// Latched supervisor wind-down request (SIGUSR1): stop quoting and
+    /// flatten via reduce-only exits. Sticky once set.
+    pub(super) wind_down: bool,
     pub(super) ledger: MakerLedger,
     pub(super) performance_started: std::time::Instant,
     pub(super) performance_epoch_ms: i64,
@@ -80,6 +83,7 @@ pub(super) struct MakerRuntime {
     pub(super) lifecycle: RuntimeLifecycleState,
     pub(super) live_session: Option<LiveSession>,
     pub(super) ctrl_c_rx: tokio::sync::watch::Receiver<bool>,
+    pub(super) wind_down_rx: tokio::sync::watch::Receiver<bool>,
 }
 
 pub(super) enum LoopDirective {
@@ -155,6 +159,7 @@ impl MakerRuntime {
         // default disposition with no maker cleanup, leaving resting orders
         // on the venue (observed on the 2026-07-17 stage-2 arm boundary).
         let (ctrl_c_tx, ctrl_c_rx) = tokio::sync::watch::channel(false);
+        let (wind_down_tx, wind_down_rx) = tokio::sync::watch::channel(false);
         tokio::spawn(async move {
             #[cfg(unix)]
             {
@@ -164,12 +169,25 @@ impl MakerRuntime {
                 let mut sigterm =
                     tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
                         .expect("failed to install SIGTERM handler");
+                // SIGUSR1 (from the A/B orchestrator at the arm deadline)
+                // requests wind-down: stop quoting and flatten. It must be
+                // registered unconditionally — an unhandled SIGUSR1 kills the
+                // process by default.
+                let mut sigusr1 =
+                    tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())
+                        .expect("failed to install SIGUSR1 handler");
                 loop {
                     tokio::select! {
-                        _ = sigint.recv() => {}
-                        _ = sigterm.recv() => {}
+                        _ = sigint.recv() => {
+                            let _ = ctrl_c_tx.send(true);
+                        }
+                        _ = sigterm.recv() => {
+                            let _ = ctrl_c_tx.send(true);
+                        }
+                        _ = sigusr1.recv() => {
+                            let _ = wind_down_tx.send(true);
+                        }
                     }
-                    let _ = ctrl_c_tx.send(true);
                 }
             }
             #[cfg(not(unix))]
@@ -198,6 +216,7 @@ impl MakerRuntime {
             loop_state: RuntimeLoopState {
                 resting: Vec::new(),
                 inventory_exit_pending: false,
+                wind_down: false,
                 ledger,
                 performance_started,
                 performance_epoch_ms,
@@ -239,6 +258,7 @@ impl MakerRuntime {
             },
             live_session,
             ctrl_c_rx,
+            wind_down_rx,
         })
     }
 }

--- a/crates/standx-cli/src/commands/maker/runtime/state.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/state.rs
@@ -149,10 +149,34 @@ impl MakerRuntime {
 
         // Tokio installs a process-wide SIGINT handler on the first call. Keep
         // one long-lived task and latch presses so no phase can lose Ctrl+C.
+        // Supervisors (systemd, docker stop, the A/B orchestrator via the
+        // observed wrapper) stop the maker with SIGTERM, which must take the
+        // same graceful path: without a handler the process dies by the
+        // default disposition with no maker cleanup, leaving resting orders
+        // on the venue (observed on the 2026-07-17 stage-2 arm boundary).
         let (ctrl_c_tx, ctrl_c_rx) = tokio::sync::watch::channel(false);
         tokio::spawn(async move {
-            while tokio::signal::ctrl_c().await.is_ok() {
-                let _ = ctrl_c_tx.send(true);
+            #[cfg(unix)]
+            {
+                let mut sigint =
+                    tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+                        .expect("failed to install SIGINT handler");
+                let mut sigterm =
+                    tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                        .expect("failed to install SIGTERM handler");
+                loop {
+                    tokio::select! {
+                        _ = sigint.recv() => {}
+                        _ = sigterm.recv() => {}
+                    }
+                    let _ = ctrl_c_tx.send(true);
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                while tokio::signal::ctrl_c().await.is_ok() {
+                    let _ = ctrl_c_tx.send(true);
+                }
             }
         });
 

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -176,6 +176,29 @@ pub(crate) fn inventory_exit_plan(
     })
 }
 
+/// Wind-down exit: flatten any position larger than the quantity tolerance in
+/// one reduce-only request, ignoring the configured trigger thresholds. The
+/// whole residual is taken at once because session position caps are small by
+/// design. Like [`inventory_exit_plan`] this is only a plan — the caller
+/// cancels stale quotes and submits the reduce-only order separately.
+pub(crate) fn wind_down_exit_plan(position: f64, qty_tolerance: f64) -> Option<InventoryExit> {
+    if !position.is_finite() || !qty_tolerance.is_finite() || qty_tolerance < 0.0 {
+        return None;
+    }
+    let abs_position = position.abs();
+    if abs_position <= qty_tolerance {
+        return None;
+    }
+    Some(InventoryExit {
+        side: if position > 0.0 {
+            OrderSide::Sell
+        } else {
+            OrderSide::Buy
+        },
+        qty: abs_position,
+    })
+}
+
 /// A quote currently resting (a real order in live mode, simulated in paper
 /// mode).
 #[derive(Debug, Clone, PartialEq)]
@@ -576,6 +599,13 @@ pub struct CycleInput<'a> {
     pub active_exit_enabled: bool,
     pub inventory_exit_pct: f64,
     pub inventory_exit_qty: f64,
+    /// Supervisor-requested wind-down (e.g. an A/B arm past its scheduled
+    /// window): never place new quotes again and flatten any residual
+    /// position through the reduce-only exit path, ignoring the configured
+    /// exit thresholds. Converges to flat instead of re-accumulating.
+    pub wind_down: bool,
+    /// Positions at or below this magnitude count as flat during wind-down.
+    pub qty_tolerance: f64,
 }
 
 /// A deterministic plan for the executor to apply after a successful preflight.
@@ -598,16 +628,27 @@ pub struct CyclePlan {
 /// The caller owns transport state (pending HTTP submissions and exit
 /// acknowledgements) and must run [`preflight_cycle`] first. This function
 /// deliberately cannot perform I/O.
+///
+/// With `input.wind_down` set (a supervisor requesting session end, e.g. an
+/// A/B arm past its scheduled window) the plan converges to flat: no new
+/// quotes are ever desired — even once the position reaches zero — and any
+/// residual position above `input.qty_tolerance` yields a reduce-only exit
+/// plan regardless of the configured exit thresholds.
 pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> CyclePlan {
     let market_active = input.market_data_mode == MarketDataMode::Active;
-    let requested_inventory_exit = (market_active && input.active_exit_enabled)
+    let requested_inventory_exit = (market_active
+        && (input.active_exit_enabled || input.wind_down))
         .then(|| {
-            inventory_exit_plan(
-                input.position,
-                cfg.max_position,
-                input.inventory_exit_pct,
-                input.inventory_exit_qty,
-            )
+            if input.wind_down {
+                wind_down_exit_plan(input.position, input.qty_tolerance)
+            } else {
+                inventory_exit_plan(
+                    input.position,
+                    cfg.max_position,
+                    input.inventory_exit_pct,
+                    input.inventory_exit_qty,
+                )
+            }
         })
         .flatten();
 
@@ -616,7 +657,9 @@ pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> Cyc
     let inventory_exit = (!halted && market_active)
         .then_some(requested_inventory_exit.clone())
         .flatten();
-    let desired = if halted || !market_active || inventory_exit.is_some() {
+    // Wind-down never places new quotes, even once flat: the session must
+    // converge to flat instead of re-accumulating inventory.
+    let desired = if halted || !market_active || inventory_exit.is_some() || input.wind_down {
         Vec::new()
     } else {
         let raw = compute_desired_quotes(
@@ -1918,6 +1961,8 @@ mod tests {
             active_exit_enabled: true,
             inventory_exit_pct: 80.0,
             inventory_exit_qty: 0.01,
+            wind_down: false,
+            qty_tolerance: 0.0005,
         };
 
         let exit_plan = plan_cycle(&c, input, false);
@@ -1970,6 +2015,8 @@ mod tests {
                 active_exit_enabled: false,
                 inventory_exit_pct: 0.0,
                 inventory_exit_qty: 0.0,
+                wind_down: false,
+                qty_tolerance: 0.0005,
             },
             false,
         );
@@ -2008,6 +2055,8 @@ mod tests {
                 active_exit_enabled: true,
                 inventory_exit_pct: 80.0,
                 inventory_exit_qty: 0.01,
+                wind_down: false,
+                qty_tolerance: 0.0005,
             },
             false,
         );
@@ -2126,5 +2175,134 @@ mod tests {
         assert_eq!(a.len(), 1);
         assert_eq!(a[0].kind, "margin");
         assert!(a[0].firing);
+    }
+
+    // 35. Wind-down: any residual position yields a full reduce-only exit
+    // plan and no new quotes, even with configured exits fully disabled
+    // (the frozen live configs). A vol halt suppresses the taker exit but
+    // never the quote suppression.
+    #[test]
+    fn wind_down_flattens_residual_and_stops_quoting() {
+        let c = cfg();
+        let resting = vec![
+            resting(OrderSide::Buy, 0, 99.9, 100.0),
+            resting(OrderSide::Sell, 0, 100.1, 100.0),
+        ];
+        let input = CycleInput {
+            cycle: 7,
+            market: MarketSnapshot {
+                mark: 100.0,
+                best_bid: Some(99.9),
+                best_ask: Some(100.1),
+            },
+            position: -0.02,
+            resting: &resting,
+            pending_slots: &[],
+            market_data_mode: MarketDataMode::Active,
+            active_exit_enabled: true,
+            inventory_exit_pct: 0.0,
+            inventory_exit_qty: 0.0,
+            wind_down: true,
+            qty_tolerance: 0.0005,
+        };
+        let plan = plan_cycle(&c, input, false);
+        assert_eq!(
+            plan.requested_inventory_exit,
+            Some(InventoryExit {
+                side: OrderSide::Buy,
+                qty: 0.02,
+            })
+        );
+        assert_eq!(plan.inventory_exit, plan.requested_inventory_exit);
+        assert!(plan
+            .actions
+            .iter()
+            .any(|action| matches!(action, Action::Cancel { .. })));
+        assert!(!plan
+            .actions
+            .iter()
+            .any(|action| matches!(action, Action::Place(_))));
+
+        let halted = plan_cycle(&c, input, true);
+        assert_eq!(halted.inventory_exit, None);
+        assert!(!halted
+            .actions
+            .iter()
+            .any(|action| matches!(action, Action::Place(_))));
+    }
+
+    // 36. Wind-down keeps quotes off even when already flat, so inventory
+    // cannot re-accumulate while the supervisor waits to switch.
+    #[test]
+    fn wind_down_flat_still_suppresses_quotes() {
+        let c = cfg();
+        let plan = plan_cycle(
+            &c,
+            CycleInput {
+                cycle: 8,
+                market: MarketSnapshot {
+                    mark: 100.0,
+                    best_bid: Some(99.9),
+                    best_ask: Some(100.1),
+                },
+                position: 0.0,
+                resting: &[],
+                pending_slots: &[],
+                market_data_mode: MarketDataMode::Active,
+                active_exit_enabled: true,
+                inventory_exit_pct: 0.0,
+                inventory_exit_qty: 0.0,
+                wind_down: true,
+                qty_tolerance: 0.0005,
+            },
+            false,
+        );
+        assert_eq!(plan.requested_inventory_exit, None);
+        assert_eq!(plan.inventory_exit, None);
+        assert!(plan.actions.is_empty());
+    }
+
+    // 37. Wind-down overrides the configured exit threshold (a residual
+    // below the enabled trigger still exits, both sides) and treats
+    // positions at or below the quantity tolerance as flat.
+    #[test]
+    fn wind_down_overrides_threshold_and_honors_tolerance() {
+        let c = cfg();
+        let mk = |position: f64| CycleInput {
+            cycle: 9,
+            market: MarketSnapshot {
+                mark: 100.0,
+                best_bid: Some(99.9),
+                best_ask: Some(100.1),
+            },
+            position,
+            resting: &[],
+            pending_slots: &[],
+            market_data_mode: MarketDataMode::Active,
+            active_exit_enabled: true,
+            inventory_exit_pct: 80.0,
+            inventory_exit_qty: 0.01,
+            wind_down: true,
+            qty_tolerance: 0.0005,
+        };
+        // 0.02 is below the configured 80%-of-max trigger (0.04): the
+        // configured path stays inactive, wind-down exits everything.
+        let long = plan_cycle(&c, mk(0.02), false);
+        assert_eq!(
+            long.inventory_exit,
+            Some(InventoryExit {
+                side: OrderSide::Sell,
+                qty: 0.02,
+            })
+        );
+        assert_eq!(plan_cycle(&c, mk(0.0005), false).inventory_exit, None);
+        assert_eq!(plan_cycle(&c, mk(-0.0005), false).inventory_exit, None);
+        assert_eq!(
+            plan_cycle(&c, mk(-0.0006), false).inventory_exit,
+            Some(InventoryExit {
+                side: OrderSide::Buy,
+                qty: 0.0006,
+            })
+        );
     }
 }

--- a/crates/standx-maker/src/replay.rs
+++ b/crates/standx-maker/src/replay.rs
@@ -163,6 +163,8 @@ pub fn run_replay(
                             active_exit_enabled: settings.active_exit_enabled,
                             inventory_exit_pct: settings.inventory_exit_pct,
                             inventory_exit_qty: settings.inventory_exit_qty,
+                            wind_down: false,
+                            qty_tolerance: 0.0005,
                         },
                         preflight.halted,
                     )

--- a/crates/standx-maker/src/volatility.rs
+++ b/crates/standx-maker/src/volatility.rs
@@ -525,6 +525,8 @@ mod tests {
                 active_exit_enabled: false,
                 inventory_exit_pct: 0.0,
                 inventory_exit_qty: 0.0,
+                wind_down: false,
+                qty_tolerance: 0.0005,
             },
             false,
         );

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -59,3 +59,27 @@ services:
       - ${STANDX_CREDENTIALS_FILE:-/opt/standx/state/standx/credentials.enc}:/opt/standx/state/standx/credentials.enc:ro
       # Run evidence (NDJSON + manifests) must outlive the container.
       - ${STANDX_LOG_DIR_HOST:-/opt/standx/var/standx}:/opt/standx/var/standx
+
+  # HYPE-USD variant of the stage2 A/B above. Same image, same safety model,
+  # separate container name, env file, and lock paths (see
+  # deploy/systemd/maker-stage2-hype-ab.env.example). NEVER run this profile
+  # at the same time as "ab": maker locks are container-local, so two A/B
+  # containers would not exclude each other on the shared account. Stop the
+  # XAG service, verify orders=[] positions=[], then start this one.
+  stage2-ab-hype:
+    profiles: ["ab-hype"]
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile
+    image: standx-stage2-ab:latest
+    container_name: standx-maker-stage2-ab-hype
+    restart: "no"
+    init: true
+    stop_signal: SIGTERM
+    stop_grace_period: 120s
+    network_mode: host
+    env_file:
+      - /etc/standx/maker-stage2-hype-ab.env
+    volumes:
+      - ${STANDX_CREDENTIALS_FILE:-/opt/standx/state/standx/credentials.enc}:/opt/standx/state/standx/credentials.enc:ro
+      - ${STANDX_LOG_DIR_HOST:-/opt/standx/var/standx}:/opt/standx/var/standx

--- a/deploy/systemd/maker-stage2-ab.env.example
+++ b/deploy/systemd/maker-stage2-ab.env.example
@@ -6,9 +6,10 @@ STANDX_STAGE2_BASELINE_CONFIG=/opt/standx/examples/maker-stage2-xag-baseline.tom
 STANDX_STAGE2_CANDIDATE_CONFIG=/opt/standx/examples/maker-stage2-xag-candidate.toml
 STANDX_STAGE2_POLL_SECONDS=15
 # Hard cap (seconds, from arm start) for an arm that stays non-flat past its
-# 2h minimum. Below this the arm extends and switches at the next natural
-# flat; past it the arm is invalidated and the service critical-stops (exit
-# 75, no auto-flatten). Default 21600 (6h). Must exceed the 7200s arm minimum.
+# 2h minimum. At the 2h mark the maker is signaled into wind-down (SIGUSR1):
+# it stops quoting and flattens via reduce-only market exits. Past the hard
+# cap the arm is invalidated and the service critical-stops (exit 75, no
+# auto-flatten). Default 21600 (6h). Must exceed the 7200s arm minimum.
 STANDX_STAGE2_ARM_MAX_SECONDS=21600
 STANDX_STAGE2_AB_LOCK_PATH=/run/lock/standx-maker-stage2-ab.lock
 STANDX_MAKER_LOCK_PATH=/run/lock/standx-maker-live.lock

--- a/deploy/systemd/maker-stage2-hype-ab.env.example
+++ b/deploy/systemd/maker-stage2-hype-ab.env.example
@@ -10,6 +10,10 @@ STANDX_SYMBOL=HYPE-USD
 STANDX_STAGE2_BASELINE_CONFIG=/opt/standx/examples/maker-stage2-hype-baseline.toml
 STANDX_STAGE2_CANDIDATE_CONFIG=/opt/standx/examples/maker-stage2-hype-candidate.toml
 STANDX_STAGE2_POLL_SECONDS=15
+# Arm length in seconds (default 7200 = 2h). At this mark the maker is
+# signaled into wind-down (SIGUSR1). Shortened to 1800 for the 2026-07-17
+# fix-validation rerun; restore 7200 for the standard two-hour A/B.
+STANDX_STAGE2_ARM_SECONDS=1800
 # Hard cap (seconds, from arm start) for an arm that stays non-flat past its
 # 2h minimum. At the 2h mark the maker is signaled into wind-down (SIGUSR1):
 # it stops quoting and flattens via reduce-only market exits. Past the hard

--- a/deploy/systemd/maker-stage2-hype-ab.env.example
+++ b/deploy/systemd/maker-stage2-hype-ab.env.example
@@ -1,0 +1,39 @@
+# Copy to /etc/standx/maker-stage2-hype-ab.env, edit secrets, then chmod 600.
+#
+# HYPE-USD stage2 A/B. Run SEQUENTIALLY with the XAG A/B, never in parallel:
+# maker locks are container-local, so two A/B containers would not exclude
+# each other on the shared account. Distinct lock paths below only prevent
+# collisions with stale XAG state, not concurrent trading.
+STANDX_INSTALL_ROOT=/opt/standx
+STANDX_BIN=/opt/standx/bin/standx
+STANDX_SYMBOL=HYPE-USD
+STANDX_STAGE2_BASELINE_CONFIG=/opt/standx/examples/maker-stage2-hype-baseline.toml
+STANDX_STAGE2_CANDIDATE_CONFIG=/opt/standx/examples/maker-stage2-hype-candidate.toml
+STANDX_STAGE2_POLL_SECONDS=15
+# Hard cap (seconds, from arm start) for an arm that stays non-flat past its
+# 2h minimum. At the 2h mark the maker is signaled into wind-down (SIGUSR1):
+# it stops quoting and flattens via reduce-only market exits. Past the hard
+# cap the arm is invalidated and the service critical-stops (exit 75, no
+# auto-flatten). Default 21600 (6h). Must exceed the 7200s arm minimum.
+STANDX_STAGE2_ARM_MAX_SECONDS=21600
+# Under systemd use /run/lock/... instead of /opt/standx/var/lock/...
+STANDX_STAGE2_AB_LOCK_PATH=/opt/standx/var/lock/standx-maker-stage2-ab-hype.lock
+STANDX_MAKER_LOCK_PATH=/opt/standx/var/lock/standx-maker-live-hype.lock
+STANDX_LOG_DIR=/opt/standx/var/standx
+# From the 2026-07-17 symbol-info read; re-verify with a fresh
+# `standx -o json market symbols` before enabling — blank or stale values
+# make manifest validation fail closed and prevent an arm switch.
+STANDX_BASELINE_PRICE_TICK_DECIMALS=3
+STANDX_BASELINE_QTY_TICK_DECIMALS=2
+STANDX_BASELINE_MIN_ORDER_QTY=0.1
+STANDX_ENABLE_LIVE_MAKER=1
+OPENOBSERVE_AUTO_UPLOAD=1
+OPENOBSERVE_URL=http://127.0.0.1:5080
+OPENOBSERVE_ORG=default
+OPENOBSERVE_STREAM=standx_maker
+OPENOBSERVE_USER=standx@example.com
+OPENOBSERVE_PASSWORD='ReplaceMe-123!'
+OPENOBSERVE_ALERT_WEBHOOK=https://hooks.example.com/services/REPLACE
+OPENOBSERVE_ALERT_MINUTES=3
+STANDX_SUPERVISOR_WEBHOOK=https://hooks.example.com/services/REPLACE
+STANDX_SUPERVISOR_WEBHOOK_FORMAT=slack

--- a/docs/19-maker-stage2-live-ab-runbook.md
+++ b/docs/19-maker-stage2-live-ab-runbook.md
@@ -137,17 +137,25 @@ journalctl -u standx-maker-stage2-ab.service -f
 The orchestrator alternates baseline then candidate. Each arm has a unique
 `run_id/config_hash`, runs for a two-hour **minimum**, and switches only from a
 flat position after normal maker cleanup, manifest validation, and independent
-empty-order/empty-position checks. A non-flat position at the two-hour mark is a
-normal trending-market outcome, not a safety failure: the healthy maker keeps
-running and quoting (inventory bounded by `max_position`, downside by
-`stop_loss`) and the arm switches at the next natural flat. A warning webhook
-fires every 30 minutes while an arm is extended past two hours. Only an arm that
-stays non-flat past the hard cap (`STANDX_STAGE2_ARM_MAX_SECONDS`, default six
-hours from arm start) is invalidated with a critical webhook and exit 75 —
-never with an automatic flatten. Fail-safe exit, invalid manifest, failed
-post-check, a failed venue position query, or a maker that dies mid-wait also
-block the next arm. Because arms can run longer than two hours, acceptance
-balances **quote-hours** per regime rather than assuming equal wall-clock.
+empty-order/empty-position checks. At the two-hour mark the orchestrator
+signals the arm with `SIGUSR1`, latching maker **wind-down**: the maker stops
+quoting for good and flattens any residual position via reduce-only market
+exits (bounded, deterministic cost — spread plus taker fee on the residual),
+so the arm should reach flat within a few cycles. A warning webhook fires
+every 30 minutes while an arm is not yet flat past two hours, and the signal
+is re-sent with each warning. Only an arm that stays non-flat past the hard
+cap (`STANDX_STAGE2_ARM_MAX_SECONDS`, default six hours from arm start — i.e.
+a stalled wind-down) is invalidated with a critical webhook and exit 75 —
+never with an automatic flatten beyond the reduce-only exits. Fail-safe exit,
+invalid manifest, failed post-check, a failed venue position query, or a maker
+that dies mid-wait also block the next arm. Arms now run close to two hours
+plus a short wind-down, but acceptance still balances **quote-hours** per
+regime rather than assuming equal wall-clock.
+
+Deployment constraint: the orchestrator, the observed wrapper, and the maker
+binary must ship in the **same image**. `SIGUSR1` sent to a binary built
+before wind-down support terminates it (default disposition), so never pair a
+new orchestrator with an older maker image.
 
 Keep the Stage 2 state `live_ab` until valid, market-matched quote-hours include
 at least one calm and one trend window. Acceptance requires net PnL at least

--- a/docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md
+++ b/docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md
@@ -328,3 +328,54 @@ closure. Replaces extend-to-flat quoting with a latched **wind-down**:
   binary kills it.
 - Status: implemented and verified offline; NOT yet committed (awaiting
   operator approval), not yet deployed.
+
+### Wind-down deployed; HYPE A/B #1 incident and cycle_summary fix — 2026-07-17T10:4x–15:1xZ
+
+Committed as ba60b6a + 08c08ed (PR #316, exp -> main). Docker image rebuilt
+from 08c08ed (build-time strategy_source_clean gate passed).
+
+- 10:44Z XAG A/B restarted (pre-checks: venue flat, token TTL 166h — the
+  09:04Z failure was server-side session invalidation, not JWT expiry).
+  Arm 1 healthy; operator then redirected to HYPE; XAG container stopped
+  cleanly 10:4xZ (Exited 0, venue flat).
+- HYPE bring-up: `/etc/standx/maker-stage2-hype-ab.env` installed (venue
+  metadata re-verified live: price_tick=3, qty_tick=2, min_order=0.1).
+  ws-command-canary PASS (full create/cancel chain, order 11639733982);
+  controlled-disconnect drill PASS (frozen -> cleanup empty -> fail-safe
+  exit 75); canary manifest validated (log sha256 1177c1f3... matches).
+- 10:52Z HYPE A/B #1 started. Baseline arm ran the full 2h (34+ fills,
+  PnL -0.25). 12:52Z SIGUSR1 wind-down: quotes pulled, residual +0.2
+  flattened via reduce-only market exit @59.735, position -> 0.0, maker
+  exit 0. **Wind-down's first live exercise: flatten worked exactly as
+  designed.**
+- BUT the orchestrator then critical-stopped (exit 75): the exit order
+  spent one cycle awaiting venue confirmation, that cycle aborted via the
+  duplicate-exit guard BEFORE emitting cycle_summary, and the manifest
+  gate (correctly, fail-closed) failed `cycle_sequence_complete`
+  (`missing_cycles=[2663]`, 2668/2669 present, otherwise fully eligible).
+  Arm 1 data void; arm 2 never ran. Venue verified flat.
+- Root cause: `cycle.rs` treated "exit still awaiting confirmation" as a
+  hard cycle error, skipping the summary emission. Fix (2db6106): the
+  cycle now completes with zero order work (identical execution
+  semantics — no duplicate exit, no quote churn) and emits its summary;
+  the historical `inventory_exit/failed` notification is preserved
+  byte-identical on the success path. Also afbb695 makes arm_seconds
+  env-configurable (`STANDX_STAGE2_ARM_SECONDS`, default 7200 unchanged).
+  Offline gates green; validate-only + negative-path checks pass.
+- 13:53Z HYPE A/B #2 (30-min arms, operator-directed validation rerun)
+  on image afbb695. Arm 1 baseline: wind-down at 14:23Z with residual
+  +0.2 — flatten @60.392, the awaiting-confirmation cycle (967) emitted
+  its summary, manifest `baseline_eligible=True`, `missing_cycles=[]`
+  (949 cycles / 1821s). Arm 2 candidate: wind-down at 14:53Z already
+  flat, clean stop, manifest `eligible=True`, `missing_cycles=[]`
+  (750 cycles / 1820s). Both switch styles (flatten / already-flat) PASS.
+- Operator stopped the run 15:08Z (SIGTERM, Exited 0). Arm 3 (baseline
+  #2, 371 cycles, void) had residual +0.3 HYPE long; orders=[] but
+  position non-flat. Per operator authorization, flattened via host CLI
+  reduce-only market sell 0.3 (order f8be1140-5830-42d1-a29c-4d0c69806a32);
+  post-check orders=[] positions=[]. Monitoring cron 23033b6b deleted.
+- Net: wind-down arm switching is now proven live on HYPE for both the
+  flatten and already-flat switch paths, with both arm manifests fully
+  baseline-eligible. Remaining follow-ups: restore
+  `STANDX_STAGE2_ARM_SECONDS=7200` for the standard 2h A/B; PR #316
+  awaits merge; formal 2h baseline/candidate comparison still to be run.

--- a/docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md
+++ b/docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md
@@ -1,0 +1,330 @@
+# Maker Stage 2 v0 canary and live A/B record — 2026-07-17 (docker)
+
+## Authorization
+
+Recorded verbatim in the release record, provided by the release owner on
+2026-07-17 (Asia/Shanghai), before any live action in this session:
+
+> 授权执行 XAG-USD size=0.01 max_position=0.2 的阶段2 canary 与2小时A/B
+
+Scope: XAG-USD only, `size=0.01`, one level, `max_position=0.2`, canary plus
+the guarded two-hour baseline/candidate time-slice A/B. This does not
+authorize another symbol, larger exposure, active inventory exit, or automatic
+flatten. Execution environment: docker (`deploy/docker/docker-compose.yml`,
+profile `ab`), per the release owner's instruction "在docker中执行".
+
+## Prior attempt and cleanup (must precede any retry)
+
+- Container `standx-maker-stage2-ab` ran the A/B orchestrator from
+  2026-07-16T16:48:40Z to 2026-07-16T19:19:07Z (image
+  `standx-stage2-ab:latest`, git `a4080be46ce63bd56c9c6090816392131589374d`).
+- Baseline arm `stage2-baseline-20260716T164841Z-3df955e967fa` ran 9016s
+  (3242 cycle summaries, 5 passive fills) and ended with ledger position
+  `-0.03`. The orchestrator waited the full 1800s flat grace, did not flatten
+  (by design), declared the arm **invalid** ("position remained nonzero beyond
+  flat grace"), sent the critical webhook, and exited 75.
+- Manifest: `/opt/standx/var/standx/stage2-baseline-20260716T164841Z-3df955e967fa.manifest.json`
+  (status `invalid`; strategy_source_clean=true; symbol metadata complete).
+  Per the roadmap, this arm's data is void for A/B comparison.
+- Manual residual-position disposal per the runbook emergency procedure was
+  completed by the named operator. Independent re-check on
+  2026-07-17T01:10Z (read-only venue queries inside the image, host
+  credentials mounted read-only): `account orders --symbol XAG-USD` → `[]`,
+  `account positions --symbol XAG-USD` → `[]`. Venue flat, no residual maker
+  orders. Retry gate cleared.
+
+## Frozen artifacts
+
+- git SHA: `a4080be46ce63bd56c9c6090816392131589374d` (HEAD, strategy source
+  clean per the Dockerfile build gate).
+- Baseline config SHA-256:
+  `3df955e967fa97c92557b545c6eae52b5ff27dc5fd323d5e813eb89aaa04d146`
+  (`examples/maker-stage2-xag-baseline.toml`, re-verified 2026-07-17).
+- Candidate config SHA-256:
+  `30fdd415efcc2b57f7a246f4344e9929790b95d5fd9a7a7c49f7e21b7bef891d`
+  (`examples/maker-stage2-xag-candidate.toml`, re-verified 2026-07-17).
+- Environment: `/etc/standx/maker-stage2-ab.env` (root 0600) with docker
+  container-local locks (`/opt/standx/var/lock/…`), baseline symbol metadata
+  (`price_tick_decimals=2`, `qty_tick_decimals=3`, `min_order_qty=0.001`),
+  OpenObserve + supervisor webhook (feishu) present.
+- Mutual exclusion: host `standx-maker.service`,
+  `standx-maker-stage2-ab.service`, `standx-openobserve-catchup.service` all
+  inactive; OpenObserve itself runs as a separate container (up 6 days).
+
+## Webhook probes
+
+- Image `standx-stage2-ab:latest` id `02c2775d05b9`; bundled binary SHA-256
+  `2333f6ad176d168682956b7a05fdf62ed74566bcb5a93d5821768d6659b21cd6` (matches
+  the prior attempt's manifest program hash — same commit, reproducible build).
+- Docker validate-only preflight passed 2026-07-17T01:1xZ:
+  `stage2 A/B validation ok: symbol=XAG-USD baseline=3df955e9… candidate=30fdd415…`.
+- Four probes sent 2026-07-17T01:1xZ with
+  `test_id=stage2-webhook-ccf00583cabf` (stop_loss, position_risk, equity,
+  margin; all HTTP 2xx). Receiver confirmation: **confirmed** by the release
+  owner — all four messages received in the feishu receiver.
+- Named operator wujunlin confirmed ready with authenticated venue access for
+  the first 30 minutes of the canary window.
+
+## Canary evidence
+
+Both canaries executed in docker (`docker compose --profile ab run --rm`,
+image `02c2775d05b9`, env from `/etc/standx/maker-stage2-ab.env`, credentials
+mounted read-only) on 2026-07-17T01:23Z:
+
+1. **ws-command-canary** — full create/cancel correlation chain retained:
+   `client_order_id=sxmk-canary-abe24600ea55`, `order_id=11630688166`,
+   create `request_id=15d64566-8806-4886-8313-db04becd0d9d` (accepted, code 0),
+   cancel `request_id=7459ccf2-36b8-4621-937d-59b8368cafc1` (accepted, code 0);
+   `order_visible` → `absence_verified` → `position_verified=0.0`.
+   Venue-minimum post-only 0.001 XAG @ 55.09.
+2. **Controlled-disconnect canary** — run_id `stage2-canary-20260717T012339Z`,
+   candidate config (`adaptive_spread_enabled=true`). Observed sequence exactly
+   as required: order-response fault injected at 15s → `disconnected_frozen`
+   (warning) → `maker_cleanup complete remaining_maker_orders=0` →
+   `reconnect_unavailable` (critical, refusing further live orders) → final
+   `maker_cleanup remaining_maker_orders=0` → critical `fail_safe` stop →
+   `lifecycle stopped` (6 cycles, 0 fills) → **exit 75** (expected drill
+   outcome). Both place requests closed as `effective` (ack p50 217ms,
+   effective p50 153ms); no unexplained pending requests. All 34 NDJSON events
+   uploaded to OpenObserve by the wrapper.
+3. **Manifest validation** —
+   `/opt/standx/var/standx/stage2-canary-20260717T012339Z.manifest.json`:
+   all 14 required checks true (`cycle_sequence_complete`,
+   `lifecycle_started/stopped`, `strategy_source_clean`,
+   `symbol_metadata_complete`, …); status `finished`; `final_position=0.0`;
+   log SHA-256 `a503b6ce…` matches. The sole validator complaint is
+   "manifest is not baseline eligible", which is by design for a fail-safe
+   drill (short window, exit 75) — it is gate evidence, not comparison data.
+4. **Independent post-check** 2026-07-17T01:2xZ (read-only queries):
+   `account orders --symbol XAG-USD` → `[]`,
+   `account positions --symbol XAG-USD` → `[]`.
+
+Note (non-blocking): in-container `git status` shows untracked runtime paths
+(credentials mount, var/lock, `.mimocode/.cron-lock`, this evidence file baked
+into the image). Only strategy paths are gated; `strategy_source_clean=true`.
+Consider adding those paths to `.dockerignore` after the A/B window.
+
+## Two-hour A/B
+
+- Started 2026-07-17T01:27Z via `docker compose --profile ab up -d --build`
+  (container `standx-maker-stage2-ab`, image `02c2775d05b9`).
+- Startup sequence verified: deadman alert installed before any order →
+  preflight `orders=[] positions=[]` → baseline arm start.
+- Baseline arm: `stage2-baseline-20260717T012722Z-3df955e967fa`
+  (config hash `3df955e9…`, `adaptive_spread_enabled=false`), first cycles
+  healthy: two-sided quotes, WS market feed, OpenObserve live upload.
+- Candidate arm: **never started** (see incident below).
+- Result: **baseline arm invalid, A/B stopped (exit 75) at 2026-07-17T03:58Z.**
+
+## Incident 2026-07-17: second non-flat arm + SIGTERM cleanup gap
+
+- Baseline arm ran 9015s (3385 cycles, 17 fills, range 169.6bps), ended with
+  ledger position `-0.03`. The 1800s flat grace expired without natural
+  return to zero → orchestrator invalidated the arm
+  ("position remained nonzero beyond flat grace"), sent the critical webhook,
+  exited 75 without flattening (by design). Manifest
+  `/opt/standx/var/standx/stage2-baseline-20260717T012722Z-3df955e967fa.manifest.json`.
+- **SIGTERM cleanup gap (fail-closed deviation)**: at grace expiry the
+  orchestrator SIGTERMs the arm; the wrapper forwards SIGTERM to the maker,
+  but the maker only handles SIGINT (`tokio::signal::ctrl_c()`,
+  `runtime/state.rs:154`). SIGTERM killed it with the default disposition
+  (exit 143) — no `maker_cleanup`, no terminal lifecycle event. The NDJSON
+  ends mid-quoting (last events: cancel+place pair at 03:57:08Z). Two
+  current-run orders survived on the venue; the buy leg filled at 04:04:40Z
+  (+0.01), leaving a resting sell `11633410129` (0.01 @ 55.52) and a residual
+  short `-0.02`. The same exit=143 pattern occurred on 2026-07-16, so both
+  arm boundaries left residue that was only removed by manual intervention.
+- Emergency procedure executed 2026-07-17T04:1xZ with the release owner's
+  explicit instruction: `order cancel-all XAG-USD` → orders `[]`; venue
+  position re-queried (exact `-0.02`, unchanged since 04:04:40Z); one
+  reviewed reduce-only market buy 0.02 (order id
+  `40268377-b67a-4914-8e26-79cbe8ab1511`, executed by the agent under
+  one-time authorization — a deviation from the runbook's operator-only
+  default, recorded here); final state `orders=[] positions=[]`.
+- Runbook doc bug found: the emergency commands say `standx order new …` but
+  the CLI subcommand is `standx order create …`.
+- Structural observation for the retry decision: with ~15–17 fills per 2h
+  arm and two-sided quoting throughout the grace window, ending exactly flat
+  is a low-probability outcome (~fill-parity), so most arms would fail a
+  hard-clock flat gate. **Resolved in parallel**: commit `fa00c29` (BossX,
+  2026-07-17T01:57Z) amended the orchestrator protocol — `arm_seconds` (2h)
+  is now a minimum; a non-flat arm keeps quoting and switches at the next
+  natural flat (warning webhook every 1800s), with a 6h hard cap
+  (`STANDX_STAGE2_ARM_MAX_SECONDS`) that still invalidates and exit-75s
+  without any auto-flatten. No strategy change. docs/19 was rewritten to
+  match. The release owner additionally chose: **fix the SIGTERM cleanup gap
+  first, then re-authorize a retry.**
+
+## SIGTERM cleanup-gap fix (2026-07-17, commit `c9306ce`)
+
+- Root cause: the maker's shutdown watcher only awaited
+  `tokio::signal::ctrl_c()` (SIGINT). Every supervisor in the deployment
+  stack (systemd, `docker stop`, the A/B orchestrator via
+  `run_maker_observed.sh`) stops the maker with **SIGTERM**, which took the
+  default disposition — instant death (exit 143), no `maker_cleanup`,
+  resting orders left on the venue. The `deploy/README.md` claim "SIGTERM →
+  fail-safe cleanup → exit 0" never held.
+- Fix (`crates/standx-cli/src/commands/maker/runtime/state.rs`): the
+  shutdown watcher task now registers explicit unix signal streams for
+  **both** SIGINT and SIGTERM (`tokio::signal::unix::signal`) and feeds the
+  same latched watch channel, so SIGTERM drives the identical graceful
+  `StopRequested → cleanup → exit 0` path as Ctrl+C. Non-unix keeps the
+  original `ctrl_c()` loop. No strategy, accounting, or output-contract
+  change.
+- Debugging note: an earlier revision raced `tokio::signal::ctrl_c()`
+  against `sigterm.recv()` in one `select!`; in the real binary that
+  formulation never registered handlers (verified via `/proc/<pid>/status`
+  SigCgt) while a minimal reproduction did. The explicit two-`Signal`
+  formulation registers both handlers deterministically.
+- Verification (paper mode, XAG-USD, host binary, no live orders):
+  - SIGTERM drill: handler visible in SigCgt; process exits **0** in ~1s
+    with `lifecycle stopped` (previously: exit 143, no stop event).
+  - SIGINT drill: same graceful path (regression check).
+- Offline verification: workspace tests 181 cli + 154 maker + 75 sdk + 31
+  unit + 13 integration + 2 main + e2e/doc (2 credential-dependent e2e
+  ignored as before) all pass; clippy `-D warnings` clean; `cargo fmt
+  --check` clean; `py_compile openobserve_dashboard.py` ok.
+- Consequence for the retry: the binary changes, so the frozen program hash
+  changes. The retry needs a rebuilt image, a fresh canary pass with the
+  new binary, and a **new exact authorization** before the A/B restarts.
+
+## Retry after fixes (2026-07-17T05:2xZ)
+
+- New exact authorization recorded (same scope as the original, the first
+  one having been consumed by the failed run):
+  > 授权执行 XAG-USD size=0.01 max_position=0.2 的阶段2 canary 与2小时A/B
+- Retry artifact: image `standx-stage2-ab:latest` id `2dd03d005184`, git
+  `c9306cec98ea7c42526eeaf07307e0df045a617f` (SIGTERM fix `c9306ce` on top of
+  orchestrator extend-to-flat `fa00c29`), binary SHA-256
+  `1bbb707b97348f7ce8099f889cda3d325b27c9c8f0d7e6263d9f55479d186e9a`;
+  Dockerfile clean-source gate passed at build. Config hashes unchanged
+  (baseline `3df955e9…`, candidate `30fdd415…`); validate-only preflight
+  passed 2026-07-17T05:2xZ.
+- Operator wujunlin re-confirmed ready for the canary window.
+
+### Retry canary (new binary) — passed 2026-07-17T05:35Z
+
+- Webhook probes re-sent and receiver-confirmed:
+  `test_id=stage2-webhook-193034e4bd69` (all four kinds).
+- ws-command-canary: `client_order_id=sxmk-canary-2e027fd9713c`,
+  `order_id=11634874724`, create/cancel accepted (request ids
+  `006fdc91-…` / `36889edf-…`), absence + flat position verified.
+- Controlled-disconnect canary `stage2-canary-20260717T053502Z`: expected
+  fail-safe sequence (frozen → cleanup remaining=0 → critical fail_safe →
+  exit 75); manifest all 14 checks true, `final_position=0.0`,
+  `git_sha=c9306ce`; sole validator note "not baseline eligible" (drill by
+  design). Independent post-check: `orders=[] positions=[]`.
+
+### Retry A/B — started 2026-07-17T05:36Z
+
+- `docker compose --profile ab up -d`; deadman alert installed, preflight
+  `orders=[] positions=[]`, baseline arm
+  `stage2-baseline-20260717T053601Z-3df955e967fa` started.
+- Behavior change vs the failed attempts (orchestrator `fa00c29`): the 2h
+  mark is now a minimum; a non-flat arm extends to the next natural flat
+  (warning webhook every 1800s), 6h hard cap `STANDX_STAGE2_ARM_MAX_SECONDS`
+  still invalidates without flattening.
+- Result: pending
+
+### Offline arm-switch harness — passed 2026-07-17T05:55Z
+
+User asked for fast confirmation that arm switching works before the first
+real 2h switch (~07:36Z). A fully offline harness exercised the **real**
+orchestrator logic (`run_maker_stage2_ab.sh` copied to
+`/tmp/stage2-harness/` with only `arm_seconds 7200→8` and
+`flat_grace_seconds 1800→4` via sed), the **real** `run_maker_observed.sh`
+wrapper, and the **real** `maker_run_manifest.py` tooling
+(`STANDX_INSTALL_ROOT=<repo>`, frozen configs byte-compare intact), against
+a fake `standx` bash binary whose venue position is driven by a state file.
+`OPENOBSERVE_AUTO_UPLOAD`/`STANDX_SUPERVISOR_WEBHOOK` explicitly unset; no
+venue or network contact; live A/B container untouched (verified `Up`
+throughout).
+
+- **S1 — flat at deadline**: baseline arm completed at the window end,
+  candidate started, then baseline again (alternation continues); all 3
+  manifests `status=finished`, `baseline_eligible=true`,
+  `final_position=0.0`; SIGTERM to the orchestrator mid-arm forwarded to
+  the arm, graceful exit 0; no CRITICAL.
+- **S2 — non-flat at deadline**: extension warning fired
+  ("past its 8s window but not flat; extending and will switch at the next
+  natural flat"), then after the state flipped flat:
+  "reached natural flat after extension; proceeding to switch", arm
+  complete with `orders=[] positions=[]`; manifest finished+eligible+flat.
+- **S3 — non-flat past hard cap** (`ARM_MAX=20`): repeated extension
+  warnings, then `CRITICAL stage2 A/B stopped: arm=baseline stayed
+  non-flat past 20s hard cap … no automatic flatten was attempted`,
+  orchestrator exit 75, arm manifest invalidated (`status=invalid`).
+- No stray harness processes after any scenario. Artifacts (orchestrator
+  logs + manifests per scenario): `/tmp/stage2-harness/artifacts-s{1,2,3}/`.
+
+### Retry A/B — terminated by credential expiry 2026-07-17T09:04Z (exit 75)
+
+- Baseline arm `stage2-baseline-20260717T053601Z-3df955e967fa` ran 05:36Z →
+  09:04Z (4606 cycles, 11 fills, uptime ~90%, session PnL ≈ -0.01); crossed
+  the 2h minimum at 07:36Z non-flat and extended per the extend-to-flat
+  design (extension warnings at ~07:36/08:06/08:36Z, position decaying
+  -0.02 → -0.01). Candidate arm never started.
+- **Root cause: venue credential token expired mid-arm.** First symptom
+  ~09:04Z: orchestrator's `account positions` poll began failing
+  ("Authentication required", exit/JSON invalid) → extension loop's
+  fail-closed path SIGTERMed the arm. The arm's own cleanup (cancel-all)
+  then failed 3/3 attempts with the same "Authentication required" →
+  `risk_notification critical/residual_orders`, maker lifecycle stopped
+  with "cleanup failed" and exit 75; orchestrator `CRITICAL … could not
+  prove venue position state … no automatic flatten was attempted`,
+  exit 75. Container `Exited (75)`, NOT restarted (restart: "no" held).
+- Post-incident read-only venue checks (09:08–09:10Z, docker run
+  credentials.enc:ro): `account orders` and `account positions` BOTH fail
+  with "Authentication required" — account-state API visibility is down
+  until re-login. Market data (public) unaffected.
+- Last known state: expected_position=-0.01 XAG (≈$0.55; maker ledger,
+  fills_total=11 unchanged since 08:38Z). Residual orders UNKNOWN — the
+  final quote pair could not be cancelled (auth), so one bid+ask pair of
+  0.01 XAG each may still be resting on the book.
+- Handoff to operator (wujunlin): 1) `standx auth login` on the host to
+  refresh credentials.enc; 2) verify `account orders`/`account positions`;
+  3) cancel any residual sxmk- orders and flatten the -0.01 if still
+  present; 4) only then consider a fresh A/B launch (preflight requires
+  orders=[] positions=[]). NO automatic flatten or restart was attempted
+  by tooling, per runbook.
+- **Ops gap surfaced**: token lifetime (~3.5h from 05:36Z auth) is shorter
+  than a 2h+extension arm can be. Before the next run: refresh credentials
+  immediately before launch and/or schedule a mid-run re-login; consider
+  documenting expected token TTL in the runbook. Monitoring cron
+  5d7f4274 deleted at incident detection.
+
+### Wind-down arm switching — implemented and offline-verified 2026-07-17T10:2xZ
+
+Motivated by the 09:04Z incident (baseline arm extended 1.5h without
+converging) and operator request for deterministic switch-time position
+closure. Replaces extend-to-flat quoting with a latched **wind-down**:
+
+- `standx-maker`: `CycleInput.wind_down`/`qty_tolerance`; `plan_cycle` in
+  wind-down never desires new quotes (even once flat — no re-accumulation)
+  and plans a full reduce-only exit for any residual above tolerance,
+  ignoring configured exit thresholds (frozen configs have them disabled).
+  Vol-halt still suppresses the taker exit. New unit tests 35-37; maker
+  suite 157 passed.
+- `standx-cli`: SIGUSR1 handler registered alongside SIGINT/SIGTERM
+  (latched watch channel); each cycle latches `wind_down`, emits a
+  `lifecycle`/`wind_down` JSON line + webhook once, and threads the flag
+  into the planner. Existing reduce-only market-exit path
+  (`cycle.rs:762+`) executes the flatten.
+- `run_maker_observed.sh` forwards USR1; `run_maker_stage2_ab.sh` sends
+  USR1 at the 2h mark and re-sends with each 30-min warning. Flat poll,
+  6h hard cap (now "stalled wind-down"), manifest validation, postcheck,
+  and no-auto-flatten semantics unchanged.
+- No new config keys; frozen configs and byte-compare untouched.
+- Offline gates: full workspace tests green (10 suites), clippy
+  `-D warnings`, fmt, py_compile, bash -n all clean.
+- Harness (fake standx + shrunk-timer orchestrator, scratch repo copy so
+  the manifest `strategy_source_clean` gate passes with the real tree
+  dirty): **s4 wind-down happy path PASS** (USR1 → flatten → arm complete
+  → candidate starts), s1 immediate-switch PASS, s2 stalled-wind-down →
+  flat → switch PASS, s3 stalled wind-down past hard cap → CRITICAL
+  exit 75 PASS. Artifacts `/tmp/stage2-harness/artifacts-s{1..4}/`.
+- Deployment constraint (also in docs/19): orchestrator, wrapper, and
+  maker binary must ship in the same image — SIGUSR1 to a pre-wind-down
+  binary kills it.
+- Status: implemented and verified offline; NOT yet committed (awaiting
+  operator approval), not yet deployed.

--- a/examples/maker-stage2-hype-baseline.toml
+++ b/examples/maker-stage2-hype-baseline.toml
@@ -1,0 +1,56 @@
+# Stage 2 v0 live A/B arm, HYPE-USD. No credentials, webhook URL, or --live flag.
+# Venue metadata (2026-07-17 symbol-info): price_tick_decimals=3
+# qty_tick_decimals=2 min_order_qty=0.1 max_leverage=20.
+# Sizing tier approved by operator: ~$59 max notional at HYPE≈$59 (10x skew
+# room, stop_loss ≈2.7% of ~$184 equity). Vol thresholds intentionally kept
+# identical to the XAG arms so the adaptive-spread comparison stays structural.
+spread_bps = 8.0
+band_bps = 30.0
+size = 0.1
+levels = 1
+level_step_bps = 2.0
+refresh_bps = 4.0
+interval = 3
+
+max_position = 1.0
+skew_bps = 8.0
+inventory_exit_pct = 0.0
+inventory_exit_qty = 0.0
+max_divergence_bps = 15.0
+vol_pause_bps = 40.0
+vol_window_secs = 60
+
+stop_loss = 5.0
+alert_loss = 2.5
+alert_inventory_pct = 70.0
+alert_position_change_pct = 20.0
+alert_uptime = 60.0
+alert_equity_below = 94.0
+alert_margin_below = 30.0
+
+no_ws = false
+order_response_reconnect_attempts = 3
+order_response_reconnect_backoff = 2
+account_stream_reconnect_attempts = 3
+account_stream_reconnect_backoff = 2
+
+[adaptive_spread]
+enabled = false
+min_spread_bps = 8.0
+max_spread_bps = 18.0
+
+[[adaptive_spread.tiers]]
+spread_bps = 8.0
+refresh_bps = 4.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 10.0
+exit_vol_bps = 7.0
+spread_bps = 12.0
+refresh_bps = 5.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 20.0
+exit_vol_bps = 15.0
+spread_bps = 18.0
+refresh_bps = 6.0

--- a/examples/maker-stage2-hype-candidate.toml
+++ b/examples/maker-stage2-hype-candidate.toml
@@ -1,0 +1,56 @@
+# Stage 2 v0 live A/B arm, HYPE-USD. No credentials, webhook URL, or --live flag.
+# Venue metadata (2026-07-17 symbol-info): price_tick_decimals=3
+# qty_tick_decimals=2 min_order_qty=0.1 max_leverage=20.
+# Sizing tier approved by operator: ~$59 max notional at HYPE≈$59 (10x skew
+# room, stop_loss ≈2.7% of ~$184 equity). Vol thresholds intentionally kept
+# identical to the XAG arms so the adaptive-spread comparison stays structural.
+spread_bps = 8.0
+band_bps = 30.0
+size = 0.1
+levels = 1
+level_step_bps = 2.0
+refresh_bps = 4.0
+interval = 3
+
+max_position = 1.0
+skew_bps = 8.0
+inventory_exit_pct = 0.0
+inventory_exit_qty = 0.0
+max_divergence_bps = 15.0
+vol_pause_bps = 40.0
+vol_window_secs = 60
+
+stop_loss = 5.0
+alert_loss = 2.5
+alert_inventory_pct = 70.0
+alert_position_change_pct = 20.0
+alert_uptime = 60.0
+alert_equity_below = 94.0
+alert_margin_below = 30.0
+
+no_ws = false
+order_response_reconnect_attempts = 3
+order_response_reconnect_backoff = 2
+account_stream_reconnect_attempts = 3
+account_stream_reconnect_backoff = 2
+
+[adaptive_spread]
+enabled = true
+min_spread_bps = 8.0
+max_spread_bps = 18.0
+
+[[adaptive_spread.tiers]]
+spread_bps = 8.0
+refresh_bps = 4.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 10.0
+exit_vol_bps = 7.0
+spread_bps = 12.0
+refresh_bps = 5.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 20.0
+exit_vol_bps = 15.0
+spread_bps = 18.0
+refresh_bps = 6.0

--- a/scripts/run_maker_observed.sh
+++ b/scripts/run_maker_observed.sh
@@ -85,6 +85,7 @@ notify() {
 trap cleanup EXIT
 trap 'forward_signal INT' INT
 trap 'forward_signal TERM' TERM
+trap 'forward_signal USR1' USR1
 
 : >"$stdout_log"
 : >"$stderr_log"

--- a/scripts/run_maker_stage2_ab.sh
+++ b/scripts/run_maker_stage2_ab.sh
@@ -7,13 +7,15 @@ baseline_config="${STANDX_STAGE2_BASELINE_CONFIG:-$root/examples/maker-stage2-xa
 candidate_config="${STANDX_STAGE2_CANDIDATE_CONFIG:-$root/examples/maker-stage2-xag-candidate.toml}"
 symbol="${STANDX_SYMBOL:-XAG-USD}"
 arm_seconds=7200
-# Minimum arm length is arm_seconds. A non-flat position at that mark is a
-# normal trending-market outcome, not a safety failure, so the arm is extended
-# and switches at the next natural flat instead of critical-stopping. Only an
-# arm that stays non-flat past arm_max_seconds (the hard cap, counted from arm
-# start and inclusive of arm_seconds) escalates to critical_stop. While
-# extending, a warning fires every flat_grace_seconds so a long-running arm is
-# visible.
+# Minimum arm length is arm_seconds. At that mark the orchestrator signals the
+# arm with SIGUSR1, latching maker wind-down: the maker stops quoting for good
+# and flattens any residual position via reduce-only market exits (bounded,
+# deterministic cost) instead of waiting for flow-dependent natural flat. The
+# poll below then simply confirms the venue is flat; a maker that stays
+# non-flat past arm_max_seconds (the hard cap, counted from arm start and
+# inclusive of arm_seconds) still escalates to critical_stop. A warning fires
+# every flat_grace_seconds while the arm is not yet flat so a stalled
+# wind-down stays visible.
 arm_max_seconds="${STANDX_STAGE2_ARM_MAX_SECONDS:-21600}"
 flat_grace_seconds=1800
 poll_seconds="${STANDX_STAGE2_POLL_SECONDS:-15}"
@@ -199,12 +201,13 @@ run_arm() {
     sleep "$poll_seconds"
   done
 
-  # Past the arm_seconds minimum: switch at the next natural flat. Staying
-  # non-flat is a normal trending-market outcome, so the healthy maker keeps
-  # running and quoting (inventory bounded by max_position, downside by
-  # stop_loss) until it flattens — not a critical_stop. Escalate only on a
+  # Past the arm_seconds minimum: latch maker wind-down with SIGUSR1. The
+  # maker stops quoting for good and flattens any residual position via
+  # reduce-only market exits, so the arm should reach flat within a few
+  # cycles; the poll below confirms it on the venue. Escalate only on a
   # genuinely unsafe state (position query fails, maker dies) or when the arm
-  # stays non-flat past the arm_max_seconds hard cap.
+  # stays non-flat past the arm_max_seconds hard cap (wind-down stalled).
+  kill -USR1 "$pid" 2>/dev/null || true
   hard_deadline=$((arm_start + arm_max_seconds))
   next_extension_notice=$SECONDS
   extending=0
@@ -223,8 +226,8 @@ run_arm() {
     if ! kill -0 "$pid" 2>/dev/null; then
       wait "$pid"
       status=$?
-      invalidate_arm "arm exited while awaiting natural flat"
-      critical_stop "arm=$arm exited while waiting for natural flat (status=$status run_id=$run_id)"
+      invalidate_arm "arm exited while awaiting wind-down flat"
+      critical_stop "arm=$arm exited while waiting for wind-down flat (status=$status run_id=$run_id)"
     fi
     if ((SECONDS >= hard_deadline)); then
       kill -TERM "$pid" 2>/dev/null || true
@@ -234,13 +237,16 @@ run_arm() {
     fi
     if ((SECONDS >= next_extension_notice)); then
       extending=1
-      notify "stage2 A/B arm=$arm past its ${arm_seconds}s window but not flat; extending and will switch at the next natural flat (hard cap ${arm_max_seconds}s, run_id=$run_id)" warning
+      # Re-signal with each warning: wind-down is latched, so repeats are
+      # harmless and cover a signal lost to a mid-arm maker restart.
+      kill -USR1 "$pid" 2>/dev/null || true
+      notify "stage2 A/B arm=$arm past its ${arm_seconds}s window, wind-down signaled but not yet flat (hard cap ${arm_max_seconds}s, run_id=$run_id)" warning
       next_extension_notice=$((SECONDS + flat_grace_seconds))
     fi
     sleep "$poll_seconds"
   done
   if ((extending == 1)); then
-    notify "stage2 A/B arm=$arm reached natural flat after extension; proceeding to switch (run_id=$run_id)"
+    notify "stage2 A/B arm=$arm flat after wind-down; proceeding to switch (run_id=$run_id)"
   fi
 
   kill -TERM "$pid" 2>/dev/null || true

--- a/scripts/run_maker_stage2_ab.sh
+++ b/scripts/run_maker_stage2_ab.sh
@@ -80,10 +80,13 @@ done
     "$arm_max_seconds" "$arm_seconds" >&2
   exit 64
 }
-[[ "$symbol" == "XAG-USD" ]] || {
-  printf 'stage2 A/B is frozen to XAG-USD\n' >&2
-  exit 64
-}
+case "$symbol" in
+  XAG-USD|HYPE-USD) ;;
+  *)
+    printf 'stage2 A/B is frozen to XAG-USD and HYPE-USD\n' >&2
+    exit 64
+    ;;
+esac
 [[ -x "$standx_bin" && -f "$baseline_config" && -f "$candidate_config" ]] || {
   printf 'stage2 A/B binary or frozen configs are missing\n' >&2
   exit 64

--- a/scripts/run_maker_stage2_ab.sh
+++ b/scripts/run_maker_stage2_ab.sh
@@ -6,7 +6,7 @@ standx_bin="${STANDX_BIN:-$root/bin/standx}"
 baseline_config="${STANDX_STAGE2_BASELINE_CONFIG:-$root/examples/maker-stage2-xag-baseline.toml}"
 candidate_config="${STANDX_STAGE2_CANDIDATE_CONFIG:-$root/examples/maker-stage2-xag-candidate.toml}"
 symbol="${STANDX_SYMBOL:-XAG-USD}"
-arm_seconds=7200
+arm_seconds="${STANDX_STAGE2_ARM_SECONDS:-7200}"
 # Minimum arm length is arm_seconds. At that mark the orchestrator signals the
 # arm with SIGUSR1, latching maker wind-down: the maker stops quoting for good
 # and flattens any residual position via reduce-only market exits (bounded,
@@ -69,7 +69,7 @@ critical_stop() {
   exit 75
 }
 
-for value in "$poll_seconds" "$arm_max_seconds"; do
+for value in "$poll_seconds" "$arm_seconds" "$arm_max_seconds"; do
   [[ "$value" =~ ^[1-9][0-9]*$ ]] || {
     printf 'stage2 A/B durations must be positive integers\n' >&2
     exit 64


### PR DESCRIPTION
## Summary

Two commits on top of c9306ce (SIGTERM handler, already deployed):

1. **ba60b6a — SIGUSR1-latched wind-down for deterministic arm switching.**
   The 2h arm boundary previously relied on extend-to-flat: if the maker still held a position at the deadline the arm stalled open-ended (harness s2/s3), and a later switch could strand inventory across arms. Now the orchestrator sends SIGUSR1 at the deadline (and on each stall warning); the maker latches wind-down — never quotes again and flattens any residual position once via the existing reduce-only market inventory-exit path.

   - `standx-maker`: `CycleInput` gains `wind_down` + `qty_tolerance`; `plan_cycle` suppresses desired quotes under wind-down; `wind_down_exit_plan` emits the one-shot flatten intent (3 new unit tests, 157 total).
   - CLI: SIGUSR1 (`user_defined1`) wired through `state.rs`/`cycle_flow.rs`/`pipeline.rs` alongside SIGINT/SIGTERM; exit-75 stall fallback unchanged.
   - scripts: wrapper traps/forwards USR1; orchestrator signals at deadline and on stall warnings.

2. **08c08ed — HYPE-USD preparation for the next experiment.**
   - Gate extended from XAG-only to a `XAG-USD|HYPE-USD` allowlist.
   - `examples/maker-stage2-hype-{baseline,candidate}.toml`: size=0.1, max_position=1.0, stop_loss=5.0, alert_loss=2.5; arms differ only in the single `adaptive_spread.enabled` line (byte-compare gate passes).
   - `deploy/systemd/maker-stage2-hype-ab.env.example` (price_tick=3, qty_tick=2, min_order=0.1) and a docker-compose `ab-hype` profile.

## Deploy constraint

Orchestrator, wrapper, and maker binary must ship from the **same image** — SIGUSR1 is fatal to pre-wind-down binaries.

## Verification

- `cargo test --workspace --offline` (10 suites, maker 157) — green
- `cargo clippy --workspace --all-targets --offline -- -D warnings` — green
- `cargo fmt --all -- --check` + `py_compile` — green
- Harness s1–s4 all pass (s4 = wind-down happy path; s2/s3 stall paths with a fake maker ignoring USR1 still exit 75)
- Validate-only: HYPE (baseline=bbd769c5…, candidate=fb91cfd5…) and XAG regression (3df955e9…/30fdd415…)

Full day's canary + incident + implementation evidence: `docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md`

## Known follow-up (not in this PR)

Credential token lifetime (~3.5h) is shorter than an arm; before the next long run either re-login right before start, or add 401-triggered re-read of `credentials.enc` (proposal C, not yet approved).