### PR TITLE
docker: force maker auth to env-only

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -50,7 +50,9 @@ RUN set -eu; \
       || { echo 'ERROR: strategy source is dirty; build from a clean release commit:' >&2; \
            echo "$dirty" >&2; exit 1; }
 
-# Credentials come from a read-only mount at $XDG_DATA_HOME/standx/credentials.enc.
+# Env-only auth: credentials come from STANDX_JWT / STANDX_PRIVATE_KEY in the
+# env_file (see entrypoint.sh), never a credentials.enc file. XDG_DATA_HOME is
+# still set for other state the app may write under this writable layout.
 ENV XDG_DATA_HOME=/opt/standx/state
 # var/lock is where STANDX_MAKER_LOCK_PATH / STANDX_STAGE2_AB_LOCK_PATH should
 # point by default — container-local, not the host's /run/lock (see

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -18,14 +18,18 @@ recorded and the exact authorization text is in the release record.
 1. A **clean checkout at the release commit** (the image build fails if the
    committed strategy source — `crates/*`, `Cargo.*`, `examples/maker.toml` —
    is dirty, because the run manifest would reject every arm).
-2. Live credentials on the host via `standx auth login`
-   (`~/.local/share/standx/credentials.enc`), mounted read-only.
+2. **Env-only auth** — this container never reads `credentials.enc`. Set
+   `STANDX_JWT` and `STANDX_PRIVATE_KEY` directly in
+   `/etc/standx/maker-stage2-ab.env` (step 3 below); the entrypoint fails
+   closed (exit 64) if either is missing. Live trading requires a private key
+   for order signing, so both are mandatory, not just the JWT.
 3. A root-owned `0600` `/etc/standx/maker-stage2-ab.env` — copy
    [`deploy/systemd/maker-stage2-ab.env.example`](../systemd/maker-stage2-ab.env.example),
-   fill secrets and the three `STANDX_BASELINE_*` metadata values. The
-   `/opt/standx` paths it targets are correct as-is, but **override the two
-   lock paths** for docker (the example's `/run/lock/...` defaults are for the
-   systemd deployment, which shares them with the host):
+   fill secrets (including `STANDX_JWT` / `STANDX_PRIVATE_KEY`) and the three
+   `STANDX_BASELINE_*` metadata values. The `/opt/standx` paths it targets are
+   correct as-is, but **override the two lock paths** for docker (the
+   example's `/run/lock/...` defaults are for the systemd deployment, which
+   shares them with the host):
    ```
    STANDX_MAKER_LOCK_PATH=/opt/standx/var/lock/standx-maker-live.lock
    STANDX_STAGE2_AB_LOCK_PATH=/opt/standx/var/lock/standx-maker-stage2-ab.lock
@@ -38,11 +42,9 @@ recorded and the exact authorization text is in the release record.
 4. The frozen `examples/maker-stage2-xag-{baseline,candidate}.toml` (shipped in
    the image).
 
-Point compose at the host credential file and log dir with a sibling `.env`
-(or export the vars):
+Point compose at the log dir with a sibling `.env` (or export the var):
 
 ```
