### PR TITLE
fix(auth): correct expired status output, validate login inputs, show source/trading

### DIFF
--- a/crates/standx-cli/src/commands/auth.rs
+++ b/crates/standx-cli/src/commands/auth.rs
@@ -1,6 +1,6 @@
 use crate::cli::*;
 use anyhow::Result;
-use standx_sdk::auth::Credentials;
+use standx_sdk::auth::{credentials::ENV_JWT_TOKEN, Credentials, StandXSigner};
 
 /// Handle auth commands
 pub async fn handle_auth(command: AuthCommands) -> Result<()> {
@@ -60,12 +60,33 @@ pub async fn handle_auth(command: AuthCommands) -> Result<()> {
                 None
             };
 
+            if let Some(key) = private_key.as_deref() {
+                if StandXSigner::from_base58(key).is_err() {
+                    anyhow::bail!(
+                        "Private key is malformed; re-check the Base58-encoded Ed25519 private key"
+                    );
+                }
+            }
+
             let credentials = Credentials::new(token, private_key.clone());
             let expires_at = credentials.expires_at_string();
+            let jwt_exp_unknown = credentials.jwt_exp().is_none();
+            let token_is_expired = credentials.is_expired();
             credentials.save()?;
 
             println!("✅ Login successful!");
             println!("   Token expires at: {}", expires_at);
+            if jwt_exp_unknown {
+                println!("   ⚠️  Warning: Token does not look like a standard JWT.");
+                println!(
+                    "   Its real expiry is unknown; the expiry shown above is a local 7-day placeholder."
+                );
+            }
+            if token_is_expired {
+                println!(
+                    "   ⚠️  Warning: Token is already expired; this login will not be usable."
+                );
+            }
             if private_key.is_none() {
                 println!("   ⚠️  No private key provided - trading operations will be unavailable");
                 println!("   Run 'standx auth login' again to add a private key");
@@ -78,16 +99,34 @@ pub async fn handle_auth(command: AuthCommands) -> Result<()> {
         AuthCommands::Status => match Credentials::load() {
             Ok(creds) => {
                 let expires_at = creds.expires_at_string();
-                println!("✅ Authenticated");
-                println!("   Token expires at: {}", expires_at);
-                let remaining = creds.remaining_seconds();
-                if remaining < 24 * 60 * 60 {
-                    println!("   ⚠️  Warning: Token expires in less than 24 hours!");
+                let source = if std::env::var(ENV_JWT_TOKEN).is_ok() {
+                    "environment variable (STANDX_JWT)"
                 } else {
-                    println!("   Remaining: {} hours", remaining / 3600);
-                }
+                    "file"
+                };
+                let trading = if creds.private_key.is_empty() {
+                    "unavailable (no private key)"
+                } else {
+                    "enabled"
+                };
+
                 if creds.is_expired() {
-                    println!("   ❌ Token has expired! Please login again.");
+                    println!("❌ Token has expired!");
+                    println!("   Token expired at: {}", expires_at);
+                    println!("   Source: {}", source);
+                    println!("   Trading: {}", trading);
+                    println!("   Run 'standx auth login' to re-authenticate");
+                } else {
+                    println!("✅ Authenticated");
+                    println!("   Token expires at: {}", expires_at);
+                    println!("   Source: {}", source);
+                    println!("   Trading: {}", trading);
+                    let remaining = creds.remaining_seconds();
+                    if remaining < 24 * 60 * 60 {
+                        println!("   ⚠️  Warning: Token expires in less than 24 hours!");
+                    } else {
+                        println!("   Remaining: {} hours", remaining / 3600);
+                    }
                 }
             }
             Err(_) => {


### PR DESCRIPTION
## 背景

调研 `auth login` / `auth status` 实现时发现三处可修复的问题(#2/#3/#4,编号沿用调研笔记)。本 PR 只改 `crates/standx-cli/src/commands/auth.rs`,不触碰凭证的 XOR 存储层。

## 改动

### #2 — `auth status` 对过期 token 输出自相矛盾
过期时 `remaining_seconds()==0` 会落进 `<24h` 分支,于是同时打印 `✅ Authenticated` + `⚠️ 不到24小时过期` + `❌ 已过期` 三条互相打架的信息。
现在先判 `is_expired()`,过期只输出一个干净的过期块(`❌ Token has expired!` + 过期时间 + 重新登录提示),不再打 `✅ Authenticated` 和 `<24h` 警告。

### #3 — `auth login` 不校验输入,错误延迟到交易时才暴露
- **私钥**:显式提供(`--private-key` / `--key-file`)时,在 `save()` **之前**用 `StandXSigner::from_base58` 校验,非法直接报错、不落盘坏凭证。此前非法私钥会被静默存下,直到下单时 `build_auth_headers` 静默跳过签名、请求裸发被服务端 401,难以排查。未提供私钥的只读登录不受影响。
- **token**:非标准 JWT(`jwt_exp()` 为 None)提示真实过期时间未知、显示的是本地 7 天占位值;已过期 token 提示本次登录不可用。两者只警告不阻断。

### #4 — `auth status` 不显示凭证来源与交易能力
认证/过期两个分支都新增:
- `Source: environment variable (STANDX_JWT)` 或 `Source: file`(与 `Credentials::load()` 的 env 优先逻辑一致)
- `Trading: enabled` 或 `Trading: unavailable (no private key)`

## 验证

- `cargo fmt --check`:通过
- `cargo clippy --all-targets -- -D warnings`:通过
- `cargo test -p standx-sdk auth::`:23 passed
- 逐条走查过期/opaque/非法私钥/无私钥各路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)