### PR TITLE
stage3v1 round2: raise guard enter/exit to 10/5 as new base

### DIFF
--- a/crates/standx-cli/src/commands/maker/config.rs
+++ b/crates/standx-cli/src/commands/maker/config.rs
@@ -472,8 +472,10 @@ add_side_factor = 0.5
         let candidate_guard = candidate.external_guard.unwrap().into_domain();
         assert!(!baseline_guard.enabled);
         assert!(candidate_guard.enabled);
-        assert_eq!(candidate_guard.enter_bps, 6.0);
-        assert_eq!(candidate_guard.exit_bps, 3.0);
+        // Round-2 base (release owner 2026-07-23): thresholds raised to shed
+        // the noisy 6-10bps band; see docs/22.
+        assert_eq!(candidate_guard.enter_bps, 10.0);
+        assert_eq!(candidate_guard.exit_bps, 5.0);
         assert_eq!(candidate_guard.max_age_ms, 5000);
 
         // Band red line holds for the frozen candidate: spread + cap <= band.

--- a/docs/18-maker-strategy-roadmap.md
+++ b/docs/18-maker-strategy-roadmap.md
@@ -325,6 +325,13 @@ baseline 维持 HYPE 静态配置。判定报告见
 **uptime 判据修订为绝对值 ≥80%**（替代原 ≤3pp 相对判据，release owner 2026-07-22）。
 设计、红线（SIP-5A 带内 cap、无迟滞、guard fail-open）与预注册判据全文见
 [22-maker-stage3v1-guard-design.md](22-maker-stage3v1-guard-design.md)。
+
+**Round 1 → Round 2（2026-07-23 release owner 决定）**：Round 1（enter=6/exit=3）
+8 臂中期读数——非线性 skew 达标（p95 |pos| 降 50–67%、零 uptime 代价，判定为
+干净赢家）；防御门方向对但剂量超标（激活率 11.5–22.6%，是跳变预算的 5–10 倍，
+uptime 贴 80% 线、撤单率触边）。三症状同源=guard 开门过勤。处置：直接把
+`enter=10 / exit=5` 固定为新 base（不再单独验证阈值，纯配置变更不重锁），下一轮
+A/B 用此配置对；lag 分层证据支持——防御价值集中在 ≥16bps 大跳。skew 参数不动。
 立项依据是三项仲裁分析（610 笔 fill / 81 个库存事件 / 16 笔实测退出成本），记录见
 [maker-stage3-arbitration-2026-07-20.md](evidence/maker-stage3-arbitration-2026-07-20.md)，
 分析脚本 `scripts/maker_tail_arbitration.py`。

--- a/docs/22-maker-stage3v1-guard-design.md
+++ b/docs/22-maker-stage3v1-guard-design.md
@@ -62,8 +62,12 @@ HL midPx 已跳走、StandX mark 未跟上时，**临时压制危险侧**；mark
 - 控制器（core 纯逻辑，`GuardConfig { enabled, enter_bps, exit_bps, max_age_ms }`）：
   `|excess| ≥ enter_bps` 激活，回落 `< exit_bps` 解除（小迟滞防抖动）；激活
   期间反号越过 enter 立即换边。与 v0 闩锁的本质区别：解除条件是 excess 收敛
-  （StandX 追平即闭合，实测中位 2.6s），不依赖成交，无长闩锁风险。冻结候选
-  `enter=6 / exit=3`。
+  （StandX 追平即闭合，实测中位 2.6s），不依赖成交，无长闩锁风险。
+  **冻结候选 `enter=10 / exit=5`（Round 2，2026-07-23 release owner 固定为
+  base）**。Round 1 用 `enter=6 / exit=3` 实测激活率 11.5–22.6%（跳变预算
+  ~2.1% 的 5–10 倍），uptime ≈ 100%−激活率；lag 分层显示防御价值集中在
+  ≥16bps 大跳档（8–16bps 档信噪比差），故上调阈值剔除噪声段、保留尾部杀手
+  覆盖。纯配置变更，不重锁。
 - 压制语义复用现有 `SideSuppressed` 路径：激活时危险侧 desired 为空 →
   reconcile 撤该侧 resting、不摆新单；解除后自然恢复。事件时长秒级，
   按 lag 数据预算激活时间 ~0.7%/天，uptime 影响可忽略。