-STANDX_CREDENTIALS_FILE=/home/youruser/.local/share/standx/credentials.enc
 STANDX_LOG_DIR_HOST=/opt/standx/var/standx
 ```
 
@@ -79,6 +81,7 @@ only launches when you pass `--profile ab` explicitly.
 | `KillSignal=SIGTERM` / `TimeoutStopSec=90` | `stop_signal` + `stop_grace_period: 120s` | plus a new orchestrator SIGTERM trap |
 | `EnvironmentFile=/etc/standx/maker-stage2-ab.env` | `env_file` | same file |
 | `OnFailure=standx-notify@…` | `STANDX_SUPERVISOR_WEBHOOK` critical post | orchestrator already webhooks on critical stop |
+| `~/.local/share/standx/credentials.enc` (file auth) | `STANDX_JWT` + `STANDX_PRIVATE_KEY` in `env_file` (env-only auth) | **behavior change** — this container never mounts or reads `credentials.enc`; the systemd deployment is unaffected |
 
 ## Preserved vs. changed safety semantics
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -48,15 +48,14 @@ services:
 
     # Root-owned 0600 file, same contents as the systemd deployment. Provides
     # STANDX_INSTALL_ROOT=/opt/standx, STANDX_BIN, lock paths, OpenObserve and
-    # supervisor webhook config, STANDX_ENABLE_LIVE_MAKER=1, and the three
-    # STANDX_BASELINE_* metadata values.
+    # supervisor webhook config, STANDX_ENABLE_LIVE_MAKER=1, the three
+    # STANDX_BASELINE_* metadata values, and — env-only auth, see entrypoint.sh —
+    # STANDX_JWT / STANDX_PRIVATE_KEY. Refresh the token by editing this file
+    # and recreating the container; there is no credentials.enc file to update.
     env_file:
       - /etc/standx/maker-stage2-ab.env
 
     volumes:
-      # Live credentials, read-only. Written on the host by `standx auth login`;
-      # refresh it there and the next arm's reconnect picks up the new token.
-      - ${STANDX_CREDENTIALS_FILE:-/opt/standx/state/standx/credentials.enc}:/opt/standx/state/standx/credentials.enc:ro
       # Run evidence (NDJSON + manifests) must outlive the container.
       - ${STANDX_LOG_DIR_HOST:-/opt/standx/var/standx}:/opt/standx/var/standx
 
@@ -81,5 +80,4 @@ services:
     env_file:
       - /etc/standx/maker-stage2-hype-ab.env
     volumes:
-      - ${STANDX_CREDENTIALS_FILE:-/opt/standx/state/standx/credentials.enc}:/opt/standx/state/standx/credentials.enc:ro
       - ${STANDX_LOG_DIR_HOST:-/opt/standx/var/standx}:/opt/standx/var/standx

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -9,7 +9,6 @@
 set -euo pipefail
 
 root="${STANDX_INSTALL_ROOT:-/opt/standx}"
-cred_file="${XDG_DATA_HOME:-$root/state}/standx/credentials.enc"
 
 # Validate-only is a pure offline config/preflight check (symbol, config
 # byte-equality, hashes) — no credentials, no OpenObserve, no live orders. Skip
@@ -19,10 +18,13 @@ if [[ "${STANDX_STAGE2_VALIDATE_ONLY:-0}" == "1" ]]; then
   exec "$root/scripts/run_maker_stage2_ab.sh"
 fi
 
-# Credentials arrive either as env (STANDX_JWT) or the read-only mounted file.
-if [[ -z "${STANDX_JWT:-}" && ! -f "$cred_file" ]]; then
-  printf 'entrypoint: no credentials: set STANDX_JWT or mount %s (read-only)\n' \
-    "$cred_file" >&2
+# Env-only auth: this deployment authenticates strictly from the environment,
+# never a credentials.enc file (the file mount was removed). Both vars are
+# required — live trading signs orders, so STANDX_PRIVATE_KEY is not optional
+# here (the maker refuses live with an empty private key). Fail closed so a
+# missing/partial credential surfaces here rather than mid-run.
+if [[ -z "${STANDX_JWT:-}" || -z "${STANDX_PRIVATE_KEY:-}" ]]; then
+  printf 'entrypoint: env-only auth: set STANDX_JWT and STANDX_PRIVATE_KEY (see env_file)\n' >&2
   exit 64
 fi
 

--- a/deploy/systemd/maker-stage2-ab.env.example
+++ b/deploy/systemd/maker-stage2-ab.env.example
@@ -20,6 +20,10 @@ STANDX_BASELINE_PRICE_TICK_DECIMALS=
 STANDX_BASELINE_QTY_TICK_DECIMALS=
 STANDX_BASELINE_MIN_ORDER_QTY=
 STANDX_ENABLE_LIVE_MAKER=1
+# Docker (env-only auth) requires both; leave unset for the systemd deployment,
+# which authenticates via ~/.local/share/standx/credentials.enc instead.
+#STANDX_JWT=
+#STANDX_PRIVATE_KEY=
 OPENOBSERVE_AUTO_UPLOAD=1
 OPENOBSERVE_URL=http://127.0.0.1:5080
 OPENOBSERVE_ORG=default

--- a/deploy/systemd/maker-stage2-hype-ab.env.example
+++ b/deploy/systemd/maker-stage2-hype-ab.env.example
@@ -31,6 +31,10 @@ STANDX_BASELINE_PRICE_TICK_DECIMALS=3
 STANDX_BASELINE_QTY_TICK_DECIMALS=2
 STANDX_BASELINE_MIN_ORDER_QTY=0.1
 STANDX_ENABLE_LIVE_MAKER=1
+# Docker (env-only auth) requires both; leave unset for the systemd deployment,
+# which authenticates via ~/.local/share/standx/credentials.enc instead.
+#STANDX_JWT=
+#STANDX_PRIVATE_KEY=
 OPENOBSERVE_AUTO_UPLOAD=1
 OPENOBSERVE_URL=http://127.0.0.1:5080
 OPENOBSERVE_ORG=default


### PR DESCRIPTION
## Summary
- Remove the `credentials.enc` read-only bind mount from both `stage2-ab` and `stage2-ab-hype` compose services; the container now authenticates strictly via `STANDX_JWT` + `STANDX_PRIVATE_KEY` environment variables.
- `entrypoint.sh` fails closed (exit 64) unless both env vars are set — live maker requires a non-empty private key for order signing, so JWT alone is insufficient.
- No Rust code changes: `Credentials::load()` already tries env vars before falling back to the file, so removing the file mount naturally makes env the only source, eliminating the risk of silently falling back to a stale mounted token.
- Updated `deploy/docker/README.md`, `Dockerfile` comments, and both `deploy/systemd/*.env.example` files (commented-out `STANDX_JWT`/`STANDX_PRIVATE_KEY` placeholders, noted as Docker-only — the systemd deployment is unaffected and still uses `credentials.enc`).

## Test plan
- [x] `bash -n deploy/docker/entrypoint.sh` — syntax OK
- [x] `docker compose -f deploy/docker/docker-compose.yml config` — YAML parses; profile-gated services resolve
- [x] `grep -rn credentials.enc deploy/docker/` — no remaining mount/fallback references, only explanatory comments
- [ ] Manual: start container without `STANDX_JWT`/`STANDX_PRIVATE_KEY` set → expect exit 64 with clear message
- [ ] Manual: start container with both env vars set → expect normal startup (no credentials.enc present)