### PR TITLE
stage3v1: combined candidate — nonlinear price skew + external-price guard

### DIFF
--- a/crates/standx-cli/src/commands/maker/config.rs
+++ b/crates/standx-cli/src/commands/maker/config.rs
@@ -69,6 +69,57 @@ impl SizeSkewFileConfig {
     }
 }
 
+/// Stage 3 v1 nonlinear price skew (`[nonlinear_skew]`). Field defaults match
+/// [`standx_maker::NonlinearSkewConfig`] so partial files stay valid.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct NonlinearSkewFileConfig {
+    pub enabled: Option<bool>,
+    pub boost: Option<f64>,
+    pub cap_bps: Option<f64>,
+}
+
+impl NonlinearSkewFileConfig {
+    pub(super) fn into_domain(self) -> standx_maker::NonlinearSkewConfig {
+        let defaults = standx_maker::NonlinearSkewConfig::default();
+        standx_maker::NonlinearSkewConfig {
+            enabled: self.enabled.unwrap_or(false),
+            boost: self.boost.unwrap_or(defaults.boost),
+            cap_bps: self.cap_bps.unwrap_or(defaults.cap_bps),
+        }
+    }
+}
+
+/// External-price defensive guard (`[external_guard]`). Field defaults match
+/// [`standx_maker::GuardConfig`] so partial files stay valid.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ExternalGuardFileConfig {
+    pub enabled: Option<bool>,
+    pub enter_bps: Option<f64>,
+    pub exit_bps: Option<f64>,
+    pub max_age_ms: Option<u64>,
+    /// CLI-side basis EMA half-life (seconds): the guard triggers on the
+    /// excess divergence over this slow baseline, so the persistent
+    /// leader-vs-mark basis never latches the guard.
+    pub basis_half_life_secs: Option<u64>,
+}
+
+/// Default half-life for the divergence-basis EMA (seconds).
+pub(super) const DEFAULT_GUARD_BASIS_HALF_LIFE_SECS: u64 = 300;
+
+impl ExternalGuardFileConfig {
+    pub(super) fn into_domain(self) -> standx_maker::GuardConfig {
+        let defaults = standx_maker::GuardConfig::default();
+        standx_maker::GuardConfig {
+            enabled: self.enabled.unwrap_or(false),
+            enter_bps: self.enter_bps.unwrap_or(defaults.enter_bps),
+            exit_bps: self.exit_bps.unwrap_or(defaults.exit_bps),
+            max_age_ms: self.max_age_ms.unwrap_or(defaults.max_age_ms),
+        }
+    }
+}
+
 /// Values are optional so an explicit CLI flag can override one field without
 /// requiring every strategy default to be repeated in TOML.
 #[derive(Debug, Default, Deserialize)]
