### PR TITLE
stage3 gate 重验 + lag-recorder HYPE 45h 实测 + manifest 容错

### DIFF
--- a/docs/14-maker-live-gate.md
+++ b/docs/14-maker-live-gate.md
@@ -66,5 +66,6 @@ unlock decision.
 
 ## Execution records
 
+- [2026-07-21 Stage 3 v0 renewed gate: canary and A/B start](evidence/maker-stage3-canary-2026-07-21.md)
 - [2026-07-14 WS order-command controlled canary](evidence/maker-ws-order-command-canary-2026-07-14.md)
 - [2026-07-10 maker paper long run, controlled disconnect, and supervised production canary](evidence/maker-live-gate-2026-07-10.md)

--- a/docs/18-maker-strategy-roadmap.md
+++ b/docs/18-maker-strategy-roadmap.md
@@ -311,7 +311,8 @@ peak-to-trough `vol_bps`）和当前 touch spread。markout/toxicity 与滚动 l
 
 ## 阶段 3：非线性库存控制
 
-当前状态：`implemented_pending_ab`（2026-07-20 实现已落地，待实盘时间片 A/B）。
+当前状态：`live_ab`（2026-07-20 实现落地；2026-07-21 gate 重验通过并启动 4 小时时间片 A/B，
+执行记录见 [maker-stage3-canary-2026-07-21.md](evidence/maker-stage3-canary-2026-07-21.md)）。
 立项依据是三项仲裁分析（610 笔 fill / 81 个库存事件 / 16 笔实测退出成本），记录见
 [maker-stage3-arbitration-2026-07-20.md](evidence/maker-stage3-arbitration-2026-07-20.md)，
 分析脚本 `scripts/maker_tail_arbitration.py`。

--- a/docs/21-maker-stage3-live-ab-runbook.md
+++ b/docs/21-maker-stage3-live-ab-runbook.md
@@ -1,0 +1,87 @@
+# Maker Stage 3 v0 live canary and A/B runbook
+
+本手册把 renewed live gate 应用到阶段 3 v0（size skew，退化为加仓侧压制）。
+流程与 [19-maker-stage2-live-ab-runbook.md](19-maker-stage2-live-ab-runbook.md)
+相同，本文只记录阶段 3 的差异与本次授权；未提及的章节（应急处置、webhook
+探针、bounded canary 判定顺序）以 19 号手册为准，symbol 一律替换为 HYPE-USD。
+
+Named online operator：**wujunlin**。Live work must not begin until the
+release record contains this exact authorization:
+
+> 授权执行 HYPE-USD size=0.1 max_position=1.0 的阶段3 canary 与4小时A/B
+
+该文本仅授权 HYPE-USD、`size=0.1`、一档、`max_position=1.0`。不授权其他
+symbol、更大敞口、主动库存退出或自动平仓。判定标准（预注册）见
+[18-maker-strategy-roadmap.md](18-maker-strategy-roadmap.md) 阶段 3 验收标准。
+
+## Frozen artifacts and preflight
+
+- Release commit：`c4fc893fb86d8c16193017a6dd047b097c57b2d0`
+  （stage3 v0 commit1–3 + 路线图快照，工作树干净）。
+- Frozen arm configs（仅 `[size_skew].enabled` 一行不同，编排器 preflight
+  已接受该形态）：
+  - `examples/maker-stage3-hype-baseline.toml`
+    sha256 `cccb5610c086aef9e2fb2b8f1d38266983f3acb877002a27f486f7fd456857db`
+  - `examples/maker-stage3-hype-candidate.toml`
+    sha256 `1e12bf17e35ad9c8105cbb733cbad21d28554677f62f59f38d1e76a798491dda`
+- 本地冻结 binary：`target/release/standx`（canary 用），sha256
+  `22a86c60d4caa9f5089aba8a5420784ce2b1c6e16907ce6dd38985ee4334b17f`。
+  A/B 容器内 binary 以镜像构建记录为准（同一 commit）。
+- 部署沿用阶段 2 HYPE 的 docker 路径：`deploy/docker/` 的 `ab-hype`
+  profile，`env_file=/etc/standx/maker-stage2-hype-ab.env`。阶段 3 仅需把该
+  env 中的两条配置路径改指 stage3 文件；
+  `STANDX_STAGE2_ARM_SECONDS=14400`（4h 臂）与
+  `STANDX_STAGE2_ARM_MAX_SECONDS=21600` 已就位。
+- 场馆 metadata（2026-07-21 新鲜 `standx -o json market symbols` 核对）：
+  `price_tick_decimals=3`、`qty_tick_decimals=2`、`min_order_qty=0.1`，与
+  env 的 `STANDX_BASELINE_*` 一致。
+- 离线证据（2026-07-21，commit c4fc893）：workspace tests 481 passed / 0
+  failed；strict Clippy 干净；`cargo fmt --check` 通过；
+  `py_compile scripts/openobserve_dashboard.py` 通过；编排器
+  `STANDX_STAGE2_VALIDATE_ONLY=1` 通过（pair 形态 size_skew.enabled-only）。
+- Candidate paper run：run_id `stage3-paper-20260721T012548Z`（35 分钟，
+  candidate 配置，703 cycles 完整、无 panic / 无不变量违规，manifest
+  `valid: true`）。
+- canary 期间 XAG/HYPE 两条 A/B 容器与任何手工 live maker 全部停止；锁路径
+  为容器本地（docker 部署的既有取舍，见 deploy/docker/README.md）。
+
+## Bounded canary（HYPE-USD）
+
+确认 `orders=[]` / `positions=[]` 后执行场馆最小 `ws-command-canary`，保留
+完整 create/cancel 关联链；随后用 **candidate** 配置做 15 秒受控断流演练
+（fail-safe 停机演习，非重连演习，语义见 19 号手册）：
+
+```bash
+export STANDX_ENABLE_LIVE_MAKER=1
+target/release/standx --output json maker ws-command-canary HYPE-USD
+
+export STANDX_RUN_ID="stage3-canary-$(date -u +%Y%m%dT%H%M%SZ)"
+scripts/run_maker_observed.sh target/release/standx --output json maker run HYPE-USD \
+  --maker-config examples/maker-stage3-hype-candidate.toml --live \
+  --controlled-disconnect-after 15
+```
+
+期望序列：order-response fault observed → frozen → maker cleanup/empty book →
+fail-safe shutdown（非零退出是演习预期结果）。任何残余订单、非零终仓或
+cleanup 失败 → 走 19 号手册应急处置（symbol 换 HYPE-USD），本次 run 标记
+失败，重试需要新的精确授权。
+
+## Four-hour automatic A/B
+
+Canary 证据接受后：
+
+```bash
+cd deploy/docker
+docker compose --profile ab-hype up -d --build   # 镜像按 c4fc893 重建
+docker compose --profile ab-hype logs -f
+```
+
+编排器 baseline 先行、candidate 随后交替；每臂 4 小时最小时长 + SIGUSR1
+wind-down 换臂，换臂前 manifest validate + 独立空订单/空仓检查。判定按 18
+号文档阶段 3 验收标准：样本外 `p95 |position|` 降 ≥15% 或
+`|position| >= 70% max_position` 时间降 ≥25%；net PnL ≥ 基线 95%；时间加权
+双边 uptime 降幅 ≤3pp；主动退出次数与总 taker exit cost 不高于基线。比较
+窗口须同时覆盖平静与趋势时段，趋势不足则延长采集。
+
+**注意**：不要把 `--controlled-disconnect-after` 传给 A/B 编排器（提前退出的
+臂会被判 critical stop）。

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,9 @@ docs/
 ├── 16-ws-iteration-goals.md  # Maker WebSocket 迭代目标
 ├── 17-ws-command-canary-quickstart.md # WS 生产 Canary 快速启动
 ├── 18-maker-strategy-roadmap.md # Maker 策略迭代路线与验收标准
