### PR TITLE
evidence: stage2 HYPE 4h-arm A/B (3 pairs) — candidate no measurable …

### DIFF
--- a/docs/18-maker-strategy-roadmap.md
+++ b/docs/18-maker-strategy-roadmap.md
@@ -220,11 +220,22 @@ python3 -m py_compile scripts/openobserve_dashboard.py
 
 ## 阶段 2：波动驱动的自适应 Spread 与 Refresh（v0 单因子）
 
-当前状态：`implemented_pending_evidence`。代码、冻结配置与自动 A/B 运维件已进入离线验收；
-30 分钟 candidate paper 已通过；在 renewed canary 和覆盖平静/趋势市场的有效 live A/B 证据完成前，
-不得标记 `accepted`。执行手册见
+当前状态：`ab_completed_not_accepted`（2026-07-18 判定）。代码、冻结配置与自动 A/B 运维件已通过离线验收；
+canary 重验通过；2026-07-17T15:23Z → 07-18T16:1xZ 在 HYPE-USD 完成 3 对 4 小时臂的实盘时间片 A/B
+（docker,24h+ 连续，6 次 wind-down 换臂全部干净），candidate 未达到下方经济晋级门槛，按规约不晋级。
+执行手册见
 [19-maker-stage2-live-ab-runbook.md](19-maker-stage2-live-ab-runbook.md)，实现证据见
-[maker-strategy-stage-2-v0-implementation-2026-07-16.md](evidence/maker-strategy-stage-2-v0-implementation-2026-07-16.md)。
+[maker-strategy-stage-2-v0-implementation-2026-07-16.md](evidence/maker-strategy-stage-2-v0-implementation-2026-07-16.md)，
+A/B 全程记录与 markout 分析见
+[maker-strategy-stage-2-canary-ab-2026-07-17.md](evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md)
+（分析脚本 `scripts/maker_markout_ab.py`）。
+
+A/B 要点（3 对，baseline n=222 / candidate n=112 笔被动成交）：单笔毒性、capture、净边际两臂在噪声内
+一致（mo5 -5.51 vs -5.35 bps,mo30 -8.71 vs -9.13 bps）；自适应加宽的唯一实测效果是高波动时段少成交
+（tier 激活 14–23% 时间），未转化为 PnL 或 markout 改善。运维门槛（uptime、撤单率）达标，经济门槛未达。
+附带策略级发现：当前 8bps / ~2.45s 报价循环在 HYPE 上为结构性负边际（每笔 30s 净边际约 -4~-5bps,
+90%+ 成交 5s 内被反向穿越），亏损主因是逆选择与库存盯市而非费率——这是后续迭代（非对称报价 /
+requote 提速 / 漂移侧收手）应优先攻击的问题，而非继续调 tier 宽度。
 
 运维件现有两条部署路径：systemd（`deploy/systemd/standx-maker-stage2-ab.service`）与容器化
 （`deploy/docker/`，docker-compose，同一 runbook 授权门槛）。容器化路径已在 2026-07-16 完成首次
@@ -269,13 +280,20 @@ peak-to-trough `vol_bps`）和当前 touch spread。markout/toxicity 与滚动 l
 - [x] planner 回归覆盖不会生成穿 touch、出 band、低于最小数量或突破敞口预算的报价。
 - [x] 波动单调恶化时 spread 不收窄；恢复时通过 hysteresis 回落；档位切换在阈值附近无振荡。
 
-实盘时间片 A/B（按统一验收口径）：
+实盘时间片 A/B（按统一验收口径；2026-07-17/18 HYPE 3 对 4h 臂实测）：
 
-- [ ] 代码合并后完成一次 canary 重验，A/B 在风险预算边界内运行。
+- [x] 代码合并后完成一次 canary 重验，A/B 在风险预算边界内运行。
 - [ ] 比较窗口（含平静与趋势时段）合计 net PnL 不低于静态基线的 95%。
