### PR TITLE
chore: add Claude Code hook reminding to update CHANGELOG on commit

### DIFF
--- a/.claude/hooks/changelog-reminder.sh
+++ b/.claude/hooks/changelog-reminder.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse (Bash) hook — non-blocking CHANGELOG reminder.
+#
+# When Claude runs a `git commit` that stages Rust source (*.rs) but does NOT
+# stage CHANGELOG.md, emit a reminder to update the [Unreleased] section.
+# It never blocks the commit; it only injects a note Claude sees next turn
+# plus a one-line message for the user.
+#
+# Limitation: only inspects the staged index (`git diff --cached`). A commit
+# made with `git commit -a` (auto-stage) won't be seen here.
+set -uo pipefail
+
+input=$(cat)
+
+# Only act on commands that actually commit (handles `git add x && git commit`).
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+case "$cmd" in
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
+staged=$(git diff --cached --name-only 2>/dev/null || true)
+
+if printf '%s\n' "$staged" | grep -qE '\.rs$' \
+   && ! printf '%s\n' "$staged" | grep -qx 'CHANGELOG.md'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: "Staged .rs source changes but CHANGELOG.md is not staged. Add an entry under the [Unreleased] section of CHANGELOG.md, then: git add CHANGELOG.md && git commit --amend --no-edit."
+    },
+    systemMessage: "⚠️  CHANGELOG.md not updated for this commit — consider adding an [Unreleased] entry."
+  }'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/changelog-reminder.sh\"",
+            "timeout": 10,
+            "statusMessage": "Checking CHANGELOG…"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 目的

团队级 Claude Code hook:提醒在提交代码时同步更新 `CHANGELOG.md`。

## 行为

`PreToolUse` / `Bash` hook。当 Claude 执行含 `git commit` 的命令时:
- 若暂存区有 `.rs` 源码改动但**未**暂存 `CHANGELOG.md` → 注入一条提醒(Claude 可见的 `additionalContext` + 用户可见的 `systemMessage`),提示在 `[Unreleased]` 段补条目。
- 命中 CHANGELOG、或非 commit 命令 → 完全静默。
- **不拦截提交**(仅提醒)。

## 文件

- `.claude/settings.json` — 注册 hook
- `.claude/hooks/changelog-reminder.sh` — 逻辑(可执行)

## 作用范围与限制

- 只对**通过 Claude Code 发起**的提交生效;终端手敲的 `git commit` 不触发(Claude Code hook 的固有边界)。
- 只检查暂存区(`git diff --cached`),因此 `git commit -a` 自动暂存的提交看不到。
- 团队成员合并后需在交互式会话打开一次 `/hooks` 或重启,配置监视器才会加载。

## 验证

已 pipe-test 四种场景全绿:非 commit 命令静默 / .rs 无 CHANGELOG 提醒 / 两者都暂存静默 / 空 stdin 不崩;`settings.json` 通过 jq schema 校验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)