-└── 19-maker-stage2-live-ab-runbook.md # Stage 2 canary/A-B 操作手册
+├── 19-maker-stage2-live-ab-runbook.md # Stage 2 canary/A-B 操作手册
+├── 20-maker-short-term-roadmap-2026-07.md # Maker 短期迭代路线图快照（2026-07）
+└── 21-maker-stage3-live-ab-runbook.md # Stage 3 canary/A-B 操作手册
 ```
 
 ---
@@ -55,6 +57,8 @@ docs/
 | [17-ws-command-canary-quickstart.md](17-ws-command-canary-quickstart.md) | WS 生产 Canary 配置、执行与成功判据 | 操作手册 |
 | [18-maker-strategy-roadmap.md](18-maker-strategy-roadmap.md) | Maker 策略分阶段目标、量化验收标准与晋级门槛 | 开发参考 |
 | [19-maker-stage2-live-ab-runbook.md](19-maker-stage2-live-ab-runbook.md) | Stage 2 小额 canary、应急处置与 2 小时 A/B | 操作手册 |
+| [20-maker-short-term-roadmap-2026-07.md](20-maker-short-term-roadmap-2026-07.md) | Maker 短期迭代路线图快照（主线阶段 3 A/B） | 开发参考 |
+| [21-maker-stage3-live-ab-runbook.md](21-maker-stage3-live-ab-runbook.md) | Stage 3 canary、应急处置与 4 小时 A/B | 操作手册 |
 
 ---
 

--- a/docs/evidence/lag-recorder-hype-result-2026-07-22.md
+++ b/docs/evidence/lag-recorder-hype-result-2026-07-22.md
@@ -78,3 +78,63 @@
 - 录制进程 uptime 44.5h，双源零重连；NDJSON 665,407 行末行校验通过。
 - 录制期间每 4 小时增量分析一次（共 11 次），跟随事件 n 从 8 增至 29，
   中位数收敛过程：838 → 865 → 945 → 985 → 1097 → 1240 → 1271 → 1209ms。
+- 更正：首次 SIGTERM 只终止了 shell 包装进程，录制子进程多运行了 ~1.7h；
+  真实停止于 2026-07-22T02:08Z（优雅 flush，末行校验通过）。最终文件
+  672,499 行（standx=514,583 / hyperliquid=157,916），重叠跨度 161,946s。
+  上文 44.5h 数字基于冻结前的 665,407 行快照，结论不受影响。
+
+## Update 2026-07-22: per-source fields + stratified coverage + own-feed response
+
+分析器补丁（`scripts/lag_analysis.py`，对同一份数据重跑，零新录制成本）：
+
+1. 每源独立字段：leader 改用 HL `midPx`（`--leader-field mid`，盘口中间价，
+   该 feed 上最快的公开价格），StandX 侧仍用 `mark`（maker 报价基准）。
+   原 `--field` 参数被 `--standx-field` / `--leader-field` 取代。
+2. 覆盖率按跳幅分层（[1x, 2x, 4x, 8x) × event-bps）。
+3. 新增 StandX mark 自身跳动响应速度统计（own-feed 快撤定价）。
+
+### Results with midPx leader（冻结后的完整文件）
+
+Cross-correlation：峰值 **+1500ms（StandX LAGS）**，r=0.071 仍弱，
+但 +750~+2250ms 呈宽平台（0.06–0.07），方向与"StandX 滞后"假设一致——
+此前 markPx-vs-markPx 的负向噪声峰值部分是把滞后聚合价当 leader 的伪影。
+
+Event response（≥8bps / 2s 窗口，131 次跳动）：
+
+- already ahead：**26（20%）**（markPx leader 时为 65%）
+- never follow：25（19%）
+- measurable follow：**80（61%）**，median=**2622ms**，p25=1834ms，
+  p75=3425ms，mean=2755ms
+
+按跳幅分层：
+
+| tier(bps) | jumps | already | never | follow | follow-median |
+| --- | --- | --- | --- | --- | --- |
+| 8–16 | 123 | 26 | 24 | 73 | 2570ms |
+| 16–32 | 8 | 0 | 1 | 7 | 2681ms |
+| ≥32 | 0 | – | – | – | – |
+
+StandX own-feed response（自身 mark ≥8bps / 6s 窗口，267 次）：
+
+- 覆盖自身 50% 变动：median=3001ms，p25=3000ms，p75=5999ms，mean=4119ms
+- 覆盖自身 90% 变动：median=5998ms，p25=3000ms，p75=6000ms，mean=4686ms
+- 数值量化到 ~3s 的 mark 更新节奏（p25/p75 恰为 3000/6000ms），应读作
+  "跳动需要 1–2 个 mark tick 完成"，而非连续速度。
+
+### Revised interpretation
+
+- **条件性 lag 上修至 ~2.6s**（此前 markPx leader 估计 1.2s）：HL markPx
+  本身是向 oracle 平滑的滞后聚合价；以盘口 midPx 为真正领先者，StandX
+  mark 的跟随中位数 2.6s，p75 3.4s，明确落在 1–3s 可防守窗口内。
+- **覆盖率大幅上修**：可测量跟随占 61%（此前 19%），"StandX 已在前侧"
+  仅 20%。且分层显示跳幅越大 StandX 越可靠地落后（16–32bps 档 0 次
+  already-ahead、跟随率 7/8），可利用性集中在真正造成 toxic fill 的
+  较大跳动上。≥32bps 档无样本，尾部仍未知。
+- **own-feed 快撤定价**：靠自身 mark 检测跳动，最快也要 ~3s（一个 tick）
+  才能看到 50% 的变动——own-feed 触发比外部 midPx 信号慢约一个量级，
+  但它是无条件可用的兜底（267 次自身跳动全部最终可被本地观测）。
+  快撤若按 own-feed 定价，预算为 1 个 mark tick（~3s）；外部信号预算
+  ~2.6s 的跟随中位数减去撤单 RTT（0.3–0.5s），仍有 ~2s 余量。
+- 对 Stage 4 的含义转正：外部价格引导报价路线从"弱支持"上调为"有实质
+  支持"——窗口存在、覆盖率过半、且在大跳幅档最可靠。仍须与
+  widen-spread A/B 结论及 SIP-5A $/Maker-Hour 联合决策。

--- a/docs/evidence/lag-recorder-hype-result-2026-07-22.md
+++ b/docs/evidence/lag-recorder-hype-result-2026-07-22.md
@@ -1,0 +1,80 @@
+# StandX↔Hyperliquid lag-recorder HYPE 实测结果 — 2026-07-22
+
+## Decision
+
+- Status: `measurement_complete_conditional_window_found_low_coverage`
+- 44.5 小时实测（2026-07-20T05:09Z ~ 2026-07-22T00:33Z，重叠跨度
+  160,284s，录制主机零重连）。
+- 条件性 lag（StandX 发生跟随时）≈ **1.2s**（中位数 1209ms，p25=777ms，
+  p75=2380ms，均值 1750ms），落入工具交付文档定义的 1–3s 窗口下沿；
+  **不是** `< ~0.3s 路线终止` 的情形。
+- 但信号覆盖率仅 ~19%（154 次跳动中仅 29 次产生可测量跟随）：对大多数
+  行情，外部价格并无领先性。原假设"StandX mark 系统性滞后、存在可利用
+  窗口"只得到弱支持——**窗口存在但稀疏**。
+- Stage 4（fair-price / order-flow）决策须将此覆盖率约束与 widen-spread
+  A/B 结论、SIP-5A $/Maker-Hour 联合评估；本测量只提供 lag 数字，
+  不改变任何报价行为。
+
+## Setup
+
+- Tool: `standx lag-recorder`（PR #319，`lag-recorder-standx-hyperliquid`），
+  read-only，无认证、无订单。
+- Command: `target/release/standx lag-recorder --symbol HYPE-USD --out
+  var/standx/lag-rec-20260720T050910Z.ndjson --status-secs 300`
+- Data: `var/standx/lag-rec-20260720T050910Z.ndjson`（665,407 行，
+  StandX 508,953 / Hyperliquid 156,201，SIGTERM 优雅 flush 退出，
+  末行 JSON 校验通过）；stderr 心跳日志同 basename `.stderr.log`。
+- Analyzer: `python3 scripts/lag_analysis.py`（stdlib only）。
+- 行情覆盖：HYPE mark 60.0–62.8，含多段平静期与一轮 ~4% 的下行波动
+  （62.7 → 60.1），跳动事件主要在波动期产生。
+
+## Results
+
+### Event response（主估计）
+
+154 次 Hyperliquid ≥8bps 跳动（2s 窗口内）：
+
+| 类别 | 次数 | 占比 |
+| --- | --- | --- |
+| StandX 已在前侧（同步或领先） | 100 | 65% |
+| 完全不跟随（窗口内未覆盖 50%） | 25 | 16% |
+| 可测量跟随 | 29 | 19% |
+
+可测量跟随事件（n=29）的 follow-time（覆盖 50% 跳动幅度）：
+
+- median=1209ms, p25=777ms, p75=2380ms, mean=1750ms
+- 收敛性：最近三次 4h 间隔检查中位数分别为 1271 / 1209 / 1209ms，
+  估计已稳定。
+
+### Cross-correlation（辅助估计）
+
+- 全程噪声水平（峰值 r ≤ 0.06），峰值位置在 -500ms ~ -3750ms 间漂移，
+  无证据价值，不予采信。
+
+## Interpretation
+
+- 按交付文档阈值框架：条件性 lag ≈ 1.2s 位于 1–3s "可防守窗口"下沿，
+  外部价格引导报价路线**未被证据否定**。
+- 但 65% 的跳动 StandX 并不落后、16% 完全不跟随：可利用跟随只占 ~19%。
+  即使 Stage 4 采用外部 mark 作为领先信号，其预期价值受覆盖率制约，
+  需在候选人机台/PnL 模型中以 ~19% 触发率折算。
+- 与 HYPE jump-kill 毒性诊断的关联：74% toxic fills 无本地盘口前兆，
+  本测量确认外部领先市场确实存在 StandX 跟随后 ~1.2s 才到位的行情片段，
+  与 jump-kill 假设方向一致，但只覆盖少数跳动事件。
+
+## Honest limitations
+
+- 绝对 lag 带固定差分网络延迟偏移（录制主机→StandX 与→Hyperliquid 的
+  RTT 差）。本机有 maker live 运行记录（`var/standx/` 下 stage2/xag-live
+  日志），推定为 maker 同主机，但未单独验证区域一致性；变量部分（跟随
+  分布形态）稳健，绝对值 ±RTT 差。
+- 分辨率下限 ~0.5s（HL activeAssetCtx 出块节奏）；p25=777ms 接近但仍
+  高于下限。
+- 单窗口、单品种：结果 HYPE 专属，其他 symbol 须重新录制。
+- 未覆盖极端行情（急跌/急涨 >10%）；尾部行为未知。
+
+## Data integrity
+
+- 录制进程 uptime 44.5h，双源零重连；NDJSON 665,407 行末行校验通过。
+- 录制期间每 4 小时增量分析一次（共 11 次），跟随事件 n 从 8 增至 29，
+  中位数收敛过程：838 → 865 → 945 → 985 → 1097 → 1240 → 1271 → 1209ms。

--- a/docs/evidence/maker-stage3-canary-2026-07-21.md
+++ b/docs/evidence/maker-stage3-canary-2026-07-21.md
@@ -1,0 +1,152 @@
+# Stage 3 v0 live gate 重验记录（2026-07-21）
+
+阶段 3 v0（size skew → 退化为加仓侧压制）策略代码合并后的 renewed live gate
+证据。流程依据 [14-maker-live-gate.md](../14-maker-live-gate.md) 与
+[21-maker-stage3-live-ab-runbook.md](../21-maker-stage3-live-ab-runbook.md)。
+
+- Release commit：`c4fc893fb86d8c16193017a6dd047b097c57b2d0`（工作树干净）
+- Named operator：wujunlin
+- 授权文本（release record）：
+
+  > 授权执行 HYPE-USD size=0.1 max_position=1.0 的阶段3 canary 与4小时A/B
+
+## 离线证据（commit c4fc893）
+
+- `cargo test --workspace --offline`：481 passed / 0 failed（exit 0）。
+- `cargo clippy --workspace --all-targets --offline -- -D warnings`：干净。
+- `cargo fmt --all -- --check`：通过；`py_compile openobserve_dashboard.py`：通过。
+- 编排器 preflight 接受 stage3 配置对（仅 `[size_skew].enabled` 一行差异），
+  本地与容器内 `STANDX_STAGE2_VALIDATE_ONLY=1` 均通过：
+  - baseline `maker-stage3-hype-baseline.toml` sha256
+    `cccb5610c086aef9e2fb2b8f1d38266983f3acb877002a27f486f7fd456857db`
+  - candidate `maker-stage3-hype-candidate.toml` sha256
+    `1e12bf17e35ad9c8105cbb733cbad21d28554677f62f59f38d1e76a798491dda`
+- 新鲜 venue metadata（2026-07-21 `standx -o json market symbols`）：
+  `price_tick_decimals=3`、`qty_tick_decimals=2`、`min_order_qty=0.1`，与
+  `/etc/standx/maker-stage2-hype-ab.env` 的 `STANDX_BASELINE_*` 一致。
+- 冻结 binary（canary 用 `target/release/standx`）sha256
+  `22a86c60d4caa9f5089aba8a5420784ce2b1c6e16907ce6dd38985ee4334b17f`。
+- A/B 用 docker 镜像按 c4fc893 重建（build-time dirty-tree gate 通过）。
+- Candidate paper run：见末节。
+
+## Webhook 探针
+
+- `scripts/test_maker_stage2_webhooks.py` 四类探针（stop_loss / position_risk /
+  equity / margin）全部发送成功，`test_id=stage2-webhook-829a685b2927`。
+- 操作人已在同一接收端人工确认四条全部收到。
+
+## ws-command-canary（HYPE-USD，2026-07-21T01:26Z）
+
+Preflight `orders=[] positions=[]` 后执行，关联链完整：
+
+| 环节 | 值 |
+|---|---|
+| client_order_id | `sxmk-canary-a912a08a4c22` |
+| create request_id | `6c5c39b4-f78b-45f6-be1a-5cdcfb6bfc7d` → accepted (code 0) |
+| venue order_id | `11715278851`（REST 可见） |
+| cancel request_id | `890e6b66-6678-4e1b-a197-9e931d386251` → accepted (code 0) |
+| REST absence | verified |
+| 终仓 | 0.0（verified） |
+
+## 受控断流演练（candidate 配置，`--controlled-disconnect-after 15`）
+
+run_id `stage3-canary-20260721T012635Z`，序列与预期完全一致：
+
+1. `01:26:36` lifecycle started（LIVE HYPE-USD）
+2. `01:26:51` `risk_notification order_response/disconnected_frozen`
+   （15s 故障注入，placements frozen）
+3. `01:26:52` `reconnect_unavailable`（受控注入要求 fail-safe）
+4. `01:26:53` `fail_safe/stopped` + maker cleanup → 空簿
+5. 退出码 75（fail-safe 演习预期结果，非失败）
+
+Manifest 14/14 checks 全部通过（`symbol_metadata_complete`、
+`lifecycle_stopped` 等均 true）；`baseline_eligible=false` 仅因 exit 75，
+与 stage2 历史 canary manifest 形态一致。演练后独立复核
+`orders=[] positions=[]`。
+
+## Candidate paper run
+
+- 初跑 `stage3-paper-20260721T003917Z`（35 分钟，701 cycle_summary 完整无缺
+  无重、5 笔 paper fill、零 panic/不变量违规、wrapper 报告 exit 0）；因本地
+  采集未带 `STANDX_BASELINE_*` 且停机事件未落盘，manifest 两项检查不通过，
+  仅作过程参考。
+- 重跑 `stage3-paper-20260721T012548Z`（35 分钟 / 2101s，703 cycle_summary
+  完整无缺无重、lifecycle started+stopped、零 panic/不变量违规、exit 0）：
+  **manifest `valid: true`，baseline_eligible=true**。
+
+## A/B 启动（2026-07-21T02:03Z）
+
+- `docker compose --profile ab-hype up -d`（镜像 c4fc893，entrypoint 安装
+  deadman alert 后启动编排器）。
+- **一次误启动及纠正**：首次 `up` 时 env 残留上一次 A/B 的
+  `STANDX_STAGE2_FIRST_ARM=candidate`，candidate 臂先跑了约 2.5 分钟
+  （run_id `stage2-candidate-20260721T020148Z-1e12bf17e35a`，703→22 cycles，
+  无成交、停机后独立复核 `orders=[] positions=[]`）。立即
+  `docker compose stop`（SIGTERM → 正常 freeze/cancel-all），把
+  `FIRST_ARM` 改回 `baseline` 后重启。该片段 run 不足 300 cycles，
+  `comparison_window_eligible=false`，不进入任何比较窗口，但在此留痕。
+- 正式 A/B 首臂：`stage2-baseline-20260721T020339Z-cccb5610c086`
+  （baseline，config hash `cccb5610c086…`），live 双边报价正常，
+  OpenObserve 实时上传正常。臂长 4h（`STANDX_STAGE2_ARM_SECONDS=14400`），
+  wind-down 换臂。
+
+## 判定
+
+Gate 重验通过项：离线工程证据、webhook 可达、ws-command 关联链、受控断流
+fail-safe 序列、candidate paper 长跑 manifest 有效、账面独立复核。
+A/B 于 2026-07-21T02:03Z 开跑，进入采集阶段；判定按 18 号文档阶段 3 验收
+标准执行。
+
+## 事件：baseline 首臂 manifest 误判作废与工具修复（2026-07-21T06:03Z）
+
+- **经过**：baseline 首臂（`stage2-baseline-20260721T020339Z-cccb5610c086`）
+  4h 窗口正常交易收官（5069 cycles、22 笔被动成交、net PnL +0.12、时间加权
+  uptime 99.4%、wind-down 后空仓空簿 exit 0），但 manifest
+  `cycle_sequence_complete` 检查因 1 个重复 cycle_summary（cycle 4174）
+  失败，编排器 fail-closed 判臂作废并 critical stop（exit 75）。
+- **根因**：05:21:52 cycle 4174 的 summary 发出后，cancel 打在刚成交的订单
+  上被场馆拒绝（400 "order is not open"，cancel-after-fill 竞争），运行时按
+  fail-closed 设计冻结 → cleanup → order-response 重连（2s 恢复，账本
+  17 fills = 17 trades 无重复）→ 重试该 cycle 并第二次发出 summary。这是
+  运行时"cycle 失效重试"的既定行为与 manifest"不允许重复 cycle"检查之间的
+  契约缺口，非交易故障。臂内另有 9 次 position_reconciliation 冻结（均 3s
+  窗口内恢复）未触发重复。
+- **处置（release owner 裁决）**：修复证据工具——`maker_run_manifest.py`
+  的 `cycle_sequence_complete` 现仅容忍"两次发射之间存在冻结事件
+  （`risk_notification` 的 `frozen`/`disconnected_frozen`）"的同号重复，
+  记为 `freeze_retried_cycles`；无冻结相邻的重复仍然判失败。补两个测试
+  （冻结相邻通过 / 冻结不相邻失败），10/10 通过。commit `7e8c556`。
+- **重验**：用修复后工具对原臂重新 finalize + validate：`valid: true`，
+  `baseline_eligible=true`，`duplicate_cycles=[4174]` 全部标记为
+  freeze-retried；manifest 保留 `invalidated_at=2026-07-21T06:03:52Z` 作为
+  审计痕迹。该臂数据计入比较窗口。
+- **续跑**：镜像按 7e8c556 重建（后续臂用修复后工具），
+  `STANDX_STAGE2_FIRST_ARM=candidate` 从 candidate 臂续跑；之后的循环自动
+  回到 baseline。
+
+## 事件 2：市况冻结致缺 cycle，同一契约缺口的镜像形态（2026-07-21T17:5xZ）
+
+- **经过**：candidate 臂（`stage2-candidate-20260721T093136Z-1e12bf17e35a`）
+  完成且 manifest 通过；随后的 baseline 臂
+  （`stage2-baseline-20260721T133204Z-cccb5610c086`，5496 cycles）在
+  wind-down 正常收官（含一次 0.4 HYPE reduce-only 平仓，账面空仓空簿）后，
+  因缺 cycle 5153 再被判无效，A/B 中断约 8 小时。
+- **根因**：17:15:09–17:15:50 场馆行情传输静默 ~41s
+  （`market_data degraded_frozen: feed_idle bad_for_ms=40930`），cycle
+  5153 撞上市况冻结被作废且未发任何终态事件（无 summary 无 skip）。与事件
+  1 是同一契约缺口的镜像：运行时冻结作废 cycle 可能多发（重试）或少发
+  （丢失）终态事件。
+- **处置（同一裁决原则）**：`cycle_sequence_complete` 扩展为——缺失 cycle
+  在其两侧最近观测 cycle 之间存在"cycle 字段命中 {N, N+1}"的冻结通知时记为
+  `freeze_lost_cycles` 并容忍；重复 cycle 的容忍条件同步收紧为冻结通知的
+  cycle 字段必须等于该 cycle（含 `degraded_frozen` 事件名）。新增 2 个测试，
+  12/12 通过。commit `f259582`。
+- **重验**：两条 baseline 臂均 `valid: true`、`baseline_eligible=true`
+  （事件 1 的臂在收紧后的规则下依然通过）。两臂数据计入比较窗口。
+- **续跑**：镜像按 f259582 重建，candidate 臂
+  `stage2-candidate-20260722T020734Z-1e12bf17e35a` 于 2026-07-22T02:07Z
+  起跑。
+
+**运维注记**：运行时侧让每个 cycle 必发终态事件（summary/skip）是根治方向，
+涉及遥测契约变更与重新 gate，记录为后续候选改进；在此之前工具侧容忍规则
+覆盖已观测到的两类冻结形态。

--- a/scripts/lag_analysis.py
+++ b/scripts/lag_analysis.py
@@ -2,7 +2,8 @@
 """Measure how far StandX's mark price lags Hyperliquid. Read-only, stdlib only.
 
 Usage:
-    python3 scripts/lag_analysis.py LAG.ndjson [--field mark|mid|index]
+    python3 scripts/lag_analysis.py LAG.ndjson [--standx-field mark|mid|index]
+                                    [--leader-field mark|mid|index]
                                     [--grid-ms 250] [--max-lag-ms 4000]
                                     [--event-bps 8] [--event-window-ms 2000]
                                     [--cover-frac 0.5]
@@ -11,7 +12,12 @@ Input is the NDJSON produced by `standx lag-recorder`: one price observation per
 line, each tagged `source` ("standx" | "hyperliquid") with a common-clock
 `local_recv_ms` and price fields (mark/mid/index/last/best_bid/best_ask).
 
-Two independent lag estimates are printed:
+Each source uses its own field: the leader (Hyperliquid) defaults to `mid`
+(midPx, the fastest-moving public price on that feed), StandX to `mark` (the
+price the maker quotes against). The earlier single `--field` option was
+replaced by `--standx-field` / `--leader-field`.
+
+Three statistics are printed:
 
 1. Cross-correlation of resampled price increments across candidate lags. The
    lag maximizing correlation is the typical co-movement offset (positive =
@@ -19,7 +25,16 @@ Two independent lag estimates are printed:
 2. Event response: when Hyperliquid jumps sharply, how long until StandX covers
    a fraction of that move. More robust than (1) because it isolates the moments
    that actually matter (the jumps that snipe stale quotes), and it is directly
-   causal (measured from realized price paths).
+   causal (measured from realized price paths). Coverage outcomes (already
+   ahead / never followed / measurable follow) are stratified by jump size in
+   tiers of [1x, 2x, 4x, 8x) * --event-bps, so the exploitability of the window
+   can be read per regime.
+3. StandX own-feed jump response: for jumps detected on StandX's OWN series,
+   how fast StandX's mark itself traverses 50% / 90% of the move. This prices
+   an "own-feed fast cancel": how much of the move is still ahead of you once
+   your own feed starts moving. StandX's mark updates at a slower cadence than
+   the leader feed, so its jump scan uses a wider window (--own-window-ms,
+   default 3x --event-window-ms).
 
 HONEST CAVEATS (also printed at the end):
 - The common local clock carries a FIXED differential-network-latency offset:
@@ -38,8 +53,10 @@ import json
 from statistics import mean, median
 
 
-def load(path, field):
-    """Return (standx, hyper): each a sorted list of (t_ms, price)."""
+def load(path, standx_field, leader_field):
+    """Return (standx, hyper): each a sorted list of (t_ms, price). Each source
+    reads its own price field; lines where that field is null are skipped."""
+    fields = {"standx": standx_field, "hyperliquid": leader_field}
     series = {"standx": [], "hyperliquid": []}
     with open(path) as handle:
         for line in handle:
@@ -53,7 +70,7 @@ def load(path, field):
             source = rec.get("source")
             if source not in series:
                 continue
-            price = rec.get(field)
+            price = rec.get(fields[source])
             if price is None:
                 continue
             t = rec.get("local_recv_ms")
@@ -130,9 +147,31 @@ def cross_correlation(standx, hyper, grid_ms, max_lag_ms):
     return best, curve
 
 
+def detect_jumps(series, event_bps, window_ms):
+    """Yield (t0, p0, p1, move_bps) for the first later sample within
+    `window_ms` that moves >= event_bps from each anchor sample. Detection
+    semantics are shared by the leader and the own-feed scan so jump sets are
+    comparable."""
+    n = len(series)
+    jumps = []
+    for i in range(n):
+        t0, p0 = series[i]
+        k = i + 1
+        while k < n and series[k][0] - t0 <= window_ms:
+            t1, p1 = series[k]
+            move_bps = (p1 / p0 - 1.0) * 1e4
+            if abs(move_bps) >= event_bps:
+                jumps.append((t0, p0, p1, move_bps))
+                break
+            k += 1
+    return jumps
+
+
 def event_response(standx, hyper, event_bps, window_ms, cover_frac):
     """For each sharp Hyperliquid jump, measure ms until StandX covers
-    `cover_frac` of the move in the same direction."""
+    `cover_frac` of the move in the same direction. Returns a list of
+    (abs_move_bps, outcome, follow_ms) with outcome in
+    "already" | "never" | "follow" (follow_ms set only for "follow")."""
     st_times = [row[0] for row in standx]
     st_px = [row[1] for row in standx]
 
@@ -140,44 +179,55 @@ def event_response(standx, hyper, event_bps, window_ms, cover_frac):
         i = bisect.bisect_right(st_times, t) - 1
         return st_px[i] if i >= 0 else None
 
-    responses = []
-    already = 0  # StandX had already moved by event time
-    never = 0    # StandX never covered within a generous follow window
-    follow_ms = max(window_ms * 4, 8000)
+    events = []
+    follow_ms_limit = max(window_ms * 4, 8000)
 
-    n = len(hyper)
-    j = 0
-    for i in range(n):
-        t0, p0 = hyper[i]
-        # find the first later sample within window that constitutes a jump
-        k = i + 1
-        while k < n and hyper[k][0] - t0 <= window_ms:
-            t1, p1 = hyper[k]
-            move_bps = (p1 / p0 - 1.0) * 1e4
-            if abs(move_bps) >= event_bps:
-                direction = 1.0 if p1 > p0 else -1.0
-                target = p0 + cover_frac * (p1 - p0)
-                s0 = standx_at(t0)
-                if s0 is not None and direction * (s0 - target) >= 0:
-                    already += 1
-                else:
-                    # find first StandX sample at/after t0 that reaches target
-                    idx = bisect.bisect_left(st_times, t0)
-                    hit = None
-                    while idx < len(standx) and st_times[idx] - t0 <= follow_ms:
-                        if direction * (st_px[idx] - target) >= 0:
-                            hit = st_times[idx] - t0
-                            break
-                        idx += 1
-                    if hit is None:
-                        never += 1
-                    else:
-                        responses.append(hit)
+    for t0, p0, p1, move_bps in detect_jumps(hyper, event_bps, window_ms):
+        direction = 1.0 if p1 > p0 else -1.0
+        target = p0 + cover_frac * (p1 - p0)
+        s0 = standx_at(t0)
+        if s0 is not None and direction * (s0 - target) >= 0:
+            events.append((abs(move_bps), "already", None))
+            continue
+        # find first StandX sample at/after t0 that reaches target
+        idx = bisect.bisect_left(st_times, t0)
+        hit = None
+        while idx < len(standx) and st_times[idx] - t0 <= follow_ms_limit:
+            if direction * (st_px[idx] - target) >= 0:
+                hit = st_times[idx] - t0
                 break
-            k += 1
-        j = i
-    _ = j
-    return responses, already, never
+            idx += 1
+        if hit is None:
+            events.append((abs(move_bps), "never", None))
+        else:
+            events.append((abs(move_bps), "follow", hit))
+    return events
+
+
+def own_jump_response(series, event_bps, window_ms, fracs=(0.5, 0.9)):
+    """Detect jumps on a single (StandX own) series and measure, per jump, the
+    ms from the jump's first sample until the series itself covers each
+    fraction of the move. Prices an own-feed fast cancel: how much traverse
+    time your own feed gives you once it starts moving.
+    Returns (jump_sizes, {frac: [ms, ...]})."""
+    times = [row[0] for row in series]
+    px = [row[1] for row in series]
+    n = len(series)
+    by_frac = {f: [] for f in fracs}
+    sizes = []
+    for t0, p0, p1, move_bps in detect_jumps(series, event_bps, window_ms):
+        direction = 1.0 if p1 > p0 else -1.0
+        sizes.append(abs(move_bps))
+        i0 = bisect.bisect_left(times, t0)
+        for f in fracs:
+            target = p0 + f * (p1 - p0)
+            idx = i0
+            while idx < n:
+                if direction * (px[idx] - target) >= 0:
+                    by_frac[f].append(times[idx] - t0)
+                    break
+                idx += 1
+    return sizes, by_frac
 
 
 def quantile(xs, q):
@@ -190,20 +240,36 @@ def quantile(xs, q):
     return s[lo] + (s[hi] - s[lo]) * (pos - lo)
 
 
+def fmt_stats(xs):
+    return (f"median={median(xs):.0f}ms  "
+            f"p25={quantile(xs, 0.25):.0f}ms  "
+            f"p75={quantile(xs, 0.75):.0f}ms  "
+            f"mean={mean(xs):.0f}ms")
+
+
 def main():
     ap = argparse.ArgumentParser(description="Measure StandX price lag vs Hyperliquid.")
     ap.add_argument("path")
-    ap.add_argument("--field", default="mark", choices=["mark", "mid", "index"])
+    ap.add_argument("--standx-field", default="mark",
+                    choices=["mark", "mid", "index"],
+                    help="StandX price field (the price we quote against)")
+    ap.add_argument("--leader-field", default="mid",
+                    choices=["mark", "mid", "index"],
+                    help="Hyperliquid leader field (midPx is the fastest public price)")
     ap.add_argument("--grid-ms", type=int, default=250)
     ap.add_argument("--max-lag-ms", type=int, default=4000)
     ap.add_argument("--event-bps", type=float, default=8.0)
     ap.add_argument("--event-window-ms", type=int, default=2000)
     ap.add_argument("--cover-frac", type=float, default=0.5)
+    ap.add_argument("--own-window-ms", type=int, default=None,
+                    help="jump-scan window for the StandX own-feed statistic; "
+                         "defaults to 3x --event-window-ms because StandX's mark "
+                         "cadence is slower than the leader feed's")
     args = ap.parse_args()
 
-    standx, hyper = load(args.path, args.field)
-    print(f"loaded: standx={len(standx)} hyperliquid={len(hyper)} samples "
-          f"(field={args.field})")
+    standx, hyper = load(args.path, args.standx_field, args.leader_field)
+    print(f"loaded: standx={len(standx)} (field={args.standx_field}) "
+          f"hyperliquid={len(hyper)} (field={args.leader_field}) samples")
     if len(standx) < 5 or len(hyper) < 5:
         print("not enough samples on both sources; record a longer window.")
         return
@@ -228,9 +294,12 @@ def main():
                   " treat as 'no resolvable lead'.")
 
     print("\n== 2. Event response (Hyperliquid jumps -> StandX follow time) ==")
-    responses, already, never = event_response(
+    events = event_response(
         standx, hyper, args.event_bps, args.event_window_ms, args.cover_frac)
-    total = len(responses) + already + never
+    total = len(events)
+    already = sum(1 for _, o, _ in events if o == "already")
+    never = sum(1 for _, o, _ in events if o == "never")
+    responses = [ms for _, o, ms in events if o == "follow"]
     print(f"  jumps >= {args.event_bps:g}bps within {args.event_window_ms}ms: {total}")
     if total:
         print(f"    StandX already ahead at jump: {already}")
@@ -238,12 +307,44 @@ def main():
     if responses:
         print(f"    follow-time to cover {args.cover_frac:.0%} of the move "
               f"(n={len(responses)}):")
-        print(f"      median={median(responses):.0f}ms  "
-              f"p25={quantile(responses,0.25):.0f}ms  "
-              f"p75={quantile(responses,0.75):.0f}ms  "
-              f"mean={mean(responses):.0f}ms")
+        print(f"      {fmt_stats(responses)}")
     else:
         print("    no measurable follow events (need a longer / more volatile window).")
+
+    # coverage stratified by jump size, in tiers of [1x, 2x, 4x, 8x) * event-bps
+    if total:
+        print("  coverage by jump size:")
+        print("    tier(bps)   jumps  already  never  follow  follow-median")
+        edges = [args.event_bps * m for m in (1, 2, 4, 8)]
+        for t_i in range(len(edges)):
+            lo = edges[t_i]
+            hi = edges[t_i + 1] if t_i + 1 < len(edges) else None
+            tier = [e for e in events
+                    if e[0] >= lo and (hi is None or e[0] < hi)]
+            if not tier:
+                continue
+            t_jumps = len(tier)
+            t_already = sum(1 for _, o, _ in tier if o == "already")
+            t_never = sum(1 for _, o, _ in tier if o == "never")
+            t_follow = [ms for _, o, ms in tier if o == "follow"]
+            label = f"{lo:g}-{hi:g}" if hi is not None else f">={lo:g}"
+            med = f"{median(t_follow):.0f}ms" if t_follow else "-"
+            print(f"    {label:<10} {t_jumps:>6} {t_already:>8} {t_never:>6}"
+                  f" {len(t_follow):>7}  {med:>13}")
+
+    print("\n== 3. StandX own-feed jump response (fast-cancel pricing) ==")
+    own_window_ms = args.own_window_ms or args.event_window_ms * 3
+    sizes, by_frac = own_jump_response(
+        standx, args.event_bps, own_window_ms)
+    print(f"  StandX own jumps >= {args.event_bps:g}bps within "
+          f"{own_window_ms}ms: {len(sizes)}")
+    for f in sorted(by_frac):
+        xs = by_frac[f]
+        if xs:
+            print(f"    time for own mark to cover {f:.0%} of its move (n={len(xs)}):")
+            print(f"      {fmt_stats(xs)}")
+    if not sizes:
+        print("    no own-feed jumps (need a longer / more volatile window).")
 
     print("\n== Caveats ==")
     print("  - Absolute lag carries a fixed differential-network-latency bias "

--- a/scripts/maker_run_manifest.py
+++ b/scripts/maker_run_manifest.py
@@ -250,6 +250,8 @@ def classify_regime(metrics: dict[str, Any], cycles: int, duration_seconds: floa
 def analyze_log(path: Path) -> dict[str, Any]:
     cycles: set[int] = set()
     cycle_counts: dict[int, int] = {}
+    cycle_summary_line_numbers: dict[int, list[int]] = {}
+    freeze_event_lines: list[int] = []
     observed_cycles: set[int] = set()
     lifecycle_events: list[str] = []
     symbols: set[str] = set()
@@ -273,7 +275,7 @@ def analyze_log(path: Path) -> dict[str, Any]:
     invalid_lines = 0
 
     with path.open(encoding="utf-8") as handle:
-        for line in handle:
+        for line_number, line in enumerate(handle, start=1):
             if not line.strip():
                 continue
             try:
@@ -313,6 +315,7 @@ def analyze_log(path: Path) -> dict[str, Any]:
                 cycle = event["cycle"]
                 cycles.add(cycle)
                 cycle_counts[cycle] = cycle_counts.get(cycle, 0) + 1
+                cycle_summary_line_numbers.setdefault(cycle, []).append(line_number)
                 mark = finite_float(event.get("mark"))
                 if mark is not None and mark > 0:
                     marks.append(mark)
@@ -340,6 +343,16 @@ def analyze_log(path: Path) -> dict[str, Any]:
                     final_position = position
             if event.get("action") == "lifecycle" and isinstance(event.get("event"), str):
                 lifecycle_events.append(event["event"])
+            # Freeze notifications mark a cycle invalidation: the runtime
+            # freezes placements, cleans the maker book, and retries the
+            # active cycle after recovery, which re-emits that cycle's
+            # cycle_summary. Line positions let validation tell such
+            # freeze-retried duplicates from genuine sequence corruption.
+            if event.get("action") == "risk_notification" and event.get("event") in {
+                "frozen",
+                "disconnected_frozen",
+            }:
+                freeze_event_lines.append(line_number)
             if event.get("action") == "performance_summary":
                 position = finite_float(event.get("position"))
                 if position is not None:
@@ -353,6 +366,14 @@ def analyze_log(path: Path) -> dict[str, Any]:
         else []
     )
     duplicate_cycles = sorted(cycle for cycle, count in cycle_counts.items() if count > 1)
+    freeze_retried_cycles = sorted(
+        cycle
+        for cycle in duplicate_cycles
+        if any(
+            min(cycle_summary_line_numbers[cycle]) < freeze < max(cycle_summary_line_numbers[cycle])
+            for freeze in freeze_event_lines
+        )
+    )
     duration_seconds = (
         last_timestamp_epoch - first_timestamp_epoch
         if last_timestamp_epoch is not None and first_timestamp_epoch is not None
@@ -411,6 +432,7 @@ def analyze_log(path: Path) -> dict[str, Any]:
         "cycle_max": cycle_max,
         "missing_cycles": missing_cycles,
         "duplicate_cycles": duplicate_cycles,
+        "freeze_retried_cycles": freeze_retried_cycles,
         "lifecycle_events": lifecycle_events,
         "regime": regime,
         "regime_metrics": regime_metrics,
@@ -484,7 +506,7 @@ def finalize_manifest(args: argparse.Namespace) -> int:
         "json_only": log["invalid_lines"] == 0,
         "cycle_sequence_complete": bool(log["cycle_summaries"])
         and not log["missing_cycles"]
-        and not log["duplicate_cycles"],
+        and not sorted(set(log["duplicate_cycles"]) - set(log["freeze_retried_cycles"])),
         "lifecycle_started": "started" in log["lifecycle_events"],
         "lifecycle_stopped": "stopped" in log["lifecycle_events"],
     }

--- a/scripts/maker_run_manifest.py
+++ b/scripts/maker_run_manifest.py
@@ -251,7 +251,8 @@ def analyze_log(path: Path) -> dict[str, Any]:
     cycles: set[int] = set()
     cycle_counts: dict[int, int] = {}
     cycle_summary_line_numbers: dict[int, list[int]] = {}
-    freeze_event_lines: list[int] = []
+    observed_cycle_lines: dict[int, list[int]] = {}
+    freeze_event_lines: list[tuple[int, int | None]] = []
     observed_cycles: set[int] = set()
     lifecycle_events: list[str] = []
     symbols: set[str] = set()
@@ -311,6 +312,7 @@ def analyze_log(path: Path) -> dict[str, Any]:
             ):
                 observed_cycle = event["cycle"]
                 observed_cycles.add(observed_cycle)
+                observed_cycle_lines.setdefault(observed_cycle, []).append(line_number)
             if event.get("action") == "cycle_summary" and isinstance(event.get("cycle"), int):
                 cycle = event["cycle"]
                 cycles.add(cycle)
@@ -346,13 +348,19 @@ def analyze_log(path: Path) -> dict[str, Any]:
             # Freeze notifications mark a cycle invalidation: the runtime
             # freezes placements, cleans the maker book, and retries the
             # active cycle after recovery, which re-emits that cycle's
-            # cycle_summary. Line positions let validation tell such
-            # freeze-retried duplicates from genuine sequence corruption.
+            # cycle_summary. A cycle invalidated before emitting anything
+            # leaves a missing-cycle gap instead. Line positions plus the
+            # notification's own cycle let validation tell such
+            # freeze-caused duplicates/gaps from genuine sequence corruption.
             if event.get("action") == "risk_notification" and event.get("event") in {
                 "frozen",
                 "disconnected_frozen",
+                "degraded_frozen",
             }:
-                freeze_event_lines.append(line_number)
+                freeze_cycle = event.get("cycle")
+                freeze_event_lines.append(
+                    (line_number, freeze_cycle if isinstance(freeze_cycle, int) else None)
+                )
             if event.get("action") == "performance_summary":
                 position = finite_float(event.get("position"))
                 if position is not None:
@@ -370,10 +378,27 @@ def analyze_log(path: Path) -> dict[str, Any]:
         cycle
         for cycle in duplicate_cycles
         if any(
-            min(cycle_summary_line_numbers[cycle]) < freeze < max(cycle_summary_line_numbers[cycle])
-            for freeze in freeze_event_lines
+            min(cycle_summary_line_numbers[cycle]) < freeze_line < max(cycle_summary_line_numbers[cycle])
+            and freeze_cycle == cycle
+            for freeze_line, freeze_cycle in freeze_event_lines
         )
     )
+    # A missing cycle is freeze-justified when a freeze notification for that
+    # cycle or the immediately following one was recorded between the nearest
+    # observed cycles below and above the gap.
+    freeze_lost_cycles: list[int] = []
+    for missing in missing_cycles:
+        lower = max((c for c in observed_cycles if c < missing), default=None)
+        upper = min((c for c in observed_cycles if c > missing), default=None)
+        if lower is None or upper is None:
+            continue
+        lower_line = max(observed_cycle_lines[lower])
+        upper_line = min(observed_cycle_lines[upper])
+        if any(
+            lower_line < freeze_line < upper_line and freeze_cycle in {missing, missing + 1}
+            for freeze_line, freeze_cycle in freeze_event_lines
+        ):
+            freeze_lost_cycles.append(missing)
     duration_seconds = (
         last_timestamp_epoch - first_timestamp_epoch
         if last_timestamp_epoch is not None and first_timestamp_epoch is not None
@@ -433,6 +458,7 @@ def analyze_log(path: Path) -> dict[str, Any]:
         "missing_cycles": missing_cycles,
         "duplicate_cycles": duplicate_cycles,
         "freeze_retried_cycles": freeze_retried_cycles,
+        "freeze_lost_cycles": freeze_lost_cycles,
         "lifecycle_events": lifecycle_events,
         "regime": regime,
         "regime_metrics": regime_metrics,
@@ -505,7 +531,7 @@ def finalize_manifest(args: argparse.Namespace) -> int:
         "timestamps_monotonic": log["timestamp_regressions"] == 0,
         "json_only": log["invalid_lines"] == 0,
         "cycle_sequence_complete": bool(log["cycle_summaries"])
-        and not log["missing_cycles"]
+        and not sorted(set(log["missing_cycles"]) - set(log["freeze_lost_cycles"]))
         and not sorted(set(log["duplicate_cycles"]) - set(log["freeze_retried_cycles"])),
         "lifecycle_started": "started" in log["lifecycle_events"],
         "lifecycle_stopped": "stopped" in log["lifecycle_events"],

--- a/scripts/test_maker_run_manifest.py
+++ b/scripts/test_maker_run_manifest.py
@@ -210,6 +210,83 @@ class MakerRunManifestTests(unittest.TestCase):
             self.assertEqual(analyzed["missing_cycles"], [])
             self.assertEqual(analyzed["duplicate_cycles"], [])
 
+    def test_freeze_retried_duplicate_keeps_cycle_sequence_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "run.ndjson"
+            log.write_text(
+                "\n".join(
+                    [
+                        '{"ts":1,"action":"cycle_summary","cycle":0}',
+                        '{"ts":2,"action":"cycle_summary","cycle":1}',
+                        '{"ts":3,"action":"risk_notification","event":"frozen","kind":"position_reconciliation"}',
+                        '{"ts":4,"action":"cycle_summary","cycle":1}',
+                        '{"ts":5,"action":"cycle_summary","cycle":2}',
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            analyzed = manifest.analyze_log(log)
+            self.assertEqual(analyzed["duplicate_cycles"], [1])
+            self.assertEqual(analyzed["freeze_retried_cycles"], [1])
+
+            root = Path(directory)
+            output = root / "run.manifest.json"
+            output.write_text(
+                json.dumps(
+                    {
+                        "git_sha": "a" * 40,
+                        "git_dirty": False,
+                        "strategy_dirty_paths": [],
+                        "symbol": "BTC-USD",
+                        "program": {"sha256": "c" * 64},
+                        "collector": {
+                            "manifest_tool": {"sha256": "d" * 64},
+                            "wrapper": {"sha256": "e" * 64},
+                        },
+                        "config": {"sha256": "b" * 64},
+                        "symbol_metadata": {
+                            "price_tick_decimals": 1,
+                            "qty_tick_decimals": 1,
+                            "min_order_qty": "0.1",
+                        },
+                        "log": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with log.open("a", encoding="utf-8") as handle:
+                handle.write('{"ts":6,"action":"lifecycle","event":"started"}\n')
+                handle.write('{"ts":7,"action":"lifecycle","event":"stopped"}\n')
+            manifest.finalize_manifest(
+                argparse.Namespace(manifest=output, log=log, exit_status=0)
+            )
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertTrue(payload["validation"]["checks"]["cycle_sequence_complete"])
+            self.assertTrue(payload["validation"]["baseline_eligible"])
+
+    def test_duplicate_without_freeze_breaks_cycle_sequence_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "run.ndjson"
+            log.write_text(
+                "\n".join(
+                    [
+                        '{"ts":1,"action":"cycle_summary","cycle":0}',
+                        '{"ts":2,"action":"cycle_summary","cycle":1}',
+                        '{"ts":3,"action":"risk_notification","event":"frozen","kind":"position_reconciliation"}',
+                        '{"ts":4,"action":"cycle_summary","cycle":2}',
+                        '{"ts":5,"action":"cycle_summary","cycle":2}',
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            analyzed = manifest.analyze_log(log)
+            # The freeze precedes both copies of cycle 2, so the duplicate is
+            # not a freeze retry and must stay disqualifying.
+            self.assertEqual(analyzed["duplicate_cycles"], [2])
+            self.assertEqual(analyzed["freeze_retried_cycles"], [])
+
     def test_regime_report_distinguishes_calm_trend_and_stress(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/scripts/test_maker_run_manifest.py
+++ b/scripts/test_maker_run_manifest.py
@@ -218,7 +218,7 @@ class MakerRunManifestTests(unittest.TestCase):
                     [
                         '{"ts":1,"action":"cycle_summary","cycle":0}',
                         '{"ts":2,"action":"cycle_summary","cycle":1}',
-                        '{"ts":3,"action":"risk_notification","event":"frozen","kind":"position_reconciliation"}',
+                        '{"ts":3,"action":"risk_notification","event":"frozen","kind":"position_reconciliation","cycle":1}',
                         '{"ts":4,"action":"cycle_summary","cycle":1}',
                         '{"ts":5,"action":"cycle_summary","cycle":2}',
                     ]
@@ -286,6 +286,79 @@ class MakerRunManifestTests(unittest.TestCase):
             # not a freeze retry and must stay disqualifying.
             self.assertEqual(analyzed["duplicate_cycles"], [2])
             self.assertEqual(analyzed["freeze_retried_cycles"], [])
+
+    def test_freeze_lost_missing_cycle_keeps_cycle_sequence_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "run.ndjson"
+            log.write_text(
+                "\n".join(
+                    [
+                        '{"ts":1,"action":"cycle_summary","cycle":0}',
+                        '{"ts":2,"action":"risk_notification","event":"degraded_frozen","kind":"market_data","cycle":2}',
+                        '{"ts":3,"action":"cycle_summary","cycle":2}',
+                        '{"ts":4,"action":"lifecycle","event":"started"}',
+                        '{"ts":5,"action":"lifecycle","event":"stopped"}',
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            analyzed = manifest.analyze_log(log)
+            # Cycle 1 was lost to the market-data freeze recorded between its
+            # neighbours, so the gap must not disqualify the trace.
+            self.assertEqual(analyzed["missing_cycles"], [1])
+            self.assertEqual(analyzed["freeze_lost_cycles"], [1])
+
+            output = Path(directory) / "run.manifest.json"
+            output.write_text(
+                json.dumps(
+                    {
+                        "git_sha": "a" * 40,
+                        "git_dirty": False,
+                        "strategy_dirty_paths": [],
+                        "symbol": "BTC-USD",
+                        "program": {"sha256": "c" * 64},
+                        "collector": {
+                            "manifest_tool": {"sha256": "d" * 64},
+                            "wrapper": {"sha256": "e" * 64},
+                        },
+                        "config": {"sha256": "b" * 64},
+                        "symbol_metadata": {
+                            "price_tick_decimals": 1,
+                            "qty_tick_decimals": 1,
+                            "min_order_qty": "0.1",
+                        },
+                        "log": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manifest.finalize_manifest(
+                argparse.Namespace(manifest=output, log=log, exit_status=0)
+            )
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertTrue(payload["validation"]["checks"]["cycle_sequence_complete"])
+            self.assertTrue(payload["validation"]["baseline_eligible"])
+
+    def test_missing_cycle_without_freeze_breaks_cycle_sequence_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "run.ndjson"
+            log.write_text(
+                "\n".join(
+                    [
+                        '{"ts":1,"action":"cycle_summary","cycle":0}',
+                        '{"ts":2,"action":"risk_notification","event":"degraded_frozen","kind":"market_data","cycle":5}',
+                        '{"ts":3,"action":"cycle_summary","cycle":2}',
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            analyzed = manifest.analyze_log(log)
+            # Cycle 5's freeze sits above the gap at cycle 1, so the missing
+            # cycle is not freeze-caused and must stay disqualifying.
+            self.assertEqual(analyzed["missing_cycles"], [1])
+            self.assertEqual(analyzed["freeze_lost_cycles"], [])
 
     def test_regime_report_distinguishes_calm_trend_and_stress(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## 内容

- **manifest 容错**（7e8c556, f259582）：`cycle_sequence_complete` 容忍 freeze 重试产生的重复 cycle_summary 及 freeze 丢失的缺失 cycle
- **lag-recorder HYPE 实测**（3caa0d2）：45h 实测证据文档（`docs/evidence/lag-recorder-hype-result-2026-07-22.md`）
- **lag-analysis 补丁 + 重跑**（bc53b45）：每源独立字段（HL midPx 作领先者）、覆盖率按跳幅分层、新增 StandX own-feed 跳动响应统计（own-feed 快撤定价）
- **阶段3 gate 重验文档**（f9b2a8b）：A/B 启动与两次 manifest 事件记录（2026-07-21）

## lag 实测结论（HYPE，45h，672,499 条记录）

- 以 HL **midPx** 为领先者：StandX mark 条件性跟随 lag **中位 2622ms**（p25=1834 / p75=3425），明确落入 1–3s 可防守窗口
- 可测量跟随覆盖率 **61%**（80/131 跳动）；跳幅越大越可靠（16–32bps 档 0 次 already-ahead、7/8 跟随）；≥32bps 无样本
- 此前 markPx-vs-markPx 的否定性结果部分是把滞后聚合价当 leader 的伪影
- own-feed 快撤定价：自身 mark 看到 50% 变动需 ~1 个 tick（~3s），比外部信号慢约一个量级但无条件可用
- 对 Stage 4（外部价格引导报价）的含义由弱支持上调为**有实质支持**，仍须与 widen-spread A/B 结论及 SIP-5A $/Maker-Hour 联合决策

## 验证

- `python3 -m py_compile scripts/lag_analysis.py` 通过
- 分析器为只读脚本，不涉及 maker 策略/风控/下单路径，无需 live-gate
- 录制进程已 SIGTERM 优雅停止，NDJSON 末行校验通过