@@ -91,6 +142,8 @@ pub(super) struct MakerFileConfig {
     pub vol_window_secs: Option<u64>,
     pub adaptive_spread: Option<AdaptiveSpreadFileConfig>,
     pub size_skew: Option<SizeSkewFileConfig>,
+    pub nonlinear_skew: Option<NonlinearSkewFileConfig>,
+    pub external_guard: Option<ExternalGuardFileConfig>,
     pub stop_loss: Option<f64>,
     pub alert_loss: Option<f64>,
     pub alert_inventory_pct: Option<f64>,
@@ -334,5 +387,98 @@ add_side_factor = 0.5
         assert_eq!(baseline.activate_pct, 30.0);
         assert_eq!(baseline.release_pct, 20.0);
         assert_eq!(baseline.add_side_factor, 0.5);
+    }
+
+    #[test]
+    fn parses_nonlinear_skew_and_external_guard_sections() {
+        let config: MakerFileConfig = toml::from_str(
+            "[nonlinear_skew]\nenabled = true\nboost = 3.0\ncap_bps = 12.0\n\n[external_guard]\nenabled = true\nenter_bps = 6.0\nexit_bps = 3.0\nmax_age_ms = 5000\n",
+        )
+        .unwrap();
+        let nonlinear = config.nonlinear_skew.unwrap().into_domain();
+        assert!(nonlinear.enabled);
+        assert_eq!(nonlinear.boost, 3.0);
+        assert_eq!(nonlinear.cap_bps, 12.0);
+        let guard = config.external_guard.unwrap().into_domain();
+        assert!(guard.enabled);
+        assert_eq!(guard.enter_bps, 6.0);
+        assert_eq!(guard.exit_bps, 3.0);
+        assert_eq!(guard.max_age_ms, 5000);
+
+        // Partial sections fall back to domain defaults, disabled by default.
+        let partial: MakerFileConfig =
+            toml::from_str("[nonlinear_skew]\nboost = 2.0\n\n[external_guard]\nenter_bps = 8.0\n")
+                .unwrap();
+        let nonlinear = partial.nonlinear_skew.unwrap().into_domain();
+        assert!(!nonlinear.enabled);
+        assert_eq!(nonlinear.boost, 2.0);
+        assert_eq!(nonlinear.cap_bps, 12.0);
+        let guard = partial.external_guard.unwrap().into_domain();
+        assert!(!guard.enabled);
+        assert_eq!(guard.enter_bps, 8.0);
+        assert_eq!(guard.exit_bps, 3.0);
+    }
+
+    #[test]
+    fn stage3v1_live_arms_only_differ_by_combined_enable_switches() {
+        let baseline = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/maker-stage3v1-hype-baseline.toml"
+        ));
+        let candidate = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/maker-stage3v1-hype-candidate.toml"
+        ));
+        assert_eq!(baseline.lines().count(), candidate.lines().count());
+        let differing_lines: Vec<_> = baseline
+            .lines()
+            .zip(candidate.lines())
+            .filter(|(baseline_line, candidate_line)| baseline_line != candidate_line)
+            .collect();
+        assert_eq!(
+            differing_lines,
+            vec![
+                ("enabled = false", "enabled = true"),
+                ("enabled = false", "enabled = true"),
+            ]
+        );
+
+        let baseline: MakerFileConfig = toml::from_str(baseline).unwrap();
+        let candidate: MakerFileConfig = toml::from_str(candidate).unwrap();
+        // Every other controller stays off in both arms.
+        assert!(!baseline.adaptive_spread.as_ref().unwrap().enabled.unwrap());
+        assert!(!candidate.adaptive_spread.as_ref().unwrap().enabled.unwrap());
+        assert!(!baseline
+            .size_skew
+            .as_ref()
+            .unwrap()
+            .enabled
+            .unwrap_or(false));
+        assert!(!candidate
+            .size_skew
+            .as_ref()
+            .unwrap()
+            .enabled
+            .unwrap_or(false));
+
+        let baseline_nl = baseline.nonlinear_skew.unwrap().into_domain();
+        let candidate_nl = candidate.nonlinear_skew.unwrap().into_domain();
+        assert!(!baseline_nl.enabled);
+        assert!(candidate_nl.enabled);
+        assert_eq!(candidate_nl.boost, 3.0);
+        assert_eq!(candidate_nl.cap_bps, 12.0);
+
+        let baseline_guard = baseline.external_guard.unwrap().into_domain();
+        let candidate_guard = candidate.external_guard.unwrap().into_domain();
+        assert!(!baseline_guard.enabled);
+        assert!(candidate_guard.enabled);
+        assert_eq!(candidate_guard.enter_bps, 6.0);
+        assert_eq!(candidate_guard.exit_bps, 3.0);
+        assert_eq!(candidate_guard.max_age_ms, 5000);
+
+        // Band red line holds for the frozen candidate: spread + cap <= band.
+        let spread = candidate.spread_bps.unwrap();
+        let band = candidate.band_bps.unwrap();
+        assert!(spread + candidate_nl.cap_bps <= band);
     }
 }

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -3,7 +3,8 @@ use super::ledger::{adopt_order, apply_rest_trade};
 use super::ledger::{apply_account_trade, apply_order_update, maker_trade_fill};
 use super::model::{position_for_symbol, rest_order_observation};
 use super::output::{
-    emit_cycle_skip, emit_maker_cycle, log_maker_event, CycleOutput, MakerLogEvent,
+    emit_cycle_skip, emit_guard_transition, emit_maker_cycle, log_maker_event, CycleOutput,
+    MakerLogEvent,
 };
 use super::pipeline::{
     fetch_account_audit, CycleRequest, CycleResult, CycleState, OrderRequestKind,
@@ -231,6 +232,10 @@ pub(super) async fn maker_cycle(
         breaker,
         spread_controller,
         size_skew_controller,
+        nonlinear_skew,
+        guard_controller,
+        external_divergence,
+        external_basis_bps,
         mut order_request_deadlines,
         live_account_poll,
         mut order_latency,
@@ -511,6 +516,11 @@ pub(super) async fn maker_cycle(
 
     // 3. Build the pure quote/exit plan from the synchronized state.
     let size_skew_decision = size_skew_controller.observe(position, cfg);
+    let previous_guard_side = guard_controller.endangered();
+    let guard_decision = guard_controller.observe(external_divergence);
+    if guard_decision.endangered != previous_guard_side {
+        emit_guard_transition(output_format, symbol, cycle, &guard_decision);
+    }
     let active_resting = if live {
         projected_resting.as_slice()
     } else {
@@ -536,6 +546,8 @@ pub(super) async fn maker_cycle(
             inventory_exit_pct,
             inventory_exit_qty,
             size_skew: size_skew_decision,
+            nonlinear_skew,
+            guard: guard_decision,
             wind_down,
             qty_tolerance,
         },
@@ -928,6 +940,13 @@ pub(super) async fn maker_cycle(
         halt_vol_bps: halted.then(|| breaker.vol_bps()),
         spread_decision: &spread_decision,
         size_skew_decision: &size_skew_decision,
+        guard_decision: &guard_decision,
+        external_basis_bps,
+        skew_shift_bps: if mark > 0.0 {
+            (mark - ref_center) / mark * 1e4
+        } else {
+            0.0
+        },
         cfg,
         performance: performance_summary.as_ref(),
     });

--- a/crates/standx-cli/src/commands/maker/external_feed.rs
+++ b/crates/standx-cli/src/commands/maker/external_feed.rs
@@ -1,0 +1,319 @@
+//! Hyperliquid midPx feed for the external-price guard (stage 3 v1).
+//!
+//! A resident background task keeps the latest leader mid price in a shared
+//! cache; the maker cycle reads it and normalizes freshness into the typed
+//! [`standx_maker::ExternalDivergence`] input. The client mirrors the proven
+//! `lag-recorder` Hyperliquid session (same endpoint, channel, and keepalive)
+//! but is deliberately a separate, minimal copy: the diagnostic tool and the
+//! trading path must not share evolution.
+//!
+//! Failure semantics are OPEN by design: any disconnect, parse gap, or silence
+//! simply leaves the cache stale, the guard controller treats stale samples as
+//! absent, and quoting continues unaffected. This task can never stop the
+//! maker.
+
+use futures::{SinkExt, StreamExt};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{watch, RwLock};
+use tokio::task::JoinHandle;
+use tokio_tungstenite::tungstenite::Message;
+
+const HYPERLIQUID_WS_URL: &str = "wss://api.hyperliquid.xyz/ws";
+const RECONNECT_DELAY: Duration = Duration::from_secs(5);
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Latest leader observation. `received_at` is the local monotonic receipt
+/// time; the cycle derives `age_ms` from it when building the typed input.
+#[derive(Debug, Default, Clone, Copy)]
+pub(super) struct ExternalFeedState {
+    pub mid: Option<f64>,
+    pub received_at: Option<Instant>,
+}
+
+/// Derive the Hyperliquid coin from a StandX symbol (`HYPE-USD` -> `HYPE`).
+pub(super) fn leader_coin(symbol: &str) -> String {
+    let upper = symbol.to_uppercase();
+    for suffix in ["-USDT", "-USD"] {
+        if let Some(base) = upper.strip_suffix(suffix) {
+            return base.to_string();
+        }
+    }
+    upper
+}
+
+/// Spawn the resident leader-feed task. The watch channel ticks on every
+/// accepted update so the cycle loop can wake early on fresh divergence.
+pub(super) fn spawn_external_feed(
+    coin: String,
+) -> (
+    Arc<RwLock<ExternalFeedState>>,
+    watch::Receiver<u64>,
+    JoinHandle<()>,
+) {
+    let state = Arc::new(RwLock::new(ExternalFeedState::default()));
+    let (tx, rx) = watch::channel(0u64);
+    let task_state = Arc::clone(&state);
+    let handle = tokio::spawn(async move {
+        let mut seq: u64 = 0;
+        loop {
+            if let Err(error) = feed_session(&coin, &task_state, &tx, &mut seq).await {
+                eprintln!(
+                    "⚠️ external guard feed error (fail-open, quoting unaffected): {error:#}"
+                );
+            }
+            if tx.is_closed() {
+                return;
+            }
+            tokio::time::sleep(RECONNECT_DELAY).await;
+        }
+    });
+    (state, rx, handle)
+}
+
+async fn feed_session(
+    coin: &str,
+    state: &Arc<RwLock<ExternalFeedState>>,
+    tx: &watch::Sender<u64>,
+    seq: &mut u64,
+) -> anyhow::Result<()> {
+    let (stream, _response) = tokio_tungstenite::connect_async(HYPERLIQUID_WS_URL).await?;
+    let (mut write, mut read) = stream.split();
+
+    let subscribe = serde_json::json!({
+        "method": "subscribe",
+        "subscription": { "type": "activeAssetCtx", "coin": coin },
+    })
+    .to_string();
+    write.send(Message::Text(subscribe.into())).await?;
+
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    ping.reset();
+
+    loop {
+        tokio::select! {
+            _ = ping.tick() => {
+                let frame = serde_json::json!({ "method": "ping" }).to_string();
+                write.send(Message::Text(frame.into())).await?;
+            }
+            msg = read.next() => {
+                let msg = match msg {
+                    Some(Ok(msg)) => msg,
+                    Some(Err(error)) => return Err(error.into()),
+                    None => return Ok(()),
+                };
+                match msg {
+                    Message::Text(text) => {
+                        if let Some(mid) = parse_mid(&text) {
+                            {
+                                let mut guard = state.write().await;
+                                guard.mid = Some(mid);
+                                guard.received_at = Some(Instant::now());
+                            }
+                            *seq += 1;
+                            if tx.send(*seq).is_err() {
+                                return Ok(());
+                            }
+                        }
+                    }
+                    Message::Ping(payload) => {
+                        write.send(Message::Pong(payload)).await?;
+                    }
+                    Message::Close(_) => return Ok(()),
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+/// Extract midPx from an `activeAssetCtx` frame; anything else is `None`.
+fn parse_mid(text: &str) -> Option<f64> {
+    let value: serde_json::Value = serde_json::from_str(text).ok()?;
+    if value.get("channel")?.as_str()? != "activeAssetCtx" {
+        return None;
+    }
+    match value.get("data")?.get("ctx")?.get("midPx")? {
+        serde_json::Value::String(s) => s.parse::<f64>().ok(),
+        serde_json::Value::Number(n) => n.as_f64(),
+        _ => None,
+    }
+    .filter(|mid| mid.is_finite() && *mid > 0.0)
+}
+
+/// Raw leader-vs-mark divergence in bps plus the sample age. `None` on any
+/// missing or non-positive value (fail-open).
+pub(super) fn raw_divergence(
+    state: ExternalFeedState,
+    mark: f64,
+    now: Instant,
+) -> Option<(f64, u64)> {
+    let mid = state.mid?;
+    let received_at = state.received_at?;
+    if !mark.is_finite() || mark <= 0.0 {
+        return None;
+    }
+    Some((
+        (mid / mark - 1.0) * 1e4,
+        now.saturating_duration_since(received_at).as_millis() as u64,
+    ))
+}
+
+/// Slow EMA baseline over the raw divergence.
+///
+/// HL midPx and StandX mark carry a persistent static basis (~-14bps observed
+/// on HYPE in the 2026-07-22 paper smoke — venue premium/funding structure,
+/// not a snipe signal). Feeding raw levels into the guard would latch it
+/// permanently on one side — the exact uptime failure that rejected stage-3
+/// v0. The guard therefore triggers on the EXCESS divergence over this
+/// baseline: jumps (seconds) pass through, the basis (minutes-stable) is
+/// absorbed. The first sample initializes the baseline, so startup basis
+/// never fires the guard.
+#[derive(Debug)]
+pub(super) struct DivergenceBaseline {
+    ema_bps: Option<f64>,
+    last_update: Option<Instant>,
+    half_life: Duration,
+}
+
+impl DivergenceBaseline {
+    pub(super) fn new(half_life_secs: u64) -> Self {
+        Self {
+            ema_bps: None,
+            last_update: None,
+            half_life: Duration::from_secs(half_life_secs.max(1)),
+        }
+    }
+
+    /// Excess of `raw_bps` over the baseline as of BEFORE this observation
+    /// (a fresh jump is never partially absorbed by its own sample), then
+    /// fold the observation into the EMA.
+    pub(super) fn observe(&mut self, raw_bps: f64, now: Instant) -> f64 {
+        let excess = self.peek(raw_bps);
+        match (self.ema_bps, self.last_update) {
+            (Some(ema), Some(last)) => {
+                let dt = now.saturating_duration_since(last).as_secs_f64();
+                let alpha = 1.0 - 0.5f64.powf(dt / self.half_life.as_secs_f64());
+                self.ema_bps = Some(ema + alpha * (raw_bps - ema));
+            }
+            _ => self.ema_bps = Some(raw_bps),
+        }
+        self.last_update = Some(now);
+        excess
+    }
+
+    /// Excess without updating the baseline (used by the early-wake check;
+    /// the cycle is the single writer).
+    pub(super) fn peek(&self, raw_bps: f64) -> f64 {
+        match self.ema_bps {
+            Some(ema) => raw_bps - ema,
+            None => 0.0,
+        }
+    }
+
+    /// Current baseline (telemetry).
+    pub(super) fn basis_bps(&self) -> Option<f64> {
+        self.ema_bps
+    }
+}
+
+/// Normalize the cached leader state into the core's typed input: raw
+/// divergence minus the slow baseline. Updates the baseline as a side effect
+/// (call once per cycle). `None` fails open.
+pub(super) fn divergence_input(
+    state: ExternalFeedState,
+    mark: f64,
+    now: Instant,
+    baseline: &mut DivergenceBaseline,
+) -> Option<standx_maker::ExternalDivergence> {
+    let (raw_bps, age_ms) = raw_divergence(state, mark, now)?;
+    let excess = baseline.observe(raw_bps, now);
+    Some(standx_maker::ExternalDivergence {
+        divergence_bps: excess,
+        age_ms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leader_coin_strips_quote_suffix() {
+        assert_eq!(leader_coin("HYPE-USD"), "HYPE");
+        assert_eq!(leader_coin("btc-usdt"), "BTC");
+        assert_eq!(leader_coin("HYPE"), "HYPE");
+    }
+
+    #[test]
+    fn parse_mid_accepts_active_asset_ctx_only() {
+        let frame = r#"{"channel":"activeAssetCtx","data":{"coin":"HYPE","ctx":{"markPx":"59.1","midPx":"59.2","oraclePx":"59.0"}}}"#;
+        assert_eq!(parse_mid(frame), Some(59.2));
+        assert_eq!(
+            parse_mid(r#"{"channel":"subscriptionResponse","data":{}}"#),
+            None
+        );
+        assert_eq!(parse_mid("not json"), None);
+        let bad = r#"{"channel":"activeAssetCtx","data":{"ctx":{"midPx":"-1"}}}"#;
+        assert_eq!(parse_mid(bad), None);
+    }
+
+    #[test]
+    fn divergence_input_normalizes_and_fails_open() {
+        let now = Instant::now();
+        let state = ExternalFeedState {
+            mid: Some(60.06),
+            received_at: Some(now),
+        };
+        let mut baseline = DivergenceBaseline::new(300);
+        // First sample initializes the baseline: startup basis yields ZERO
+        // excess, never a guard trigger.
+        let input = divergence_input(state, 60.0, now, &mut baseline).unwrap();
+        assert_eq!(input.divergence_bps, 0.0);
+        assert_eq!(input.age_ms, 0);
+        assert!((baseline.basis_bps().unwrap() - 10.0).abs() < 1e-9);
+
+        let mut baseline = DivergenceBaseline::new(300);
+        assert!(divergence_input(ExternalFeedState::default(), 60.0, now, &mut baseline).is_none());
+        assert!(divergence_input(state, 0.0, now, &mut baseline).is_none());
+        assert!(divergence_input(state, f64::NAN, now, &mut baseline).is_none());
+    }
+
+    #[test]
+    fn baseline_absorbs_static_basis_but_passes_jumps_through() {
+        let start = Instant::now();
+        let mut baseline = DivergenceBaseline::new(300);
+
+        // Persistent -14bps basis (the HYPE paper-smoke observation): after
+        // initialization every repeat reads ~zero excess.
+        assert_eq!(baseline.observe(-14.0, start), 0.0);
+        for i in 1..=10 {
+            let now = start + Duration::from_secs(3 * i);
+            let excess = baseline.observe(-14.0, now);
+            assert!(excess.abs() < 1e-9, "static basis must not fire: {excess}");
+        }
+
+        // A fresh 8bps jump on top of the basis passes through (measured
+        // against the pre-jump baseline, not absorbed by its own sample).
+        let jump_at = start + Duration::from_secs(60);
+        let excess = baseline.observe(-14.0 + 8.0, jump_at);
+        assert!(
+            (excess - 8.0).abs() < 0.1,
+            "jump must pass through: {excess}"
+        );
+
+        // peek never mutates.
+        let before = baseline.basis_bps().unwrap();
+        let _ = baseline.peek(50.0);
+        assert_eq!(baseline.basis_bps().unwrap(), before);
+
+        // A sustained shift is slowly absorbed into the basis (half-life
+        // behavior): after one half-life the excess halves.
+        let mut shifted = DivergenceBaseline::new(300);
+        shifted.observe(0.0, start);
+        let one_half_life = start + Duration::from_secs(300);
+        shifted.observe(10.0, one_half_life);
+        let after = shifted.basis_bps().unwrap();
+        assert!((after - 5.0).abs() < 0.1, "half-life absorption: {after}");
+    }
+}

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 mod canary;
 mod config;
 mod cycle;
+mod external_feed;
 mod feed;
 mod ledger;
 mod market_data;
@@ -192,6 +193,21 @@ pub async fn handle_maker(
                 }
                 None => maker::SizeSkewConfig::default(),
             };
+            // Stage 3 v1 combined candidate: TOML-only switches (no CLI
+            // overrides) so frozen A/B configs stay the single source of truth.
+            let nonlinear_skew = file
+                .nonlinear_skew
+                .map(|config| config.into_domain())
+                .unwrap_or_default();
+            let external_guard_basis_half_life_secs = file
+                .external_guard
+                .as_ref()
+                .and_then(|config| config.basis_half_life_secs)
+                .unwrap_or(config::DEFAULT_GUARD_BASIS_HALF_LIFE_SECS);
+            let external_guard = file
+                .external_guard
+                .map(|config| config.into_domain())
+                .unwrap_or_default();
             // Keep accepting the removed rolling-circuit knobs for one
             // compatibility window so existing production commands/configs do
             // not fail to parse. They deliberately do not enter MakerRunArgs.
@@ -219,6 +235,9 @@ pub async fn handle_maker(
                     vol_window_secs: selected_vol_window_secs,
                     adaptive_spread,
                     size_skew,
+                    nonlinear_skew,
+                    external_guard,
+                    external_guard_basis_half_life_secs,
                     stop_loss: choose(stop_loss, file.stop_loss, 0.0),
                     alert_loss: choose(alert_loss, file.alert_loss, 0.0),
                     alert_inventory_pct: choose(alert_inventory_pct, file.alert_inventory_pct, 0.0),
@@ -306,6 +325,9 @@ struct MakerRunArgs {
     vol_window_secs: Option<u64>,
     adaptive_spread: maker::AdaptiveSpreadConfig,
     size_skew: maker::SizeSkewConfig,
+    nonlinear_skew: maker::NonlinearSkewConfig,
+    external_guard: maker::GuardConfig,
+    external_guard_basis_half_life_secs: u64,
     stop_loss: f64,
     alert_loss: f64,
     alert_inventory_pct: f64,

--- a/crates/standx-cli/src/commands/maker/output.rs
+++ b/crates/standx-cli/src/commands/maker/output.rs
@@ -229,6 +229,12 @@ pub(super) struct CycleOutput<'a> {
     pub(super) halt_vol_bps: Option<f64>,
     pub(super) spread_decision: &'a maker::SpreadDecision,
     pub(super) size_skew_decision: &'a maker::SizeSkewDecision,
+    pub(super) guard_decision: &'a maker::GuardDecision,
+    /// Divergence-basis EMA the guard's excess is measured against.
+    pub(super) external_basis_bps: Option<f64>,
+    /// Realized quote-center shift in bps (mark vs plan ref_center); covers
+    /// linear and nonlinear skew alike. Telemetry only.
+    pub(super) skew_shift_bps: f64,
     pub(super) cfg: &'a MakerConfig,
     pub(super) performance: Option<&'a maker::PerformanceSummary>,
 }
@@ -254,6 +260,9 @@ pub(super) fn emit_maker_cycle(output: CycleOutput<'_>) {
         halt_vol_bps,
         spread_decision,
         size_skew_decision,
+        guard_decision,
+        external_basis_bps,
+        skew_shift_bps,
         cfg,
         performance,
     } = output;
@@ -339,32 +348,37 @@ pub(super) fn emit_maker_cycle(output: CycleOutput<'_>) {
             }
             println!(
                 "{}",
-                with_size_skew_fields(
-                    with_spread_fields(
-                        serde_json::json!({
-                            "ts": ts, "cycle": cycle, "mode": mode, "symbol": symbol,
-                            "action": "cycle_summary",
-                            "mark": format_decimals(mark, cfg.price_decimals),
-                            "best_bid": best_bid, "best_ask": best_ask,
-                            "market_source": market_source,
-                            "market_fallback_reason": market_fallback_reason,
-                            "ws_snapshot": ws_snapshot.map(ws_snapshot_json),
-                            "position": position,
-                            "starting_position": starting_position,
-                            "account": account.map(account_json),
-                            "holds": holds, "places": places, "cancels": cancels,
-                            "fills": fills.len(),
-                            "pnl": (pnl * 1e6).round() / 1e6,
-                            "fills_total": stats.fills(),
-                            "uptime_pct": (stats.uptime_pct() * 10.0).round() / 10.0,
-                            "avg_capture_bps": (stats.avg_spread_capture_bps() * 100.0).round() / 100.0,
-                            "performance": performance.map(performance_json),
-                            "halted": halt_vol_bps.is_some(),
-                            "vol_bps": halt_vol_bps.map(|v| (v * 100.0).round() / 100.0),
-                        }),
-                        spread_decision,
+                with_guard_fields(
+                    with_size_skew_fields(
+                        with_spread_fields(
+                            serde_json::json!({
+                                "ts": ts, "cycle": cycle, "mode": mode, "symbol": symbol,
+                                "action": "cycle_summary",
+                                "mark": format_decimals(mark, cfg.price_decimals),
+                                "best_bid": best_bid, "best_ask": best_ask,
+                                "market_source": market_source,
+                                "market_fallback_reason": market_fallback_reason,
+                                "ws_snapshot": ws_snapshot.map(ws_snapshot_json),
+                                "position": position,
+                                "starting_position": starting_position,
+                                "account": account.map(account_json),
+                                "holds": holds, "places": places, "cancels": cancels,
+                                "fills": fills.len(),
+                                "pnl": (pnl * 1e6).round() / 1e6,
+                                "fills_total": stats.fills(),
+                                "uptime_pct": (stats.uptime_pct() * 10.0).round() / 10.0,
+                                "avg_capture_bps": (stats.avg_spread_capture_bps() * 100.0).round() / 100.0,
+                                "performance": performance.map(performance_json),
+                                "halted": halt_vol_bps.is_some(),
+                                "vol_bps": halt_vol_bps.map(|v| (v * 100.0).round() / 100.0),
+                            }),
+                            spread_decision,
+                        ),
+                        size_skew_decision,
                     ),
-                    size_skew_decision,
+                    guard_decision,
+                    external_basis_bps,
+                    skew_shift_bps,
                 )
             );
         }
@@ -520,6 +534,44 @@ fn with_spread_fields(
     summary
 }
 
+/// Additive stage-3 v1 fields: external-guard state and the realized skew
+/// shift. Optional top-level keys only — old consumers keep working.
+fn with_guard_fields(
+    mut summary: serde_json::Value,
+    decision: &maker::GuardDecision,
+    external_basis_bps: Option<f64>,
+    skew_shift_bps: f64,
+) -> serde_json::Value {
+    let object = summary
+        .as_object_mut()
+        .expect("cycle summary JSON must be an object");
+    object.insert(
+        "guard_enabled".to_string(),
+        serde_json::json!(decision.enabled),
+    );
+    object.insert(
+        "guard_active".to_string(),
+        serde_json::json!(decision.active),
+    );
+    object.insert(
+        "guard_side".to_string(),
+        serde_json::json!(decision.endangered),
+    );
+    object.insert(
+        "external_divergence_bps".to_string(),
+        serde_json::json!(decision.divergence_bps.map(|d| (d * 100.0).round() / 100.0)),
+    );
+    object.insert(
+        "external_basis_bps".to_string(),
+        serde_json::json!(external_basis_bps.map(|d| (d * 100.0).round() / 100.0)),
+    );
+    object.insert(
+        "skew_shift_bps".to_string(),
+        serde_json::json!((skew_shift_bps * 100.0).round() / 100.0),
+    );
+    summary
+}
+
 fn with_size_skew_fields(
     mut summary: serde_json::Value,
     decision: &maker::SizeSkewDecision,
@@ -640,6 +692,45 @@ fn side_str(side: OrderSide) -> &'static str {
 
 /// Emit a one-off maker event (order rejection, no-op cancel) inline,
 /// respecting the output format. Only reached in live mode.
+/// One line per external-guard activation/release/side-switch (a new additive
+/// `action`; existing consumers ignore unknown actions). Event-level
+/// attribution joins these against fills avoided inside guard windows.
+pub(super) fn emit_guard_transition(
+    output_format: OutputFormat,
+    symbol: &str,
+    cycle: u64,
+    decision: &maker::GuardDecision,
+) {
+    match output_format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                    "cycle": cycle, "symbol": symbol,
+                    "action": "external_guard",
+                    "active": decision.active,
+                    "side": decision.endangered,
+                    "divergence_bps": decision.divergence_bps
+                        .map(|d| (d * 100.0).round() / 100.0),
+                })
+            );
+        }
+        OutputFormat::Quiet => {}
+        _ => {
+            if let Some(side) = decision.endangered {
+                eprintln!(
+                    "    🛡️ external guard: suppressing {} (divergence {:+.2}bps)",
+                    side_str(side),
+                    decision.divergence_bps.unwrap_or(f64::NAN),
+                );
+            } else {
+                eprintln!("    🛡️ external guard: released");
+            }
+        }
+    }
+}
+
 pub(super) struct MakerLogEvent<'a> {
     pub(super) output_format: OutputFormat,
     pub(super) symbol: &'a str,
@@ -1125,5 +1216,44 @@ mod tests {
         assert_eq!(json["size_skew_add_side"], "buy");
         assert_eq!(json["size_skew_inventory_ratio"], 0.3);
         assert_eq!(json["size_skew_add_qty"], 0.05);
+    }
+
+    #[test]
+    fn cycle_summary_guard_fields_are_additive_and_top_level() {
+        let decision = maker::GuardDecision {
+            enabled: true,
+            active: true,
+            endangered: Some(OrderSide::Sell),
+            divergence_bps: Some(7.816),
+        };
+        let json = with_guard_fields(
+            serde_json::json!({"action": "cycle_summary", "vol_bps": null}),
+            &decision,
+            Some(-14.2),
+            4.804,
+        );
+
+        assert_eq!(json["action"], "cycle_summary");
+        assert!(json["vol_bps"].is_null());
+        assert_eq!(json["guard_enabled"], true);
+        assert_eq!(json["guard_active"], true);
+        assert_eq!(json["guard_side"], "sell");
+        assert_eq!(json["external_divergence_bps"], 7.82);
+        assert_eq!(json["external_basis_bps"], -14.2);
+        assert_eq!(json["skew_shift_bps"], 4.8);
+
+        // Inactive guard serializes nulls, never drops the keys.
+        let idle = with_guard_fields(
+            serde_json::json!({"action": "cycle_summary"}),
+            &maker::GuardDecision::INACTIVE,
+            None,
+            0.0,
+        );
+        assert_eq!(idle["guard_enabled"], false);
+        assert_eq!(idle["guard_active"], false);
+        assert!(idle["guard_side"].is_null());
+        assert!(idle["external_divergence_bps"].is_null());
+        assert!(idle["external_basis_bps"].is_null());
+        assert_eq!(idle["skew_shift_bps"], 0.0);
     }
 }

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -159,6 +159,14 @@ pub(super) struct CycleState<'a> {
     pub(super) breaker: &'a mut VolBreaker,
     pub(super) spread_controller: &'a mut SpreadController,
     pub(super) size_skew_controller: &'a mut SizeSkewController,
+    /// Stage 3 v1 nonlinear price-skew strength (disabled ≡ legacy linear).
+    pub(super) nonlinear_skew: standx_maker::NonlinearSkewConfig,
+    pub(super) guard_controller: &'a mut standx_maker::GuardController,
+    /// Caller-normalized external leader observation for this cycle; `None`
+    /// when the guard is disabled or the feed has no usable sample.
+    pub(super) external_divergence: Option<standx_maker::ExternalDivergence>,
+    /// Current divergence-basis EMA (telemetry only).
+    pub(super) external_basis_bps: Option<f64>,
     pub(super) order_request_deadlines: Option<&'a mut OrderRequestDeadlines>,
     /// Live-only REST polling state. It is deliberately a CLI concern: it
     /// controls I/O cadence and cached account presentation, not strategy.

--- a/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
@@ -210,6 +210,21 @@ impl MakerRuntime {
                 } else {
                     maker::MarketDataMode::Active
                 };
+                // Normalize the leader feed against THIS cycle's mark. A
+                // missing/stale sample yields None and the guard fails open.
+                let cycle_external_divergence = match self.loop_state.external_feed.as_ref() {
+                    Some(feed) => {
+                        let state = *feed.read().await;
+                        super::super::external_feed::divergence_input(
+                            state,
+                            mark,
+                            std::time::Instant::now(),
+                            &mut self.loop_state.external_basis,
+                        )
+                    }
+                    None => None,
+                };
+                let cycle_external_basis_bps = self.loop_state.external_basis.basis_bps();
                 let result = maker_cycle(
                     CycleRequest {
                         client,
@@ -252,6 +267,10 @@ impl MakerRuntime {
                         breaker: &mut self.loop_state.breaker,
                         spread_controller: &mut self.loop_state.spread_controller,
                         size_skew_controller: &mut self.loop_state.size_skew_controller,
+                        nonlinear_skew: self.loop_state.nonlinear_skew,
+                        guard_controller: &mut self.loop_state.guard_controller,
+                        external_divergence: cycle_external_divergence,
+                        external_basis_bps: cycle_external_basis_bps,
                         order_request_deadlines: cycle_order_request_deadlines.as_deref_mut(),
                         live_account_poll: cycle_account_poll.as_deref_mut(),
                         order_latency: cycle_order_latency.as_deref_mut(),
@@ -1189,6 +1208,12 @@ impl MakerRuntime {
                         None => std::future::pending().await,
                     }
                 };
+                let external_update = async {
+                    match self.loop_state.external_updates.as_mut() {
+                        Some(rx) => rx.changed().await.is_ok(),
+                        None => std::future::pending().await,
+                    }
+                };
                 tokio::select! {
                     _ = ctrl_c_latched(&mut self.ctrl_c_rx) => {
                         self.recovery.runtime_state.handle(MakerEvent::StopRequested(RuntimeStopReason::CtrlC));
@@ -1197,6 +1222,60 @@ impl MakerRuntime {
                     _ = tokio::time::sleep_until(deadline) => break,
                     _ = request_timeout => break,
                     _ = market_wakeup => break,
+                    ok = external_update => {
+                        // Leader-feed early wake: replan only when the fresh
+                        // divergence would change the guard's decision, and
+                        // never faster than the bounded-replan floor. A dead
+                        // feed channel is a fail-open non-event.
+                        if !ok {
+                            self.loop_state.external_updates = None;
+                            continue;
+                        }
+                        if tokio::time::Instant::now() < min_gap {
+                            continue;
+                        }
+                        let Some(feed) = self.loop_state.external_feed.as_ref() else {
+                            continue;
+                        };
+                        let Some(mark) = self.market.last_mark else {
+                            continue;
+                        };
+                        let state = *feed.read().await;
+                        let Some((raw_bps, age_ms)) =
+                            super::super::external_feed::raw_divergence(
+                                state,
+                                mark,
+                                std::time::Instant::now(),
+                            )
+                        else {
+                            continue;
+                        };
+                        let config = self.loop_state.guard_controller.config();
+                        if age_ms > config.max_age_ms {
+                            continue;
+                        }
+                        // Excess over the slow basis, read-only: the cycle is
+                        // the single writer of the baseline.
+                        let excess = self.loop_state.external_basis.peek(raw_bps);
+                        let magnitude = excess.abs();
+                        let toward = if excess > 0.0 {
+                            standx_sdk::models::OrderSide::Sell
+                        } else {
+                            standx_sdk::models::OrderSide::Buy
+                        };
+                        let would_change = match self.loop_state.guard_controller.endangered() {
+                            // Release, or a sign flip past the enter threshold
+                            // (side switch), both warrant an early replan.
+                            Some(side) => {
+                                magnitude < config.exit_bps
+                                    || (magnitude >= config.enter_bps && toward != side)
+                            }
+                            None => magnitude >= config.enter_bps,
+                        };
+                        if would_change {
+                            break;
+                        }
+                    },
                     event = account_update => {
                         // The branch futures are dropped before select! handlers
                         // run, so the session can be re-borrowed here. An event

--- a/crates/standx-cli/src/commands/maker/runtime/state.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/state.rs
@@ -43,6 +43,21 @@ pub(super) struct RuntimeLoopState {
     pub(super) breaker: VolBreaker,
     pub(super) spread_controller: maker::SpreadController,
     pub(super) size_skew_controller: maker::SizeSkewController,
+    pub(super) nonlinear_skew: maker::NonlinearSkewConfig,
+    pub(super) guard_controller: maker::GuardController,
+    /// Latest leader (Hyperliquid) sample for the external guard; `None` when
+    /// the guard is disabled and no feed task runs.
+    pub(super) external_feed: Option<
+        std::sync::Arc<
+            tokio::sync::RwLock<crate::commands::maker::external_feed::ExternalFeedState>,
+        >,
+    >,
+    pub(super) external_updates: Option<tokio::sync::watch::Receiver<u64>>,
+    /// Slow EMA over the raw leader-vs-mark divergence; the guard triggers on
+    /// the excess over it, never on the persistent venue basis.
+    pub(super) external_basis: crate::commands::maker::external_feed::DivergenceBaseline,
+    #[allow(dead_code)]
+    pub(super) external_feed_handle: Option<tokio::task::JoinHandle<()>>,
     pub(super) alerts: AlertMonitor,
     pub(super) account_balance_refresh_requested: bool,
     pub(super) balance_floor_parse_warned: bool,
@@ -146,6 +161,27 @@ impl MakerRuntime {
         };
         let spread_controller = maker::SpreadController::new(args.adaptive_spread.clone(), &cfg)?;
         let size_skew_controller = maker::SizeSkewController::new(args.size_skew, &cfg)?;
+        // Stage 3 v1 combined candidate: validate both switches up front so a
+        // bad file never rides along silently (band red line included).
+        let nonlinear_skew = args.nonlinear_skew;
+        nonlinear_skew.validate(&cfg)?;
+        let guard_basis_half_life_secs = args.external_guard_basis_half_life_secs;
+        let guard_controller = maker::GuardController::new(args.external_guard)?;
+        let (external_feed, external_updates, external_feed_handle) = if args.external_guard.enabled
+        {
+            let coin = crate::commands::maker::external_feed::leader_coin(&symbol);
+            eprintln!(
+                "🛡️ external guard enabled: leader=hyperliquid:{coin} enter={} exit={} max_age_ms={}",
+                args.external_guard.enter_bps,
+                args.external_guard.exit_bps,
+                args.external_guard.max_age_ms,
+            );
+            let (state, updates, handle) =
+                crate::commands::maker::external_feed::spawn_external_feed(coin);
+            (Some(state), Some(updates), Some(handle))
+        } else {
+            (None, None, None)
+        };
         let alerts =
             AlertMonitor::new(args.alert_loss, args.alert_inventory_pct, args.alert_uptime)
                 .with_account_floors(args.alert_equity_below, args.alert_margin_below);
@@ -230,6 +266,14 @@ impl MakerRuntime {
                 breaker,
                 spread_controller,
                 size_skew_controller,
+                nonlinear_skew,
+                guard_controller,
+                external_feed,
+                external_updates,
+                external_basis: crate::commands::maker::external_feed::DivergenceBaseline::new(
+                    guard_basis_half_life_secs,
+                ),
+                external_feed_handle,
                 alerts,
                 account_balance_refresh_requested: false,
                 balance_floor_parse_warned: false,

--- a/crates/standx-maker/src/external_guard.rs
+++ b/crates/standx-maker/src/external_guard.rs
@@ -1,0 +1,317 @@
+//! External-price defensive guard (stage 3 v1 combined candidate).
+//!
+//! When a leading external market (Hyperliquid midPx) has already moved and
+//! StandX's mark has not yet followed, resting quotes on one side are stale
+//! and about to be sniped. The guard temporarily suppresses that endangered
+//! side; it releases as soon as the divergence closes (StandX catches up,
+//! measured median ~2.6s), so activation is event-scoped seconds — unlike the
+//! rejected stage-3 v0 whose position-scoped latch pinned suppression for
+//! hours.
+//!
+//! Failure direction is OPEN: a missing, stale, or non-finite external sample
+//! deactivates the guard and quoting continues normally. The external feed is
+//! a defensive optimization, never a stop condition — it must not become a new
+//! outage source. This module is pure decision logic: no I/O, no clocks; the
+//! caller normalizes feed freshness into [`ExternalDivergence::age_ms`].
+
+use standx_sdk::models::OrderSide;
+use std::error::Error;
+use std::fmt;
+
+/// Operator configuration for the external-price guard (`[external_guard]`).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GuardConfig {
+    pub enabled: bool,
+    /// Activate when |divergence| reaches this many bps.
+    pub enter_bps: f64,
+    /// Release when |divergence| falls below this many bps (enter > exit > 0
+    /// gives a small anti-flap hysteresis; divergence closes by itself when
+    /// StandX's mark catches up, so there is no long-latch risk).
+    pub exit_bps: f64,
+    /// Samples older than this are treated as absent (fail-open).
+    pub max_age_ms: u64,
+}
+
+impl Default for GuardConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            enter_bps: 6.0,
+            exit_bps: 3.0,
+            max_age_ms: 5000,
+        }
+    }
+}
+
+/// One caller-normalized external observation for the current cycle.
+///
+/// `divergence_bps = (leader_mid / standx_mark - 1) × 1e4`: positive means the
+/// external price is above StandX's mark (our asks are stale-cheap), negative
+/// means below (our bids are stale-rich).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ExternalDivergence {
+    pub divergence_bps: f64,
+    /// Age of the external sample when this cycle's decision is made.
+    pub age_ms: u64,
+}
+
+/// Per-cycle guard outcome consumed by the planner.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GuardDecision {
+    pub enabled: bool,
+    pub active: bool,
+    /// The side whose resting quotes are endangered and must not quote.
+    pub endangered: Option<OrderSide>,
+    /// The divergence the decision was made on (telemetry only).
+    pub divergence_bps: Option<f64>,
+}
+
+impl GuardDecision {
+    pub const INACTIVE: Self = Self {
+        enabled: false,
+        active: false,
+        endangered: None,
+        divergence_bps: None,
+    };
+}
+
+impl Default for GuardDecision {
+    fn default() -> Self {
+        Self::INACTIVE
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GuardError(String);
+
+impl GuardError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for GuardError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl Error for GuardError {}
+
+/// Stateful enter/exit hysteresis around the divergence signal.
+#[derive(Clone, Debug)]
+pub struct GuardController {
+    config: GuardConfig,
+    endangered: Option<OrderSide>,
+}
+
+impl GuardController {
+    pub fn new(config: GuardConfig) -> Result<Self, GuardError> {
+        if !config.enter_bps.is_finite() || !config.exit_bps.is_finite() {
+            return Err(GuardError::new("guard thresholds must be finite"));
+        }
+        if config.exit_bps <= 0.0 || config.exit_bps >= config.enter_bps {
+            return Err(GuardError::new(
+                "guard thresholds must satisfy 0 < exit_bps < enter_bps",
+            ));
+        }
+        if config.max_age_ms == 0 {
+            return Err(GuardError::new("guard max_age_ms must be positive"));
+        }
+        Ok(Self {
+            config,
+            endangered: None,
+        })
+    }
+
+    pub fn config(&self) -> GuardConfig {
+        self.config
+    }
+
+    /// Currently suppressed side, if any (telemetry/transition logging).
+    pub fn endangered(&self) -> Option<OrderSide> {
+        self.endangered
+    }
+
+    /// Fold one cycle's external observation into the guard state.
+    ///
+    /// `None`, a stale sample, or a non-finite divergence always deactivates
+    /// (fail-open); state never survives a data gap, so a reconnecting feed
+    /// starts from a clean slate.
+    pub fn observe(&mut self, input: Option<ExternalDivergence>) -> GuardDecision {
+        if !self.config.enabled {
+            self.endangered = None;
+            return GuardDecision::INACTIVE;
+        }
+
+        let usable = input.filter(|sample| {
+            sample.age_ms <= self.config.max_age_ms && sample.divergence_bps.is_finite()
+        });
+        let Some(sample) = usable else {
+            self.endangered = None;
+            return GuardDecision {
+                enabled: true,
+                active: false,
+                endangered: None,
+                divergence_bps: None,
+            };
+        };
+
+        let divergence = sample.divergence_bps;
+        let magnitude = divergence.abs();
+        // Leader above our mark -> our asks are stale-cheap -> protect Sell.
+        let toward = if divergence > 0.0 {
+            OrderSide::Sell
+        } else {
+            OrderSide::Buy
+        };
+
+        self.endangered = match self.endangered {
+            // Entering, or an active guard whose divergence flipped sign past
+            // the enter threshold, points at the side the signal names now.
+            _ if magnitude >= self.config.enter_bps => Some(toward),
+            // Between exit and enter: hold the previous side (anti-flap).
+            Some(side) if magnitude >= self.config.exit_bps => Some(side),
+            _ => None,
+        };
+
+        GuardDecision {
+            enabled: true,
+            active: self.endangered.is_some(),
+            endangered: self.endangered,
+            divergence_bps: Some(divergence),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_config() -> GuardConfig {
+        GuardConfig {
+            enabled: true,
+            ..GuardConfig::default()
+        }
+    }
+
+    fn fresh(divergence_bps: f64) -> Option<ExternalDivergence> {
+        Some(ExternalDivergence {
+            divergence_bps,
+            age_ms: 100,
+        })
+    }
+
+    #[test]
+    fn rejects_invalid_thresholds() {
+        for config in [
+            GuardConfig {
+                enter_bps: f64::NAN,
+                ..enabled_config()
+            },
+            GuardConfig {
+                exit_bps: f64::INFINITY,
+                ..enabled_config()
+            },
+            GuardConfig {
+                exit_bps: 0.0,
+                ..enabled_config()
+            },
+            GuardConfig {
+                enter_bps: 3.0,
+                exit_bps: 3.0,
+                ..enabled_config()
+            },
+            GuardConfig {
+                max_age_ms: 0,
+                ..enabled_config()
+            },
+        ] {
+            assert!(GuardController::new(config).is_err());
+        }
+    }
+
+    #[test]
+    fn disabled_is_inactive_regardless_of_signal() {
+        let mut controller = GuardController::new(GuardConfig::default()).unwrap();
+        assert_eq!(controller.observe(fresh(50.0)), GuardDecision::INACTIVE);
+        assert_eq!(controller.observe(fresh(-50.0)), GuardDecision::INACTIVE);
+    }
+
+    #[test]
+    fn direction_maps_to_endangered_side() {
+        let mut controller = GuardController::new(enabled_config()).unwrap();
+        let up = controller.observe(fresh(8.0));
+        assert!(up.active);
+        assert_eq!(up.endangered, Some(OrderSide::Sell));
+
+        let mut controller = GuardController::new(enabled_config()).unwrap();
+        let down = controller.observe(fresh(-8.0));
+        assert!(down.active);
+        assert_eq!(down.endangered, Some(OrderSide::Buy));
+    }
+
+    #[test]
+    fn hysteresis_holds_between_exit_and_enter_and_releases_below_exit() {
+        let mut controller = GuardController::new(enabled_config()).unwrap();
+        assert!(!controller.observe(fresh(5.9)).active);
+        assert!(controller.observe(fresh(6.0)).active);
+        // Between exit (3) and enter (6): held.
+        let held = controller.observe(fresh(4.0));
+        assert!(held.active);
+        assert_eq!(held.endangered, Some(OrderSide::Sell));
+        // Below exit: released.
+        assert!(!controller.observe(fresh(2.9)).active);
+        // Re-entry requires the full enter threshold again.
+        assert!(!controller.observe(fresh(4.0)).active);
+    }
+
+    #[test]
+    fn sign_flip_past_enter_switches_sides_immediately() {
+        let mut controller = GuardController::new(enabled_config()).unwrap();
+        assert_eq!(
+            controller.observe(fresh(7.0)).endangered,
+            Some(OrderSide::Sell)
+        );
+        let flipped = controller.observe(fresh(-7.0));
+        assert!(flipped.active);
+        assert_eq!(flipped.endangered, Some(OrderSide::Buy));
+    }
+
+    #[test]
+    fn missing_stale_or_nonfinite_samples_fail_open() {
+        let mut controller = GuardController::new(enabled_config()).unwrap();
+        assert!(controller.observe(fresh(10.0)).active);
+
+        // Missing sample: deactivate.
+        let missing = controller.observe(None);
+        assert!(!missing.active);
+        assert_eq!(missing.divergence_bps, None);
+        assert!(missing.enabled);
+
+        // Stale sample: deactivate even though the value is large.
+        assert!(controller.observe(fresh(10.0)).active);
+        let stale = controller.observe(Some(ExternalDivergence {
+            divergence_bps: 10.0,
+            age_ms: 5001,
+        }));
+        assert!(!stale.active);
+
+        // Non-finite: deactivate.
+        assert!(controller.observe(fresh(10.0)).active);
+        assert!(!controller.observe(fresh(f64::NAN)).active);
+
+        // State never survives a gap: held zone after a gap does not re-latch.
+        assert!(!controller.observe(fresh(4.0)).active);
+    }
+
+    #[test]
+    fn boundary_age_is_still_usable() {
+        let mut controller = GuardController::new(enabled_config()).unwrap();
+        let decision = controller.observe(Some(ExternalDivergence {
+            divergence_bps: 9.0,
+            age_ms: 5000,
+        }));
+        assert!(decision.active);
+    }
+}

--- a/crates/standx-maker/src/inventory.rs
+++ b/crates/standx-maker/src/inventory.rs
@@ -3,6 +3,64 @@ use standx_sdk::models::OrderSide;
 use std::error::Error;
 use std::fmt;
 
+/// Stage 3 v1: non-linear price-skew strength (`[nonlinear_skew]`).
+///
+/// Replaces v0's binary add-side suppression with a steeper — but never
+/// stopping — center shift: `shift_bps = min(skew_bps × boost × |ratio|,
+/// cap_bps)` where `ratio = position / max_position`. Stateless by design (no
+/// hysteresis): v0's release-threshold latch pinned suppression for hours, so
+/// v1 strength is a pure continuous function of the current position. With
+/// `boost = 1` and `cap_bps ≥ skew_bps` the curve equals today's linear skew.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NonlinearSkewConfig {
+    pub enabled: bool,
+    /// Slope multiplier over the linear skew (≥ 1).
+    pub boost: f64,
+    /// Hard ceiling on the center shift in bps. Red line: the far-side quote
+    /// sits at `spread_bps + shift` from mark, so `spread_bps + cap_bps` must
+    /// stay inside `band_bps` (validated in [`Self::validate`]).
+    pub cap_bps: f64,
+}
+
+impl Default for NonlinearSkewConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            boost: 3.0,
+            cap_bps: 12.0,
+        }
+    }
+}
+
+impl NonlinearSkewConfig {
+    /// Validate against the base strategy config. Invalid values are rejected
+    /// even when disabled so a bad file never rides along silently.
+    pub fn validate(&self, base: &MakerConfig) -> Result<(), SizeSkewError> {
+        if !self.boost.is_finite() || !self.cap_bps.is_finite() {
+            return Err(SizeSkewError::new("nonlinear skew values must be finite"));
+        }
+        if self.boost < 1.0 {
+            return Err(SizeSkewError::new("nonlinear skew boost must be >= 1"));
+        }
+        if self.cap_bps <= 0.0 {
+            return Err(SizeSkewError::new("nonlinear skew cap_bps must be > 0"));
+        }
+        if self.enabled {
+            if !base.max_position.is_finite() || base.max_position <= 0.0 {
+                return Err(SizeSkewError::new(
+                    "enabled nonlinear skew requires positive finite max_position",
+                ));
+            }
+            if base.spread_bps + self.cap_bps > base.band_bps {
+                return Err(SizeSkewError::new(
+                    "nonlinear skew violates band red line: spread_bps + cap_bps must be <= band_bps",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SizeSkewConfig {
     pub enabled: bool,
@@ -306,6 +364,55 @@ mod tests {
         let decision = enabled.observe(2.0, &base);
         assert!(decision.active);
         assert_eq!(decision.inventory_ratio, 1.0);
+    }
+
+    #[test]
+    fn nonlinear_skew_validation_rejects_bad_values_and_band_violation() {
+        let base = base_config(); // spread 8, band 30
+        for config in [
+            NonlinearSkewConfig {
+                boost: f64::NAN,
+                ..NonlinearSkewConfig::default()
+            },
+            NonlinearSkewConfig {
+                cap_bps: f64::INFINITY,
+                ..NonlinearSkewConfig::default()
+            },
+            NonlinearSkewConfig {
+                boost: 0.9,
+                ..NonlinearSkewConfig::default()
+            },
+            NonlinearSkewConfig {
+                cap_bps: 0.0,
+                ..NonlinearSkewConfig::default()
+            },
+        ] {
+            assert!(config.validate(&base).is_err(), "{config:?}");
+        }
+
+        // Band red line: spread(8) + cap must stay <= band(30).
+        let too_wide = NonlinearSkewConfig {
+            enabled: true,
+            boost: 3.0,
+            cap_bps: 22.1,
+        };
+        assert!(too_wide.validate(&base).is_err());
+        // Same cap is fine while disabled (values still sanity-checked).
+        let disabled_wide = NonlinearSkewConfig {
+            enabled: false,
+            ..too_wide
+        };
+        assert!(disabled_wide.validate(&base).is_ok());
+
+        // Enabled requires a positive max_position.
+        let mut no_max = base_config();
+        no_max.max_position = 0.0;
+        let enabled = NonlinearSkewConfig {
+            enabled: true,
+            ..NonlinearSkewConfig::default()
+        };
+        assert!(enabled.validate(&no_max).is_err());
+        assert!(enabled.validate(&base).is_ok());
     }
 
     #[test]

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -18,6 +18,7 @@
 use standx_sdk::models::OrderSide;
 
 pub mod account_projection;
+pub mod external_guard;
 pub mod inventory;
 pub mod latency;
 pub mod ledger;
@@ -36,7 +37,12 @@ pub use account_projection::{
     ProjectionPendingRequest, ProjectionRegistryError, ProjectionRequestResolution,
     MAX_PENDING_ORDER_REQUESTS,
 };
-pub use inventory::{SizeSkewConfig, SizeSkewController, SizeSkewDecision, SizeSkewError};
+pub use external_guard::{
+    ExternalDivergence, GuardConfig, GuardController, GuardDecision, GuardError,
+};
+pub use inventory::{
+    NonlinearSkewConfig, SizeSkewConfig, SizeSkewController, SizeSkewDecision, SizeSkewError,
+};
 pub use latency::{
     LatencyError, LatencyMetricSummary, LatencyRequest, LatencyRequestContext, LatencyRequestKind,
     LatencyRequestOutcome, LatencySummary, OrderLatencyTracker,
@@ -330,6 +336,29 @@ pub(crate) fn skew_center(cfg: &MakerConfig, mark: f64, position: f64) -> f64 {
     mark * (1.0 - cfg.skew_bps * inv_ratio / 1e4)
 }
 
+/// Nonlinear-aware quote center (stage 3 v1). With the feature disabled this
+/// is byte-for-byte the legacy [`skew_center`] path; enabled, the shift grows
+/// `boost`× steeper than linear and saturates at `cap_bps`:
+/// `shift = sign(ratio) × min(skew_bps × boost × |ratio|, cap_bps)`.
+/// Stateless on purpose — no hysteresis, so strength tracks the live position
+/// with no latch (the failure mode that rejected v0).
+pub(crate) fn skew_center_with(
+    cfg: &MakerConfig,
+    nonlinear: NonlinearSkewConfig,
+    mark: f64,
+    position: f64,
+) -> f64 {
+    if !nonlinear.enabled {
+        return skew_center(cfg, mark, position);
+    }
+    if cfg.max_position <= 0.0 {
+        return mark;
+    }
+    let inv_ratio = (position / cfg.max_position).clamp(-1.0, 1.0);
+    let shift_bps = (cfg.skew_bps * nonlinear.boost * inv_ratio.abs()).min(nonlinear.cap_bps);
+    mark * (1.0 - shift_bps * inv_ratio.signum() / 1e4)
+}
+
 /// Paper-mode fill model: whether a resting quote would be filled by the
 /// current touch. A resting bid fills when offers reach down to it
 /// (`best_ask <= price`); a resting ask fills when bids reach up to it
@@ -602,6 +631,10 @@ pub struct CycleInput<'a> {
     pub inventory_exit_pct: f64,
     pub inventory_exit_qty: f64,
     pub size_skew: SizeSkewDecision,
+    /// Stage 3 v1 nonlinear price-skew strength; disabled ≡ legacy linear skew.
+    pub nonlinear_skew: NonlinearSkewConfig,
+    /// External-price guard outcome for this cycle; inactive ≡ no suppression.
+    pub guard: GuardDecision,
     /// Supervisor-requested wind-down (e.g. an A/B arm past its scheduled
     /// window): never place new quotes again and flatten any residual
     /// position through the reduce-only exit path, ignoring the configured
@@ -672,6 +705,8 @@ pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> Cyc
             input.market.best_ask,
             input.position,
             input.size_skew,
+            input.nonlinear_skew,
+            input.guard,
         );
         cap_desired_exposure(cfg, input.position, &raw, input.pending_slots)
     };
@@ -688,8 +723,9 @@ pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> Cyc
             &desired,
             input.resting,
             input.cycle,
+            input.nonlinear_skew,
         ),
-        ref_center: skew_center(cfg, input.market.mark, input.position),
+        ref_center: skew_center_with(cfg, input.nonlinear_skew, input.market.mark, input.position),
     }
 }
 
@@ -908,6 +944,7 @@ impl AlertMonitor {
 /// min-qty filter, and max-position side suppression. Quotes that fail a guard
 /// are dropped; duplicate prices after clamping/rounding are collapsed (outer
 /// level wins nothing — the inner level is kept).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_desired_quotes(
     cfg: &MakerConfig,
     mark: f64,
@@ -915,6 +952,8 @@ pub(crate) fn compute_desired_quotes(
     best_ask: Option<f64>,
     position: f64,
     size_skew: SizeSkewDecision,
+    nonlinear_skew: NonlinearSkewConfig,
+    guard: GuardDecision,
 ) -> Vec<DesiredQuote> {
     let mut out = Vec::new();
     if !mark.is_finite()
@@ -937,13 +976,20 @@ pub(crate) fn compute_desired_quotes(
 
     // Ladder is centered on the inventory-skewed price; the band/no-cross
     // guards below still reference the true mark and touch.
-    let center = skew_center(cfg, mark, position);
+    let center = skew_center_with(cfg, nonlinear_skew, mark, position);
 
     let suppress_buy = position >= cfg.max_position;
     let suppress_sell = position <= -cfg.max_position;
 
     for side in [OrderSide::Buy, OrderSide::Sell] {
         if (side == OrderSide::Buy && suppress_buy) || (side == OrderSide::Sell && suppress_sell) {
+            continue;
+        }
+        // External-price guard: the endangered side's quotes are stale against
+        // a leading market that has already moved — do not quote it this
+        // cycle. Resting quotes on that side cancel via the SideSuppressed
+        // path; the guard releases once StandX's mark catches up.
+        if guard.active && guard.endangered == Some(side) {
             continue;
         }
         let side_qty = if size_skew.active && size_skew.add_side == Some(side) {
@@ -1115,12 +1161,13 @@ pub(crate) fn reconcile(
     desired: &[DesiredQuote],
     resting: &[RestingQuote],
     cycle: u64,
+    nonlinear_skew: NonlinearSkewConfig,
 ) -> Vec<Action> {
     // Band/no-cross reference the true mark and touch; the anti-flicker anchor
     // uses the inventory-skewed center.
     let band_lo = mark * (1.0 - cfg.band_bps / 1e4);
     let band_hi = mark * (1.0 + cfg.band_bps / 1e4);
-    let center = skew_center(cfg, mark, position);
+    let center = skew_center_with(cfg, nonlinear_skew, mark, position);
 
     let desired_has = |side: OrderSide, level: u32| -> bool {
         desired.iter().any(|d| d.side == side && d.level == level)
@@ -1218,6 +1265,8 @@ mod tests {
             best_ask,
             position,
             SizeSkewDecision::INACTIVE,
+            NonlinearSkewConfig::default(),
+            GuardDecision::INACTIVE,
         )
     }
 
@@ -1274,6 +1323,7 @@ mod tests {
             &desired,
             &[],
             0,
+            Default::default(),
         );
         assert!(actions
             .iter()
@@ -1307,6 +1357,7 @@ mod tests {
             &desired,
             &resting,
             1,
+            Default::default(),
         );
         assert!(actions.iter().any(|action| matches!(
             action,
@@ -1444,7 +1495,17 @@ mod tests {
             resting(OrderSide::Buy, 0, 99.90, 100.0),
             resting(OrderSide::Sell, 0, 100.10, 100.0),
         ];
-        let actions = reconcile(&c, mark, 0.0, None, None, &desired, &rest, 7);
+        let actions = reconcile(
+            &c,
+            mark,
+            0.0,
+            None,
+            None,
+            &desired,
+            &rest,
+            7,
+            Default::default(),
+        );
         assert!(
             actions.iter().all(|a| matches!(a, Action::Hold { .. })),
             "{actions:?}"
@@ -1462,7 +1523,17 @@ mod tests {
         let mark = 100.05; // 5 bps > refresh 3
         let desired = desired(&c, mark, None, None, 0.0);
         let rest = vec![resting(OrderSide::Buy, 0, 99.90, 100.0)];
-        let actions = reconcile(&c, mark, 0.0, None, None, &desired, &rest, 1);
+        let actions = reconcile(
+            &c,
+            mark,
+            0.0,
+            None,
+            None,
+            &desired,
+            &rest,
+            1,
+            Default::default(),
+        );
         // Expect: cancel(buy, mark_moved), then places for buy+sell.
         assert!(matches!(
             actions[0],
@@ -1488,7 +1559,17 @@ mod tests {
         let mark = 100.30;
         let desired = desired(&c, mark, None, None, 0.0);
         let rest = vec![resting(OrderSide::Buy, 0, 99.90, 100.0)];
-        let actions = reconcile(&c, mark, 0.0, None, None, &desired, &rest, 1);
+        let actions = reconcile(
+            &c,
+            mark,
+            0.0,
+            None,
+            None,
+            &desired,
+            &rest,
+            1,
+            Default::default(),
+        );
         assert!(
             matches!(
                 actions[0],
@@ -1518,6 +1599,7 @@ mod tests {
             &desired,
             &rest,
             1,
+            Default::default(),
         );
         assert!(
             matches!(
@@ -1556,7 +1638,17 @@ mod tests {
             resting(OrderSide::Buy, 0, 99.90, 100.0),
             resting(OrderSide::Buy, 1, 99.88, 100.0), // stale level
         ];
-        let actions = reconcile(&c, mark, 0.0, None, None, &desired, &rest, 1);
+        let actions = reconcile(
+            &c,
+            mark,
+            0.0,
+            None,
+            None,
+            &desired,
+            &rest,
+            1,
+            Default::default(),
+        );
         let stale: Vec<_> = actions
             .iter()
             .filter(|a| {
@@ -1870,7 +1962,17 @@ mod tests {
         let pos = 0.025;
         let desired = desired(&c, mark, None, None, pos);
         let rest = vec![resting(OrderSide::Sell, 0, 100.10, 100.0)];
-        let actions = reconcile(&c, mark, pos, None, None, &desired, &rest, 1);
+        let actions = reconcile(
+            &c,
+            mark,
+            pos,
+            None,
+            None,
+            &desired,
+            &rest,
+            1,
+            Default::default(),
+        );
         assert!(actions.iter().any(|a| matches!(
             a,
             Action::Cancel {
@@ -1883,7 +1985,17 @@ mod tests {
         let pos2 = 0.01;
         let desired2 = self::desired(&c, mark, None, None, pos2);
         let rest2 = vec![resting(OrderSide::Sell, 0, 100.10, 100.0)];
-        let actions2 = reconcile(&c, mark, pos2, None, None, &desired2, &rest2, 1);
+        let actions2 = reconcile(
+            &c,
+            mark,
+            pos2,
+            None,
+            None,
+            &desired2,
+            &rest2,
+            1,
+            Default::default(),
+        );
         assert!(actions2.iter().any(|a| matches!(a, Action::Hold { .. })));
         assert!(!actions2.iter().any(|a| matches!(a, Action::Cancel { .. })));
     }
@@ -1992,6 +2104,8 @@ mod tests {
             inventory_exit_pct: 80.0,
             inventory_exit_qty: 0.01,
             size_skew: Default::default(),
+            nonlinear_skew: Default::default(),
+            guard: Default::default(),
             wind_down: false,
             qty_tolerance: 0.0005,
         };
@@ -2047,6 +2161,8 @@ mod tests {
                 inventory_exit_pct: 0.0,
                 inventory_exit_qty: 0.0,
                 size_skew: Default::default(),
+                nonlinear_skew: Default::default(),
+                guard: Default::default(),
                 wind_down: false,
                 qty_tolerance: 0.0005,
             },
@@ -2088,6 +2204,8 @@ mod tests {
                 inventory_exit_pct: 80.0,
                 inventory_exit_qty: 0.01,
                 size_skew: Default::default(),
+                nonlinear_skew: Default::default(),
+                guard: Default::default(),
                 wind_down: false,
                 qty_tolerance: 0.0005,
             },
@@ -2148,6 +2266,8 @@ mod tests {
                         inventory_exit_pct: 0.0,
                         inventory_exit_qty: 0.0,
                         size_skew: SizeSkewDecision::default(),
+                        nonlinear_skew: Default::default(),
+                        guard: Default::default(),
                         wind_down: false,
                         qty_tolerance: 0.0005,
                     };
@@ -2156,6 +2276,8 @@ mod tests {
                         &c,
                         CycleInput {
                             size_skew: inactive,
+                            nonlinear_skew: Default::default(),
+                            guard: Default::default(),
                             ..input
                         },
                         false,
@@ -2164,6 +2286,277 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn disabled_nonlinear_and_inactive_guard_are_plan_equivalent_across_state_grid() {
+        let mut c = cfg();
+        c.levels = 2;
+        c.max_position = 0.05;
+        c.skew_bps = 10.0;
+        let resting_sets = [
+            Vec::new(),
+            vec![
+                resting(OrderSide::Buy, 0, 99.9, 100.0),
+                resting(OrderSide::Sell, 0, 100.1, 100.0),
+            ],
+        ];
+        // Disabled nonlinear config with aggressive non-default parameters, and
+        // an enabled-but-inactive guard: neither may perturb a single action.
+        let disabled_nonlinear = NonlinearSkewConfig {
+            enabled: false,
+            boost: 7.0,
+            cap_bps: 9.0,
+        };
+        let inactive_guard = GuardDecision {
+            enabled: true,
+            active: false,
+            endangered: None,
+            divergence_bps: Some(2.0),
+        };
+
+        for position in [-0.04, -0.025, 0.0, 0.025, 0.04] {
+            for resting in &resting_sets {
+                let input = CycleInput {
+                    cycle: 6,
+                    market: MarketSnapshot {
+                        mark: 100.0,
+                        best_bid: Some(99.99),
+                        best_ask: Some(100.01),
+                    },
+                    position,
+                    resting,
+                    pending_slots: &[],
+                    market_data_mode: MarketDataMode::Active,
+                    active_exit_enabled: false,
+                    inventory_exit_pct: 0.0,
+                    inventory_exit_qty: 0.0,
+                    size_skew: SizeSkewDecision::default(),
+                    nonlinear_skew: Default::default(),
+                    guard: Default::default(),
+                    wind_down: false,
+                    qty_tolerance: 0.0005,
+                };
+                let default_plan = plan_cycle(&c, input, false);
+                let candidate_plan = plan_cycle(
+                    &c,
+                    CycleInput {
+                        nonlinear_skew: disabled_nonlinear,
+                        guard: inactive_guard,
+                        ..input
+                    },
+                    false,
+                );
+                assert_eq!(candidate_plan, default_plan);
+            }
+        }
+    }
+
+    #[test]
+    fn nonlinear_skew_boost_one_with_high_cap_equals_linear() {
+        let mut c = cfg();
+        c.skew_bps = 8.0;
+        c.max_position = 1.0;
+        let nl = NonlinearSkewConfig {
+            enabled: true,
+            boost: 1.0,
+            cap_bps: 8.0,
+        };
+        for position in [-1.0, -0.6, -0.2, 0.0, 0.2, 0.6, 1.0] {
+            assert_eq!(
+                skew_center_with(&c, nl, 100.0, position),
+                skew_center(&c, 100.0, position),
+                "position {position}"
+            );
+        }
+    }
+
+    #[test]
+    fn nonlinear_skew_steepens_saturates_and_mirrors() {
+        let mut c = cfg();
+        c.skew_bps = 8.0;
+        c.max_position = 1.0;
+        let nl = NonlinearSkewConfig {
+            enabled: true,
+            boost: 3.0,
+            cap_bps: 12.0,
+        };
+        // ratio 0.2 -> 8*3*0.2 = 4.8bps below mark (long favors selling).
+        let long = skew_center_with(&c, nl, 100.0, 0.2);
+        assert!((long - (100.0 * (1.0 - 4.8 / 1e4))).abs() < 1e-9);
+        // Steeper than linear (linear at 0.2 is 1.6bps).
+        assert!(long < skew_center(&c, 100.0, 0.2));
+        // ratio 0.5 -> 12bps raw but capped at 12 -> exactly the cap; deeper
+        // inventory saturates at the same shift.
+        let at_half = skew_center_with(&c, nl, 100.0, 0.5);
+        let at_full = skew_center_with(&c, nl, 100.0, 1.0);
+        assert!((at_half - (100.0 * (1.0 - 12.0 / 1e4))).abs() < 1e-9);
+        assert_eq!(at_half, at_full);
+        // Long/short mirror around the mark.
+        let short = skew_center_with(&c, nl, 100.0, -0.2);
+        assert!((short + long - 200.0).abs() < 1e-9);
+        // Zero position never shifts.
+        assert_eq!(skew_center_with(&c, nl, 100.0, 0.0), 100.0);
+    }
+
+    #[test]
+    fn guard_suppresses_endangered_side_and_cancels_its_resting_quotes() {
+        let c = cfg();
+        let resting = vec![
+            resting(OrderSide::Buy, 0, 99.9, 100.0),
+            resting(OrderSide::Sell, 0, 100.1, 100.0),
+        ];
+        let plan = plan_cycle(
+            &c,
+            CycleInput {
+                cycle: 3,
+                market: MarketSnapshot {
+                    mark: 100.0,
+                    best_bid: Some(99.99),
+                    best_ask: Some(100.01),
+                },
+                position: 0.0,
+                resting: &resting,
+                pending_slots: &[],
+                market_data_mode: MarketDataMode::Active,
+                active_exit_enabled: false,
+                inventory_exit_pct: 0.0,
+                inventory_exit_qty: 0.0,
+                size_skew: Default::default(),
+                nonlinear_skew: Default::default(),
+                guard: GuardDecision {
+                    enabled: true,
+                    active: true,
+                    endangered: Some(OrderSide::Sell),
+                    divergence_bps: Some(9.0),
+                },
+                wind_down: false,
+                qty_tolerance: 0.0005,
+            },
+            false,
+        );
+
+        // The endangered sell side: no new quotes, resting cancelled as
+        // side-suppressed.
+        assert!(!plan
+            .actions
+            .iter()
+            .any(|action| matches!(action, Action::Place(q) if q.side == OrderSide::Sell)));
+        assert!(plan.actions.iter().any(|action| matches!(
+            action,
+            Action::Cancel {
+                side: OrderSide::Sell,
+                reason: CancelReason::SideSuppressed,
+                ..
+            }
+        )));
+        // The safe buy side keeps quoting (hold of the fresh resting quote).
+        assert!(plan.actions.iter().any(|action| matches!(
+            action,
+            Action::Hold {
+                side: OrderSide::Buy,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn combined_high_inventory_and_guard_keeps_all_invariants() {
+        let mut c = cfg();
+        c.skew_bps = 8.0;
+        c.band_bps = 30.0;
+        c.max_position = 0.05;
+        let nl = NonlinearSkewConfig {
+            enabled: true,
+            boost: 3.0,
+            cap_bps: 12.0,
+        };
+        // Long 80% of max while the external leader jumps DOWN: guard protects
+        // the buy side (stale-rich bids), nonlinear skew is already pushing the
+        // center down. Both act in the same defensive direction by design.
+        let position = 0.04;
+        let plan = plan_cycle(
+            &c,
+            CycleInput {
+                cycle: 9,
+                market: MarketSnapshot {
+                    mark: 100.0,
+                    best_bid: Some(99.99),
+                    best_ask: Some(100.01),
+                },
+                position,
+                resting: &[],
+                pending_slots: &[],
+                market_data_mode: MarketDataMode::Active,
+                active_exit_enabled: false,
+                inventory_exit_pct: 0.0,
+                inventory_exit_qty: 0.0,
+                size_skew: Default::default(),
+                nonlinear_skew: nl,
+                guard: GuardDecision {
+                    enabled: true,
+                    active: true,
+                    endangered: Some(OrderSide::Buy),
+                    divergence_bps: Some(-8.0),
+                },
+                wind_down: false,
+                qty_tolerance: 0.0005,
+            },
+            false,
+        );
+
+        let band_lo = 100.0 * (1.0 - c.band_bps / 1e4);
+        let band_hi = 100.0 * (1.0 + c.band_bps / 1e4);
+        let mut worst_case_long = position;
+        for action in &plan.actions {
+            if let Action::Place(q) = action {
+                // Guard: no buy quotes at all.
+                assert_ne!(q.side, OrderSide::Buy);
+                // Band and no-cross hold under the combined shift.
+                assert!(q.price >= band_lo && q.price <= band_hi);
+                assert!(q.price >= 99.99 + c.price_tick() - 1e-9);
+                if q.side == OrderSide::Buy {
+                    worst_case_long += q.qty;
+                }
+            }
+        }
+        assert!(worst_case_long <= c.max_position + 1e-9);
+
+        // Release: guard inactive next cycle restores the buy ladder under the
+        // same (still skewed) center.
+        let released = plan_cycle(
+            &c,
+            CycleInput {
+                cycle: 10,
+                market: MarketSnapshot {
+                    mark: 100.0,
+                    best_bid: Some(99.99),
+                    best_ask: Some(100.01),
+                },
+                position,
+                resting: &[],
+                pending_slots: &[],
+                market_data_mode: MarketDataMode::Active,
+                active_exit_enabled: false,
+                inventory_exit_pct: 0.0,
+                inventory_exit_qty: 0.0,
+                size_skew: Default::default(),
+                nonlinear_skew: nl,
+                guard: GuardDecision {
+                    enabled: true,
+                    active: false,
+                    endangered: None,
+                    divergence_bps: Some(1.0),
+                },
+                wind_down: false,
+                qty_tolerance: 0.0005,
+            },
+            false,
+        );
+        assert!(released
+            .actions
+            .iter()
+            .any(|action| matches!(action, Action::Place(q) if q.side == OrderSide::Buy)));
     }
 
     // 28. Alert monitor: disabled emits nothing.
@@ -2293,6 +2686,8 @@ mod tests {
             inventory_exit_pct: 0.0,
             inventory_exit_qty: 0.0,
             size_skew: Default::default(),
+            nonlinear_skew: Default::default(),
+            guard: Default::default(),
             wind_down: true,
             qty_tolerance: 0.0005,
         };
@@ -2344,6 +2739,8 @@ mod tests {
                 inventory_exit_pct: 0.0,
                 inventory_exit_qty: 0.0,
                 size_skew: Default::default(),
+                nonlinear_skew: Default::default(),
+                guard: Default::default(),
                 wind_down: true,
                 qty_tolerance: 0.0005,
             },
@@ -2375,6 +2772,8 @@ mod tests {
             inventory_exit_pct: 80.0,
             inventory_exit_qty: 0.01,
             size_skew: Default::default(),
+            nonlinear_skew: Default::default(),
+            guard: Default::default(),
             wind_down: true,
             qty_tolerance: 0.0005,
         };

--- a/crates/standx-maker/src/replay.rs
+++ b/crates/standx-maker/src/replay.rs
@@ -172,6 +172,8 @@ pub fn run_replay(
                             inventory_exit_pct: settings.inventory_exit_pct,
                             inventory_exit_qty: settings.inventory_exit_qty,
                             size_skew: size_skew_decision,
+                            nonlinear_skew: Default::default(),
+                            guard: Default::default(),
                             wind_down: false,
                             qty_tolerance: 0.0005,
                         },

--- a/crates/standx-maker/src/volatility.rs
+++ b/crates/standx-maker/src/volatility.rs
@@ -526,6 +526,8 @@ mod tests {
                 inventory_exit_pct: 0.0,
                 inventory_exit_qty: 0.0,
                 size_skew: Default::default(),
+                nonlinear_skew: Default::default(),
+                guard: Default::default(),
                 wind_down: false,
                 qty_tolerance: 0.0005,
             },

--- a/docs/18-maker-strategy-roadmap.md
+++ b/docs/18-maker-strategy-roadmap.md
@@ -311,12 +311,20 @@ peak-to-trough `vol_bps`）和当前 touch spread。markout/toxicity 与滚动 l
 
 ## 阶段 3：非线性库存控制
 
-当前状态：`rejected_uptime_cost`（2026-07-22 判定）。v0 的 6 臂实盘 A/B 完成：
-尾部治理达标（p95 |position| 降 40–62%、≥70% 仓时间清零、退出成本未恶化），但二值加仓侧
-压制使双边 uptime 降 43–80pp（判据 ≤3pp），按预注册判据不晋级；baseline 维持 HYPE 静态
-配置。判定报告见
+当前状态：`v1_combined_implementing`（2026-07-22 立项）。v0 判定 `rejected_uptime_cost`
+（2026-07-22）：6 臂实盘 A/B 完成，尾部治理达标（p95 |position| 降 40–62%、≥70% 仓时间
+清零、退出成本未恶化），但二值加仓侧压制使双边 uptime 降 43–80pp，按预注册判据不晋级；
+baseline 维持 HYPE 静态配置。判定报告见
 [maker-stage3-ab-judgment-2026-07-22.md](evidence/maker-stage3-ab-judgment-2026-07-22.md)。
-按 20 号文档分支，下一增量候选为 v1 非线性 price skew（"更陡但不停"），重走同一验收。
+
+**v1 组合候选（release owner 2026-07-22 裁决）**：非线性 price skew（"更陡但不停"）与
+外部价防御门（HL midPx 领先信号压制危险侧，lag 证据见
+[lag-recorder-hype-result-2026-07-22.md](evidence/lag-recorder-hype-result-2026-07-22.md)）
+**合并为一个 release、各带独立 enable 开关**，一次 canary 重锁，A/B 两臂
+（baseline vs 双开组合）+ 遥测事件级归因；组合被拒时拆单机制以纯配置 A/B 重跑（不重锁）。
+**uptime 判据修订为绝对值 ≥80%**（替代原 ≤3pp 相对判据，release owner 2026-07-22）。
+设计、红线（SIP-5A 带内 cap、无迟滞、guard fail-open）与预注册判据全文见
+[22-maker-stage3v1-guard-design.md](22-maker-stage3v1-guard-design.md)。
 立项依据是三项仲裁分析（610 笔 fill / 81 个库存事件 / 16 笔实测退出成本），记录见
 [maker-stage3-arbitration-2026-07-20.md](evidence/maker-stage3-arbitration-2026-07-20.md)，
 分析脚本 `scripts/maker_tail_arbitration.py`。

--- a/docs/22-maker-stage3v1-guard-design.md
+++ b/docs/22-maker-stage3v1-guard-design.md
@@ -1,0 +1,138 @@
+# 阶段 3 v1 组合候选设计：非线性 price skew + 外部价防御门（2026-07-22）
+
+一次发布、两个独立开关、一次 canary 重锁。本文档是实现与验收的唯一设计依据；
+判据预注册于本文档"验收判据"节，与 [18](18-maker-strategy-roadmap.md) 阶段 3
+验收标准的差异（uptime 绝对门槛）由 release owner 2026-07-22 裁决。
+
+## 动机与证据链
+
+- 阶段 3 v0（二值加仓侧压制）判定 rejected：尾部治理达标（p95 |position|
+  降 40–62%、≥70% 仓时间清零）但双边 uptime 降 43–80pp。死因是结构性的：
+  激活阈值落在仓位常住区（激活率 45–79%）+ 释放迟滞闩锁（candidate #3 钉
+  +0.2 约 3h，uptime 18%）。见
+  [maker-stage3-ab-judgment-2026-07-22.md](evidence/maker-stage3-ab-judgment-2026-07-22.md)。
+- lag 44.5h 长录 midPx 重切：HL midPx 领先 StandX mark，可测量跟随占 61%、
+  条件 lag 中位 2.6s（p25 1.8s）、16–32bps 跳幅档 0 次 already-ahead。见
+  [lag-recorder-hype-result-2026-07-22.md](evidence/lag-recorder-hype-result-2026-07-22.md)。
+- 组合理由：两机制治同一亏损链的不同环节（防御门治首刀、skew 治首刀后的
+  逆势累积），canary 重锁按发布计费，合并省一轮 gate；独立开关保证组合被拒
+  时拆单机制重跑是纯配置 A/B（按路线图规则不重锁）。
+
+## 机制 1：非线性 price skew（`[nonlinear_skew]`）
+
+替代 v0 的"停挂"：加仓侧报价**永远在场**，只是随库存变陡地歪价。
+
+- 纯函数、**无状态、无迟滞**（v0 闩锁教训直接吸收）：强度是 |position| 的
+  连续函数，仓位降强度立刻降。
+- 公式：`shift_bps = sign(position) × min(skew_bps × boost × |ratio|, cap_bps)`，
+  `ratio = position / max_position`（clamp ±1）。`boost=1` 且 `cap_bps ≥ skew_bps`
+  时数值上等于现行线性 skew；`enabled=false` 时走原 `skew_center` 代码路径，
+  逐 action 等价。
+- 配置：`enabled`（默认 false）、`boost`（≥1，冻结候选 3.0）、`cap_bps`
+  （冻结候选 12.0）。
+- **红线（修订于实现时，对照代码确认）**：`spread_bps` 是**单侧**偏移
+  （报价挂在 `center × (1 ± spread_bps/1e4)`），现行线性 skew（`skew_bps=8`
+  满仓偏移）在 |ratio|>0.25 时远侧报价已越出 SIP-5A 10bps 合格带——即
+  **现行生产配置本就不满足 SIP-5A 带内约束**，且 release owner 已裁决目标
+  函数为"少亏"、不计 SIP-5A 收益。故 cap 红线改锚定策略自身 band：核心校验
+  `spread_bps + cap_bps ≤ band_bps`（8+12=20 ≤ 30），band/no-cross 硬 guard
+  照常兜底。SIP-5A proximity 损失作为已知代价记录，不作为门槛。
+- uptime 结构性不受损：skew 只歪价不撤单，双边报价始终在场（uptime 统计的
+  合格深度按 `band_bps=30` 计）。
+- 设计输入（v0 数据）：线性 skew 在 0.2–0.3 仓位区的 2–5bps 平移实测挡不住
+  趋势碾压；boost=3 下 0.2 仓位即 4.8bps、0.3 仓位 7.2bps，0.5 起顶满
+  12bps cap。
+
+## 机制 2：外部价防御门（`[external_guard]`）
+
+HL midPx 已跳走、StandX mark 未跟上时，**临时压制危险侧**；mark 追平即恢复。
+
+- 原始信号：`raw_divergence_bps = (hl_mid / standx_mark − 1) × 1e4`。
+- **基差扣除（2026-07-22 paper 冒烟发现后修订）**：HYPE 实测 HL midPx 与
+  StandX mark 存在 ~-14bps 的**持久静态基差**（场馆溢价/资金费结构，不是
+  狙击信号）。若拿原始水位差触发，guard 会在单侧永久闩锁——精确复刻 v0 的
+  uptime 死法。故 CLI 侧维护一条慢 EMA 基线（`basis_half_life_secs`，冻结
+  候选 300s），guard 的 typed input 是**超额背离** `excess = raw − basis`：
+  秒级跳变原样穿透（相对跳变前的基线度量，不被自身样本吸收），分钟级稳定的
+  基差被吸收；首个样本初始化基线，启动基差永不触发。这与 lag 分析的"跳变"
+  口径一致。遥测同时记录 `external_divergence_bps`（excess，决策依据）与
+  `external_basis_bps`（基线），raw 可重构。
+- excess > 0（外部价相对基线更高）→ 我方 ask 是过期便宜货 → 危险侧 =
+  Sell；反之 = Buy。
+- 控制器（core 纯逻辑，`GuardConfig { enabled, enter_bps, exit_bps, max_age_ms }`）：
+  `|excess| ≥ enter_bps` 激活，回落 `< exit_bps` 解除（小迟滞防抖动）；激活
+  期间反号越过 enter 立即换边。与 v0 闩锁的本质区别：解除条件是 excess 收敛
+  （StandX 追平即闭合，实测中位 2.6s），不依赖成交，无长闩锁风险。冻结候选
+  `enter=6 / exit=3`。
+- 压制语义复用现有 `SideSuppressed` 路径：激活时危险侧 desired 为空 →
+  reconcile 撤该侧 resting、不摆新单；解除后自然恢复。事件时长秒级，
+  按 lag 数据预算激活时间 ~0.7%/天，uptime 影响可忽略。
+- **降级方向 = 关（fail-open to normal）**：HL feed 缺失、断线、样本过期
+  （`age_ms > max_age_ms`，冻结候选 5000ms）→ 门自动失效、正常报价。
+  外部依赖绝不能成为新的停机源；guard 是防御优化，不是安全不变量。
+- **不建亚秒快速通道**：挂现有 cycle 早醒机制（外部 divergence 越过 enter
+  阈值 → 唤醒，仍受 1s min-gap 地板约束），反应 ~1–1.5s，对中位 2.6s /
+  p25 1.8s 的窗口够用。快速通道留作后续增量。
+- CLI 侧：HL WS 客户端从 lag-recorder 抽出为共享模块；feed 任务写
+  `Arc<RwLock>` 状态 + watch 唤醒；每 cycle 归一化为
+  `Option<ExternalDivergence { divergence_bps, age_ms }>` typed input，
+  core 不做任何 I/O（架构边界不变）。
+- Replay：确定性回放无 HL feed → guard 输入恒 None → 恒不激活。replay 只
+  承担"关闭时等价"验证（路线图既定分工），guard 的经济价值由 live A/B 判。
+
+## 遥测（归因用，全部为可选新增字段/事件）
+
+- `cycle_summary` 新增：`skew_shift_bps`、`external_divergence_bps`、
+  `guard_active`、`guard_side`。
+- guard 激活/解除各发一条 maker log 事件（新 action，additive）。
+- 目的：两臂 A/B 判组合生死；事件级归因（guard 激活窗口内躲掉的成交 vs
+  skew 生效期的库存轨迹）从日志做，组合被拒时决定拆哪一半单跑。
+
+## Paper 冒烟记录（2026-07-22/23）
+
+第一轮冒烟（candidate 配置，公共行情，无订单）**抓到基差缺陷**：guard 启动
+即因 -14bps 静态基差永久激活 Buy 侧压制——上节的基差扣除修订即由此而来，
+这正是"高仓位+外部跳动"类冒烟先行的价值。第二轮冒烟验证修复后行为（基线
+初始化后 excess≈0、guard 不再因基差激活、遥测字段齐全），结果随 evidence
+记录。
+
+## 组合交互与冒烟场景
+
+已知交互：多头高库存时 skew 把中心下移（ask 更近 touch），若此时外部价
+向下跳，guard 压 Buy 侧——两机制同向叠加是**设计内**行为（都在防同一方向
+风险）。需专门冒烟的场景：高库存 + 外部跳动同时发生时，(a) 不违反
+max_position / band / no-cross；(b) guard 解除后 skew 单独作用的报价恢复
+正确；(c) 全关组合 ≡ 现行为。paper 冒烟必须覆盖。
+
+## 验收判据（预注册，live 时间片 A/B，两臂：baseline vs 双开组合）
+
+沿用阶段 2/3 A/B 规程（4h 臂、wind-down 换臂、同 size/max_position）：
+
+- [ ] 全关（两开关均 off）≡ 现行策略，逐 action 等价（含单开×2、双开、
+  全关的状态网格离线测试）。
+- [ ] 无 max_position / band / no-cross / 账本 / generation 安全违规。
+- [ ] 样本外 p95 |position| 降 ≥15%，或 ≥70% max_position 时间降 ≥25%
+  （继承 v0 达标线）。
+- [ ] 主动退出次数与总 taker exit cost 不高于基线。
+- [ ] net PnL ≥ 基线 95%；两臂各至少覆盖一段趋势时段，否则不判 PnL。
+- [ ] **时间加权双边 uptime ≥ 80%（绝对值；release owner 2026-07-22 裁决，
+  替代原 ≤3pp 相对判据）**。
+- [ ] 每 quote-hour 撤单数相对基线增加 ≤20%（兼防 SIP-5A short-cycle
+  cancels 条款）。
+- [ ] guard 激活时间占比与激活次数落在 lag 数据预算的 3 倍以内
+  （防 HL 噪声导致的失控触发；超预算即视为信号质量问题，臂照跑但
+  记录为设计缺陷输入）。
+
+组合被拒时的预注册分支：按遥测归因拆单机制，以纯配置 A/B 重跑占优的
+一半（不重锁）；两半都无信号则阶段 3 收束、回到基线。
+
+## 实现边界
+
+- core（standx-maker）：`skew_center` 非线性扩展、`guard.rs` 纯控制器、
+  `CycleInput` 增 `guard: GuardDecision`；全部纯函数/纯状态机，不读时钟
+  不做 I/O。
+- CLI（standx-cli）：`[nonlinear_skew]`/`[external_guard]` 配置解析与校验
+  （含 cap_bps 带内红线）、HL feed 共享模块、cycle 装配、wait_phase 唤醒
+  分支、遥测输出。
+- 不改变：现有 JSON 字段语义、live 默认锁、fail-closed 语义、退出/熔断
+  政策、订单归属与账本 exactly-once。

--- a/docs/evidence/maker-stage3v1-implementation-2026-07-23.md
+++ b/docs/evidence/maker-stage3v1-implementation-2026-07-23.md
@@ -1,0 +1,97 @@
+# Stage 3 v1 组合候选实现证据 — 2026-07-23
+
+## Decision
+
+- Status: `implemented_pending_gate`
+- 范围：设计文档 [22-maker-stage3v1-guard-design.md](../22-maker-stage3v1-guard-design.md)
+  的完整实现——非线性 price skew（`[nonlinear_skew]`）+ 外部价防御门
+  （`[external_guard]`），一个 release、两个独立开关。
+- 立项与判据修订（release owner 2026-07-22）：两机制合并为一个候选；
+  **uptime 判据 = 时间加权双边 ≥80% 绝对值**（替代 ≤3pp 相对判据）；组合
+  被拒时拆单机制以纯配置 A/B 重跑（不重锁）。
+- 本文档只覆盖离线实现证据与 paper 冒烟。canary 重验、live A/B 与其授权
+  文本按 runbook 另行执行记录。
+
+## 实现摘要
+
+- core（standx-maker，纯函数/纯状态机，无 I/O 无时钟）：
+  - `inventory.rs`: `NonlinearSkewConfig { enabled, boost, cap_bps }` +
+    校验（含带内红线 `spread_bps + cap_bps ≤ band_bps`）。
+  - `lib.rs`: `skew_center_with`（disabled ≡ 原 `skew_center` 路径；enabled:
+    `shift = sign × min(skew_bps × boost × |ratio|, cap_bps)`，无迟滞），
+    三个中心计算点（ref_center / desired / reconcile）统一走它。
+  - `external_guard.rs`（新）: `GuardController` enter/exit 迟滞 +
+    换边即时切换；`None`/过期/非有限样本一律 fail-open 且状态清零。
+  - `CycleInput` 增 `nonlinear_skew` + `guard` 两个 typed 输入。
+- CLI（standx-cli）：
+  - `external_feed.rs`（新）: HL midPx 常驻任务（`activeAssetCtx`，断线
+    自愈，绝不停机）+ **`DivergenceBaseline` 慢 EMA 基差扣除**（见下）+
+    typed input 归一化。
+  - 配置解析/校验、`MakerRunArgs` 穿线、cycle 装配、wait_phase 外部唤醒
+    分支（受 1s min-gap 地板约束；换边条件覆盖）、遥测。
+  - `cycle_summary` 新增可选字段：`guard_enabled/guard_active/guard_side/
+    external_divergence_bps/external_basis_bps/skew_shift_bps`；新增
+    `action="external_guard"` 转换事件（激活/释放/换边各一条）。
+- 冻结配置对 `examples/maker-stage3v1-hype-{baseline,candidate}.toml`：
+  逐行 diff 恰为两条 `enabled = false → true`；候选参数 boost=3.0 /
+  cap=12.0 / enter=6 / exit=3 / max_age_ms=5000 / basis_half_life=300s。
+- 编排器 `run_maker_stage2_ab.sh` 冻结配置白名单新增 case (d)（两开关
+  同时翻转），五种配对形态离线验证（v1 组合/v0/自适应通过；篡改参数/
+  半翻转拒绝）。
+
+## 关键设计修订：基差扣除（paper 冒烟捕获）
+
+第一轮 paper 冒烟（candidate 配置，公共行情，无订单）暴露设计缺陷：
+HL midPx 与 StandX mark 在 HYPE 上存在 **~-14 至 -15.5bps 的持久静态基差**
+（场馆溢价/资金费结构）。原实现以原始水位差触发，guard 启动即永久压制
+Buy 侧——若进 A/B 将精确复刻 v0 的 uptime 死法。
+
+修复：CLI 侧 `DivergenceBaseline` 慢 EMA（半衰期 300s，配置项
+`basis_half_life_secs`），guard 触发于**超额背离** `excess = raw − basis`。
+跳变相对跳变前基线度量（不被自身样本吸收）；首样本初始化基线，启动基差
+永不触发。与 lag 分析的"跳变"口径一致。
+
+## 离线验证（全绿）
+
+- `cargo test --workspace --offline`：cli 198 / maker 179 / sdk 75 +
+  integration 13 + unit 31 + main 2 + e2e/doc（2 credential e2e 照旧
+  ignored）。新增测试 35 个，含：
+  - 状态网格等价：两开关全关（含非默认参数的 disabled 配置与
+    enabled-but-inactive guard）≡ 现行策略逐 action 相等；
+  - nonlinear：boost=1+cap≥skew ≡ 线性逐点相等、陡化/饱和/多空镜像、
+    带内红线校验拒绝；
+  - guard：方向映射、迟滞边界、换边、fail-open（缺失/过期/NaN、状态不
+    跨数据缺口存活）；
+  - 组合场景：高仓位(0.8×max) + 外部下跳 → guard 压 Buy、skew 已下移、
+    band/no-cross/max_position 全不变量保持、释放后恢复双边；
+  - `DivergenceBaseline`：静态基差零穿透、8bps 跳变原样穿透、半衰期
+    吸收速率、peek 无副作用；
+  - 配置：新 section 解析/部分字段回退、冻结对仅差开关行、契约测试
+    （guard 字段 additive、inactive 时键在值 null）。
+- clippy `--workspace --all-targets -D warnings`、`cargo fmt --check`、
+  `py_compile`（dashboard + lag_analysis）、`bash -n` 编排器：全部干净。
+
+## Paper 冒烟 #2（修复后，2026-07-22T16:0xZ，36 cycles）
+
+- 基线初始化：cycle 1 `basis=-15.52, excess=0.0`，guard 不触发 ✓
+- 事件级激活：cycle 5 `excess=-6.83` 越过 enter=6 → 压 Buy；cycle 7
+  `excess=-1.83` 低于 exit=3 → 释放（持续 ~6s，事件级而非闩锁级）✓
+- 真实上行段：cycle 12 起 `excess +10~+22bps` → 压 Sell，基线缓慢上调
+  （-15.6 → -14.3），行情段内持续激活 ✓
+- nonlinear skew：pos 0.2 → `skew_shift_bps=4.8`（= 8×3×0.2，公式精确）✓
+- 遥测：guard 转换事件 3 条（激活/释放/换边向上）、summary 新字段齐全 ✓
+- cycle 序列 0..35 完整（8 个市况 skip 事件均有记录，无缺号）✓
+- SIGTERM 干净退出 ✓
+
+**冒烟观察（A/B 预期管理）**：持续单边行情中 guard 会整段激活（本次
+~16 cycles），激活时间会超出 lag 数据"仅跳变"口径的 ~0.7%/天预算——判据
+中"激活预算 3 倍上限"按此校准；uptime 硬门槛（≥80% 绝对）不受威胁，
+因为激活只压单侧且行情段有限。
+
+## 已知边界
+
+- Guard 无法回放（无外部 feed 录制）；replay 只承担关闭等价验证（既定
+  分工）。经济价值由 live A/B 判定。
+- 基差 EMA 会缓慢吸收持续性真实背离（半衰期 300s）——对秒级跳杀无影响，
+  对分钟级持续错价的防御打折；接受为 v0 简化。
+- 单 symbol（HYPE）参数；换 symbol 需重录 lag 并重估基差。

--- a/examples/maker-stage3v1-hype-baseline.toml
+++ b/examples/maker-stage3v1-hype-baseline.toml
@@ -1,0 +1,81 @@
+# Stage 3 v1 combined-candidate live A/B arm, HYPE-USD. No credentials, webhook URL, or --live flag.
+# Venue metadata (2026-07-17 symbol-info): price_tick_decimals=3
+# qty_tick_decimals=2 min_order_qty=0.1 max_leverage=20.
+# Sizing tier approved by operator: ~$59 max notional at HYPE≈$59 (10x skew
+# room, stop_loss ≈2.7% of ~$184 equity). Vol thresholds intentionally kept
+# identical to the XAG arms so the adaptive-spread comparison stays structural.
+spread_bps = 8.0
+band_bps = 30.0
+size = 0.1
+levels = 1
+level_step_bps = 2.0
+refresh_bps = 4.0
+interval = 3
+
+max_position = 1.0
+skew_bps = 8.0
+inventory_exit_pct = 0.0
+inventory_exit_qty = 0.0
+max_divergence_bps = 15.0
+vol_pause_bps = 40.0
+vol_window_secs = 60
+
+stop_loss = 5.0
+alert_loss = 2.5
+alert_inventory_pct = 70.0
+alert_position_change_pct = 20.0
+alert_uptime = 60.0
+alert_equity_below = 94.0
+alert_margin_below = 30.0
+
+no_ws = false
+order_response_reconnect_attempts = 3
+order_response_reconnect_backoff = 2
+account_stream_reconnect_attempts = 3
+account_stream_reconnect_backoff = 2
+
+[adaptive_spread]
+enabled = false
+min_spread_bps = 8.0
+max_spread_bps = 18.0
+
+[[adaptive_spread.tiers]]
+spread_bps = 8.0
+refresh_bps = 4.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 10.0
+exit_vol_bps = 7.0
+spread_bps = 12.0
+refresh_bps = 5.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 20.0
+exit_vol_bps = 15.0
+spread_bps = 18.0
+refresh_bps = 6.0
+
+# size=0.1 is the venue minimum; factor 0.5 floors to 0.05, below the 0.1
+# minimum, so the active v0 controller degenerates to binary add-side suppression.
+[size_skew]
+enabled = false
+activate_pct = 30.0
+release_pct = 20.0
+add_side_factor = 0.5
+
+# Stage 3 v1 combined candidate (docs/22): nonlinear price skew — steeper but
+# never stops quoting; cap red line spread(8)+cap(12)=20 <= band(30).
+[nonlinear_skew]
+enabled = false
+boost = 3.0
+cap_bps = 12.0
+
+# External-price defensive guard: suppress the endangered side while the
+# leader (Hyperliquid midPx) has moved and StandX mark has not yet followed.
+# Fail-open: missing/stale feed deactivates the guard, quoting continues.
+[external_guard]
+enabled = false
+enter_bps = 6.0
+exit_bps = 3.0
+max_age_ms = 5000
+basis_half_life_secs = 300

--- a/examples/maker-stage3v1-hype-candidate.toml
+++ b/examples/maker-stage3v1-hype-candidate.toml
@@ -1,0 +1,81 @@
+# Stage 3 v1 combined-candidate live A/B arm, HYPE-USD. No credentials, webhook URL, or --live flag.
+# Venue metadata (2026-07-17 symbol-info): price_tick_decimals=3
+# qty_tick_decimals=2 min_order_qty=0.1 max_leverage=20.
+# Sizing tier approved by operator: ~$59 max notional at HYPE≈$59 (10x skew
+# room, stop_loss ≈2.7% of ~$184 equity). Vol thresholds intentionally kept
+# identical to the XAG arms so the adaptive-spread comparison stays structural.
+spread_bps = 8.0
+band_bps = 30.0
+size = 0.1
+levels = 1
+level_step_bps = 2.0
+refresh_bps = 4.0
+interval = 3
+
+max_position = 1.0
+skew_bps = 8.0
+inventory_exit_pct = 0.0
+inventory_exit_qty = 0.0
+max_divergence_bps = 15.0
+vol_pause_bps = 40.0
+vol_window_secs = 60
+
+stop_loss = 5.0
+alert_loss = 2.5
+alert_inventory_pct = 70.0
+alert_position_change_pct = 20.0
+alert_uptime = 60.0
+alert_equity_below = 94.0
+alert_margin_below = 30.0
+
+no_ws = false
+order_response_reconnect_attempts = 3
+order_response_reconnect_backoff = 2
+account_stream_reconnect_attempts = 3
+account_stream_reconnect_backoff = 2
+
+[adaptive_spread]
+enabled = false
+min_spread_bps = 8.0
+max_spread_bps = 18.0
+
+[[adaptive_spread.tiers]]
+spread_bps = 8.0
+refresh_bps = 4.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 10.0
+exit_vol_bps = 7.0
+spread_bps = 12.0
+refresh_bps = 5.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 20.0
+exit_vol_bps = 15.0
+spread_bps = 18.0
+refresh_bps = 6.0
+
+# size=0.1 is the venue minimum; factor 0.5 floors to 0.05, below the 0.1
+# minimum, so the active v0 controller degenerates to binary add-side suppression.
+[size_skew]
+enabled = false
+activate_pct = 30.0
+release_pct = 20.0
+add_side_factor = 0.5
+
+# Stage 3 v1 combined candidate (docs/22): nonlinear price skew — steeper but
+# never stops quoting; cap red line spread(8)+cap(12)=20 <= band(30).
+[nonlinear_skew]
+enabled = true
+boost = 3.0
+cap_bps = 12.0
+
+# External-price defensive guard: suppress the endangered side while the
+# leader (Hyperliquid midPx) has moved and StandX mark has not yet followed.
+# Fail-open: missing/stale feed deactivates the guard, quoting continues.
+[external_guard]
+enabled = true
+enter_bps = 6.0
+exit_bps = 3.0
+max_age_ms = 5000
+basis_half_life_secs = 300

--- a/scripts/run_maker_stage2_ab.sh
+++ b/scripts/run_maker_stage2_ab.sh
@@ -159,10 +159,17 @@ def spread_sections(text):
 
 
 def size_skew_sections(text):
-    """Blank only [size_skew].enabled and return both controller switches."""
+    """Blank the controller enable lines ([size_skew], [nonlinear_skew],
+    [external_guard]) and return every controller switch."""
     lines = text.splitlines(keepends=True)
     section = None
-    enabled = {"adaptive_spread": None, "size_skew": None}
+    enabled = {
+        "adaptive_spread": None,
+        "size_skew": None,
+        "nonlinear_skew": None,
+        "external_guard": None,
+    }
+    NORMALIZED = {"size_skew", "nonlinear_skew", "external_guard"}
     for i, line in enumerate(lines):
         body = line.rstrip("\r\n")
         ending = line[len(body):]
@@ -183,7 +190,7 @@ def size_skew_sections(text):
         if enabled[section] is not None:
             raise SystemExit(f"stage2 config repeats [{section}].enabled")
         enabled[section] = match.group(2) == "true"
-        if section == "size_skew":
+        if section in NORMALIZED:
             lines[i] = f"{match.group(1)}<normalized>{match.group(3)}{ending}"
     return "".join(lines), enabled
 
@@ -207,17 +214,38 @@ elif "enabled = false" in baseline and "enabled = false" in candidate:
     else:
         baseline_size_norm, baseline_enabled = size_skew_sections(baseline)
         candidate_size_norm, candidate_enabled = size_skew_sections(candidate)
-        size_skew_toggle_only = (
-            baseline_size_norm == candidate_size_norm
-            and baseline_enabled["size_skew"] is False
-            and candidate_enabled["size_skew"] is True
-            and baseline_enabled["adaptive_spread"] is False
+        adaptive_off_both = (
+            baseline_enabled["adaptive_spread"] is False
             and candidate_enabled["adaptive_spread"] is False
         )
-        if not size_skew_toggle_only:
+        # (c) stage-3 v0 pair: only [size_skew].enabled flips.
+        size_skew_toggle_only = (
+            baseline_size_norm == candidate_size_norm
+            and adaptive_off_both
+            and baseline_enabled["size_skew"] is False
+            and candidate_enabled["size_skew"] is True
+            and baseline_enabled["nonlinear_skew"] == candidate_enabled["nonlinear_skew"]
+            and baseline_enabled["external_guard"] == candidate_enabled["external_guard"]
+            and candidate_enabled["nonlinear_skew"] is not True
+            and candidate_enabled["external_guard"] is not True
+        )
+        # (d) stage-3 v1 combined pair: [nonlinear_skew].enabled AND
+        #     [external_guard].enabled both flip false -> true together.
+        combined_toggle_only = (
+            baseline_size_norm == candidate_size_norm
+            and adaptive_off_both
+            and baseline_enabled["size_skew"] is False
+            and candidate_enabled["size_skew"] is False
+            and baseline_enabled["nonlinear_skew"] is False
+            and candidate_enabled["nonlinear_skew"] is True
+            and baseline_enabled["external_guard"] is False
+            and candidate_enabled["external_guard"] is True
+        )
+        if not (size_skew_toggle_only or combined_toggle_only):
             raise SystemExit(
                 "stage2 arm configs differ outside adaptive_spread.enabled / "
-                "spread_bps / size_skew.enabled"
+                "spread_bps / size_skew.enabled / "
+                "nonlinear_skew.enabled+external_guard.enabled"
             )
 else:
     raise SystemExit(


### PR DESCRIPTION
## What

Stage 3 v1 combined candidate per the 2026-07-22 release-owner decision: **one release, two independent switches**, one canary re-lock. Design doc: `docs/22-maker-stage3v1-guard-design.md`.

1. **`[nonlinear_skew]`** — steeper-but-never-stopping center shift: `shift = sign(pos) × min(skew_bps × boost × |ratio|, cap_bps)`. Stateless by design (v0's hysteresis latch is the documented failure mode); band red line `spread + cap ≤ band` enforced at startup validation. Disabled ≡ legacy linear skew, byte-for-byte.
2. **`[external_guard]`** — suppress the endangered side while Hyperliquid midPx has moved and StandX mark has not yet followed (measured lag: median 2.6s, 61% coverage, most reliable on large jumps). Fail-open on any feed problem — the external dependency can never stop the maker. Rides the existing cycle early-wake (1s floor kept); no sub-second fast path in v0.

## The bug the smoke test caught (worth reviewer attention)

HL midPx vs StandX mark carries a **persistent ~-14bps static basis** on HYPE (venue premium/funding structure). The first implementation triggered on raw levels → the guard latched permanently on one side — exactly the uptime failure that rejected v0. Fixed: the guard now triggers on the **excess over a slow EMA baseline** (`basis_half_life_secs = 300`); startup basis never fires, second-scale jumps pass through unabsorbed (measured against the pre-jump baseline). Paper smoke #2 verified: basis absorbed, event-scoped activate→release (~6s), side-switch on a real move, `skew_shift_bps` matches the formula exactly, cycle sequence complete, graceful SIGTERM.

## Pre-registered A/B judgment (docs/18 amendment included)

- **Uptime gate revised to ≥80% absolute** (release-owner decision 2026-07-22, replaces ≤3pp relative).
- Two arms (baseline vs both-on); if rejected, telemetry attribution decides which half re-runs as a **config-only** A/B (no re-lock — that's the point of independent switches).
- Frozen config pair `examples/maker-stage3v1-hype-{baseline,candidate}.toml`: line diff is exactly the two `enabled` lines; orchestrator frozen-diff allowance extended with case (d) and verified against 5 pair shapes (v1/v0/adaptive pass; tampered params / half-toggle rejected).

## Verification

- Workspace tests green: cli 198 / maker 179 / sdk 75 (+35 new: all-off state-grid equivalence incl. non-default disabled params, nonlinear curve/mirror/saturation, guard hysteresis/fail-open/side-switch, combined high-inventory+external-jump invariants, baseline basis absorption).
- clippy `-D warnings` clean, fmt clean, py_compile ok, `bash -n` ok.
- Two live paper smokes (public feeds, no orders): #1 caught the basis bug; #2 verified the fix end-to-end. Evidence: `docs/evidence/maker-stage3v1-implementation-2026-07-23.md`.

## Not in this PR

Canary re-verification, live A/B, and their authorization texts — separate ops steps per the runbook. Guard is not replayable (no external feed recording); replay only carries the off-equivalence duty, per the established division of evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)