--- a/examples/maker-stage3v1-hype-baseline.toml
+++ b/examples/maker-stage3v1-hype-baseline.toml
@@ -73,9 +73,14 @@ cap_bps = 12.0
 # External-price defensive guard: suppress the endangered side while the
 # leader (Hyperliquid midPx) has moved and StandX mark has not yet followed.
 # Fail-open: missing/stale feed deactivates the guard, quoting continues.
+# Round 2 (2026-07-23, release owner): enter 6->10 / exit 3->5 fixed as the
+# new base. Round-1 activation ran 11.5-22.6% (5-10x the jump-only budget),
+# uptime tracked ~100%-activation; lag stratification shows the defensive
+# value concentrates in >=16bps jumps, so the raise sheds the noisy 6-10bps
+# band while keeping tail-killer coverage. Pure config change, no re-lock.
 [external_guard]
 enabled = false
-enter_bps = 6.0
-exit_bps = 3.0
+enter_bps = 10.0
+exit_bps = 5.0
 max_age_ms = 5000
 basis_half_life_secs = 300

--- a/examples/maker-stage3v1-hype-candidate.toml
+++ b/examples/maker-stage3v1-hype-candidate.toml
@@ -73,9 +73,14 @@ cap_bps = 12.0
 # External-price defensive guard: suppress the endangered side while the
 # leader (Hyperliquid midPx) has moved and StandX mark has not yet followed.
 # Fail-open: missing/stale feed deactivates the guard, quoting continues.
+# Round 2 (2026-07-23, release owner): enter 6->10 / exit 3->5 fixed as the
+# new base. Round-1 activation ran 11.5-22.6% (5-10x the jump-only budget),
+# uptime tracked ~100%-activation; lag stratification shows the defensive
+# value concentrates in >=16bps jumps, so the raise sheds the noisy 6-10bps
+# band while keeping tail-killer coverage. Pure config change, no re-lock.
 [external_guard]
 enabled = true
-enter_bps = 6.0
-exit_bps = 3.0
+enter_bps = 10.0
+exit_bps = 5.0
 max_age_ms = 5000
 basis_half_life_secs = 300


### PR DESCRIPTION
## What

Round-2 base for the stage-3 v1 combined candidate: external-guard thresholds **enter 6→10bps, exit 3→5bps**, frozen directly (no separate threshold-only A/B — pure config, no gate re-lock). Nonlinear skew params untouched.

## Why (round-1 mid-read, 8 arms / ~32h)

- **Nonlinear skew: clean winner.** p95 |pos| 0.20 across all 4 candidate arms vs 0.40–0.60 baseline (down 50–67%; gate needs ≥15%), ≥70%-position time ~0, exit cost not worse, zero uptime cost.
- **External guard: right direction, wrong dose.** mo30 and per-fill loss improved (~half), but activation ran **11.5–22.6%** — 5–10× the jump-only budget (~2.1%). uptime tracked ≈ 100%−activation (89–90%, one in-progress arm dipped to 79%), and one arm's cancel rate touched the +20% gate edge. All three risk symptoms share one root cause: the guard opens too often.
- **The raise targets the noise.** lag stratification shows defensive value concentrates in **≥16bps jumps** (0 already-ahead, 7/8 follow); the 6–10bps band is low-SNR. enter=10 sheds it while keeping tail-killer coverage — the −56bps tail holes are all large jumps.

## Changes

- `examples/maker-stage3v1-hype-{baseline,candidate}.toml`: enter 10 / exit 5 (line diff stays exactly the two `enabled` lines; harness pair-check passes).
- `docs/18` + `docs/22`: round-1 read recorded, round-2 rationale, thresholds updated.
- config test asserts the new frozen thresholds.

## Verification

fmt clean, clippy `-D warnings` clean, config tests pass (33), harness frozen-pair check passes.

## Not in this PR

Next A/B run uses this pair. If the guard still can't be balanced by config, the fallback is the skew-only single-mechanism A/B (config-only, skew evidence already strong) or the "event-widen instead of suppress" v1.1 (code-level, re-lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)