+  **未达**:Σ baseline -0.173 vs Σ candidate -0.740 USD（先后时段、行情混淆，但门槛未过）。
 - [ ] 最大回撤绝对值不得大于基线；5s 负向 markout 绝对值至少改善 10%，否则不晋级。
-- [ ] 时间加权双边 uptime 相对基线下降不超过 3 个百分点。
-- [ ] 每 quote-hour 撤单数相对基线增加不超过 20%。
+  **未达**:mo5 -5.35 vs -5.51 bps(≈3%,噪声内）,mo30 反而略差；candidate 最差臂 PnL -0.280
+  大于 baseline 最差 -0.166。
+- [x] 时间加权双边 uptime 相对基线下降不超过 3 个百分点。
+  （baseline 均值 98.5% / candidate 99.2%,candidate 反而略高。）
+- [x] 每 quote-hour 撤单数相对基线增加不超过 20%。
+  （baseline 均值约 118 / candidate 约 98，无增加。）
+
+判定：运维门槛通过，经济门槛未过，candidate 不晋级；阶段 2 v0 维持 baseline 配置为生产基线。
 
 ## 阶段 3：非线性库存控制
 

--- a/docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md
+++ b/docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md
@@ -379,3 +379,67 @@ from 08c08ed (build-time strategy_source_clean gate passed).
   baseline-eligible. Remaining follow-ups: restore
   `STANDX_STAGE2_ARM_SECONDS=7200` for the standard 2h A/B; PR #316
   awaits merge; formal 2h baseline/candidate comparison still to be run.
+
+### Overnight 4h-arm A/B (3 pairs) and experiment conclusion — 2026-07-17T15:23Z → 2026-07-18T16:1xZ
+
+PR #316 merged to main (`a37bf4f`). `STANDX_STAGE2_ARM_SECONDS=14400`
+(4h arms) installed in `/etc/standx/maker-stage2-hype-ab.env`, image
+rebuilt from main `a37bf4f`, venue verified flat, run started 15:23Z
+under a 30-min monitoring cron (auto-report only; no auto-restart,
+no auto-flatten policy). Stopped by operator 16:1xZ the next day.
+
+Operations: 24h+ continuous, 7 arms, 6 switches — all clean, zero
+manual intervention. Four switches carried inventory into wind-down
+(+0.2, +0.4, +0.3, +0.4) and each flattened via reduce-only exit in
+~1s; two switched already-flat. Every completed arm manifest:
+`baseline_eligible=True`, `missing_cycles=[]`. One pre-switch cancel
+race (07:21Z) left a residual order that cleanup retry cleared in 2s
+(designed path). Stop: SIGUSR1 wind-down of arm 7 (+0.3 flattened
+@59.209), then `docker stop` (Exited 0); venue read-only check
+orders=[] positions=[]. Monitoring cron deleted.
+
+Completed arms (all HYPE-USD, spread 8bps, size 0.1):
+
+| arm | window (UTC) | fills | cap bps | mo5 bps | mo30 bps | PnL | mark range |
+|-----|--------------|-------|---------|---------|----------|-----|------------|
+| B1 baseline | 15:23–19:23 07-17 | 163 | +4.49 | -5.65 | -9.10 | -0.076 | 59.80–60.80 |
+| C1 candidate | 19:23–23:24 07-17 | 27 | +4.87 | -6.52 | -8.63 | -0.196 | 59.55–60.34 |
+| B2 baseline | 23:24–03:24 | 28 | +4.99 | -5.78 | -8.26 | +0.068 | 59.41–60.09 |
+| C2 candidate | 03:24–07:25 07-18 | 31 | +3.85 | -4.55 | -11.05 | -0.264 | 58.67–59.71 |
+| B3 baseline | 07:25–11:25 07-18 | 31 | +4.64 | -4.50 | -7.11 | -0.166 | 58.76–59.50 |
+| C3 candidate | 11:25–15:26 07-18 | 54 | +4.35 | -5.23 | -8.27 | -0.280 | 58.39–59.68 |
+
+Pooled (baseline n=222 fills, candidate n=112): capture +4.58 vs +4.34
+bps; markout-5s -5.51 vs -5.35 bps (90–91% of fills adverse within 5s
+in both); markout-30s -8.71 vs -9.13 bps; net per-fill edge
+(cap+mo30) ≈ -4.1 vs -4.8 bps. Candidate tier-0-only fills vs all
+baseline fills: mo5 -5.01 vs -5.51, mo30 -9.14 vs -8.71 — identical
+within noise. Candidate tier-stratified: tier0 cap+3.8/mo5-5.0,
+tier1 cap+5.9/mo5-6.5 (n=21), tier2 cap+8.5/mo5-7.4 (n=3) — the wider
+tier spread's extra capture is offset by equally higher toxicity.
+Analysis: `scripts/maker_markout_ab.py` (markout from cycle marks;
+runner-side aggregates cross-checked, differ by ≈capture as expected
+since they measure from fill price).
+
+Conclusions (consistent across all 3 pairs):
+
+1. **A/B verdict: candidate shows no measurable edge.** Fill-level
+   toxicity, capture, and net edge are identical within noise; the
+   adaptive spread's only real effect is fewer fills during high-vol
+   windows (tier-active 14–23% of time), and skipping those (already
+   negative-edge) fills did not improve PnL.
+2. **B1's 40 fills/h was an outlier active window.** In quiet regimes
+   both arms trade ~7–13 fills/h; the preliminary "candidate trades
+   6x less" read was regime confounding, not treatment.
+3. **Strategy-level finding: the 8bps / ~2.45s-cycle quote loop is
+   structurally negative-edge on HYPE.** ~90%+ of fills are adversely
+   selected within 5s; net ≈ -4 to -5 bps per fill at 30s. Losses are
+   adverse selection + inventory MTM, not fees. This is the problem
+   the next strategy iteration must attack (asymmetric quoting /
+   faster requote / drift-side pullback), not tier tuning.
+4. **Wind-down arm switching is operationally proven**: 6/6 clean
+   switches, 4 with inventory, all flattening in ~1s, all manifests
+   eligible. The A/B harness itself is ready for reuse.
+
+Experiment stopped by operator 16:1xZ 07-18 after 3 pairs; further
+pairs were judged low marginal value given the per-pair consistency.

--- a/scripts/maker_markout_ab.py
+++ b/scripts/maker_markout_ab.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Pooled markout / toxicity comparison for stage2 A/B maker arms. Read-only.
+
+Usage:
+    python3 scripts/maker_markout_ab.py ARM.ndjson [ARM.ndjson ...]
+
+Each arm file is a maker NDJSON log whose name contains "baseline" or
+"candidate" (treatment is inferred from the filename). Prints per-arm
+fill/capture/markout stats, pooled per-treatment aggregates, a
+matched-condition cut (candidate tier-0 fills vs baseline), and candidate
+fills broken down by adaptive-spread tier.
+
+Markout convention: (mark(t+h) - mark(t_fill)) * side_sign / mark * 1e4 bps,
+using cycle_summary marks (~2.45s cadence) as the mark series; the actual
+horizon is the first cycle at or after t_fill + h. The runner's own
+performance.markout_* fields instead measure from the fill price (i.e. they
+include capture), so the two conventions differ by ~capture_bps.
+"""
+import bisect
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from statistics import mean, median
+
+HORIZONS = [1.0, 5.0, 30.0]
+
+
+def parse_ts(s):
+    return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+
+
+def load_arm(path):
+    cycles, fills, last_perf, pnl_last = [], [], None, None
+    with open(path) as f:
+        for line in f:
+            try:
+                d = json.loads(line)
+            except Exception:
+                continue
+            a = d.get("action")
+            if a == "cycle_summary":
+                try:
+                    cycles.append((parse_ts(d["ts"]), float(d["mark"]),
+                                   d.get("adaptive_spread_tier", 0)))
+                except Exception:
+                    pass
+                last_perf = d.get("performance")
+                pnl_last = d.get("pnl")
+            elif a == "fill":
+                fills.append(d)
+    cycles.sort()
+    return cycles, fills, last_perf, pnl_last
+
+
+def arm_rows(cycles, fills):
+    """Per passive fill: (cap_bps, mo1, mo5, mo30, tier, side, qty)."""
+    ts_list = [c[0] for c in cycles]
+    rows = []
+    for f in fills:
+        if f.get("role") != "passive_maker":
+            continue
+        t = parse_ts(f["ts"])
+        price = float(f["price"])
+        sign = 1.0 if f["side"] == "buy" else -1.0
+        i = bisect.bisect_left(ts_list, t)
+        if i >= len(cycles):
+            continue
+        mark0 = cycles[i][1]
+        tier = cycles[max(0, i - 1)][2]
+        cap = (mark0 - price) * sign / price * 1e4
+        mo = {}
+        for h in HORIZONS:
+            j = bisect.bisect_left(ts_list, t + h)
+            mo[h] = (cycles[j][1] - mark0) * sign / mark0 * 1e4 if j < len(cycles) else None
+        rows.append((cap, mo[1.0], mo[5.0], mo[30.0], tier, f["side"], float(f["qty"])))
+    return rows
+
+
+def stat(xs):
+    xs = [x for x in xs if x is not None]
+    if not xs:
+        return "n/a"
+    neg = sum(1 for x in xs if x < 0) / len(xs) * 100
+    return f"mean{mean(xs):+6.2f} med{median(xs):+6.2f} neg%{neg:3.0f}"
+
+
+def main(paths):
+    arm_summary = []
+    pooled = defaultdict(list)
+    tier0_only = defaultdict(list)
+    for path in paths:
+        base = path.rsplit("/", 1)[-1]
+        treatment = "baseline" if "baseline" in base else "candidate" if "candidate" in base else None
+        if treatment is None:
+            print(f"skip (no treatment in name): {base}")
+            continue
+        name = base.split(".")[0]
+        cycles, fills, last_perf, pnl_last = load_arm(path)
+        if not cycles:
+            print(f"skip (no cycles): {base}")
+            continue
+        ts_list = [c[0] for c in cycles]
+        dur_h = (ts_list[-1] - ts_list[0]) / 3600
+        marks = [c[1] for c in cycles]
+        tiers = Counter(c[2] for c in cycles)
+        rows = arm_rows(cycles, fills)
+        pooled[treatment].extend(rows)
+        tier0_only[treatment].extend(r for r in rows if r[4] == 0)
+        mo5 = [r[2] for r in rows if r[2] is not None]
+        mo30 = [r[3] for r in rows if r[3] is not None]
+        caps = [r[0] for r in rows]
+        arm_summary.append(dict(
+            name=name, treatment=treatment, dur=dur_h, n=len(rows),
+            rate=len(rows) / dur_h, cap=mean(caps) if caps else None,
+            mo5=mean(mo5) if mo5 else None, mo30=mean(mo30) if mo30 else None,
+            pnl=pnl_last if isinstance(pnl_last, (int, float)) else None,
+            mark0=marks[0], mark1=marks[-1], mlo=min(marks), mhi=max(marks),
+            tiers=dict(tiers), gross=(last_perf or {}).get("gross_spread_quote"),
+            inv=(last_perf or {}).get("inventory_avg_abs_qty")))
+
+    print("=== per-arm ===")
+    for a in arm_summary:
+        tier_s = f"  tiers {a['tiers']}" if a["treatment"] == "candidate" else ""
+        pnl_s = f"{a['pnl']:+7.3f}" if a["pnl"] is not None else "    n/a"
+        print(f"{a['name']}: {a['dur']:.1f}h fills {a['n']:3d} ({a['rate']:4.1f}/h) "
+              f"cap{a['cap']:+5.2f} mo5{a['mo5']:+6.2f} mo30{a['mo30']:+6.2f} "
+              f"pnl{pnl_s} gross{a['gross']:+5.3f} inv{a['inv']:.2f} "
+              f"mark {a['mark0']:.2f}->{a['mark1']:.2f} [{a['mlo']:.2f},{a['mhi']:.2f}]{tier_s}")
+
+    print("\n=== pooled by treatment (all passive fills) ===")
+    for t in ("baseline", "candidate"):
+        rows = pooled.get(t, [])
+        if not rows:
+            continue
+        print(f"{t:9s}: n{len(rows):3d}  cap {stat([r[0] for r in rows])}")
+        for i, h in enumerate(HORIZONS):
+            print(f"{'':9s}  mo{h:>4.0f}s {stat([r[1 + i] for r in rows])}")
+        arms = [a for a in arm_summary if a["treatment"] == t and a["pnl"] is not None]
+        if arms:
+            print(f"{'':9s}  sum pnl {sum(a['pnl'] for a in arms):+.3f}  "
+                  f"sum gross_spread {sum(a['gross'] for a in arms if a['gross']):+.3f}")
+
+    if pooled.get("baseline") and tier0_only.get("candidate"):
+        print("\n=== matched-condition: candidate tier0 fills vs all baseline fills ===")
+        for label, rows in (("baseline(all)", pooled["baseline"]),
+                            ("candidate(t0)", tier0_only["candidate"])):
+            mo5 = [r[2] for r in rows if r[2] is not None]
+            mo30 = [r[3] for r in rows if r[3] is not None]
+            print(f"{label:14s}: n{len(rows):3d} cap{mean([r[0] for r in rows]):+5.2f} "
+                  f"mo5{mean(mo5):+6.2f} mo30{mean(mo30):+6.2f}")
+
+    if pooled.get("candidate"):
+        print("\n=== candidate fills by tier ===")
+        by_t = defaultdict(list)
+        for r in pooled["candidate"]:
+            by_t[r[4]].append(r)
+        for t in sorted(by_t):
+            rows = by_t[t]
+            mo5 = [r[2] for r in rows if r[2] is not None]
+            mo30 = [r[3] for r in rows if r[3] is not None]
+            mo5_s = f"{mean(mo5):+6.2f}" if mo5 else "   n/a"
+            mo30_s = f"{mean(mo30):+6.2f}" if mo30 else "   n/a"
+            print(f"tier{t}: n{len(rows):3d} cap{mean([r[0] for r in rows]):+5.2f} "
+                  f"mo5{mo5_s} mo30{mo30_s}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit(__doc__)
+    main(sys.argv[1:])


### PR DESCRIPTION
…edge, not accepted

Overnight 2026-07-17T15:23Z -> 07-18T16:1xZ: 24h+ continuous docker run, 6 clean wind-down arm switches (4 with inventory, ~1s flatten), all completed arm manifests eligible with no missing cycles.

Pooled (baseline n=222, candidate n=112 passive fills): capture +4.58 vs +4.34 bps, markout-5s -5.51 vs -5.35 bps, markout-30s -8.71 vs -9.13 bps — identical within noise. Ops acceptance gates pass (uptime 99.2% vs 98.5%, no cancel-rate increase); economic gates fail (PnL -0.740 vs -0.173, markout improvement ~3% < required 10%).

Roadmap: stage 2 -> ab_completed_not_accepted; baseline remains the production config. Strategy-level finding recorded: the 8bps/~2.45s quote loop is structurally negative-edge on HYPE (~90%+ of fills adversely selected within 5s, net ~-4..-5 bps/fill at 30s) — next iteration should target asymmetric quoting / requote latency rather than tier tuning.

Adds scripts/maker_markout_ab.py (parameterized pooled markout analysis, used for the above numbers).