### PR TITLE
feat: standx update 自更新命令（校验 sha256、原子替换、拒绝碰 brew）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`standx update`** (alias `self-update`) — replace the running binary with the
   latest GitHub release. `--check` reports installed vs latest and changes
   nothing; `--pre` considers pre-releases; `--force` reinstalls the current
-  version; `--yes` skips the prompt (required when stdin is not a TTY).
-  `-o json` emits `update_check` / `update_applied`
+  version. Confirmation uses the existing global `--yes` /
+  `STANDX_AUTO_CONFIRM=true` (required when stdin is not a TTY) rather than a
+  second copy of that flag. `-o json` emits `update_check` / `update_applied`
   - The release asset for the running platform is downloaded over TLS, its
     SHA-256 verified against the published `checksums.txt`, and the unpacked
     binary asked for its own `--version` to confirm it matches the release before
@@ -20,7 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     binary untouched
   - Checksum verification covers corruption and truncation, **not** provenance:
     the checksum ships from the same place as the archive. A detached signature
-    would be the next step and is not implemented
+    would be the next step and is not implemented. Because of that, the one place
+    the downloaded binary is executed (the `--version` probe) runs with
+    `env_clear()` and a minimal allow-list, so a hostile release cannot read this
+    process's `STANDX_JWT` / `STANDX_PRIVATE_KEY` / `GITHUB_TOKEN` on the way in
   - A Homebrew-managed install is refused with a pointer to `brew upgrade
     standx-cli`, so the formula and the installed binary cannot silently diverge.
     An unwritable install directory is an error with instructions — the command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`standx update`** (alias `self-update`) — replace the running binary with the
+  latest GitHub release. `--check` reports installed vs latest and changes
+  nothing; `--pre` considers pre-releases; `--force` reinstalls the current
+  version; `--yes` skips the prompt (required when stdin is not a TTY).
+  `-o json` emits `update_check` / `update_applied`
+  - The release asset for the running platform is downloaded over TLS, its
+    SHA-256 verified against the published `checksums.txt`, and the unpacked
+    binary asked for its own `--version` to confirm it matches the release before
+    an atomic rename over the running executable. Any failure leaves the existing
+    binary untouched
+  - Checksum verification covers corruption and truncation, **not** provenance:
+    the checksum ships from the same place as the archive. A detached signature
+    would be the next step and is not implemented
+  - A Homebrew-managed install is refused with a pointer to `brew upgrade
+    standx-cli`, so the formula and the installed binary cannot silently diverge.
+    An unwritable install directory is an error with instructions — the command
+    never elevates privileges
+  - Stable checks resolve the latest tag through the `releases/latest` redirect
+    rather than the REST API, so they are not subject to the 60-per-hour
+    unauthenticated API limit. Only `--pre` needs the API, and it names the rate
+    limit explicitly (and honours `GITHUB_TOKEN`) instead of surfacing a bare 403
+
 ## [1.1.0] - 2026-07-28
 
 Maker safety-track tier 2 (stage 5-b), complete net-PnL attribution, and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "sha2",
  "standx-maker",
  "standx-sdk",
  "tabled",

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cargo install standx-cli
 ```bash
 standx update --check     # compare installed vs latest release, change nothing
 standx update             # download, verify sha256, replace this binary
-standx update --yes       # same, no prompt (for scripts)
+standx --yes update       # same, no prompt (for scripts; also STANDX_AUTO_CONFIRM=true)
 ```
 
 `update` refuses to touch a Homebrew-managed binary — use `brew upgrade
@@ -454,6 +454,7 @@ For local structured log collection and SQL analysis, see
 ```bash
 standx update --check              # report installed vs latest; exit
 standx update                      # verify + replace (prompts unless --yes)
+standx --yes update                # no prompt; required when stdin is not a TTY
 standx update --pre                # allow pre-release candidates
 standx update --force              # reinstall the current version
 standx -o json update --check      # machine-readable check

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ brew install standx-cli
 cargo install standx-cli
 ```
 
+#### Keeping it current
+
+```bash
+standx update --check     # compare installed vs latest release, change nothing
+standx update             # download, verify sha256, replace this binary
+standx update --yes       # same, no prompt (for scripts)
+```
+
+`update` refuses to touch a Homebrew-managed binary — use `brew upgrade
+standx-cli` there so the formula and the binary stay in agreement. It never
+elevates privileges: if the install directory is not writable it says so instead
+of reaching for `sudo`.
+
 ### 2. Configure
 
 StandX CLI requires authentication for most operations. You need:
@@ -435,6 +448,27 @@ rails.
 
 For local structured log collection and SQL analysis, see
 **[docs/15-openobserve.md](docs/15-openobserve.md)**.
+
+### Self-update
+
+```bash
+standx update --check              # report installed vs latest; exit
+standx update                      # verify + replace (prompts unless --yes)
+standx update --pre                # allow pre-release candidates
+standx update --force              # reinstall the current version
+standx -o json update --check      # machine-readable check
+```
+
+The release asset for the running platform is downloaded over TLS and its
+SHA-256 verified against the `checksums.txt` published beside it, the archive's
+`standx` binary is asked for its own `--version` to confirm it matches the
+release, and only then is it atomically renamed over the running executable.
+
+Two limits worth knowing: checksum verification protects against a corrupted or
+truncated download, **not** against a compromised release (the checksum ships
+from the same place as the archive — provenance would need a detached
+signature); and a Homebrew-managed install is refused rather than silently
+diverging from its formula.
 
 ---
 

--- a/crates/standx-cli/Cargo.toml
+++ b/crates/standx-cli/Cargo.toml
@@ -31,6 +31,10 @@ tokio-tungstenite.workspace = true
 # HTTP (risk-alert webhook delivery)
 reqwest.workspace = true
 
+# Self-update: verify the published sha256 of a downloaded release asset.
+# Already in the tree via ed25519-dalek, so this adds no new compilation unit.
+sha2 = "0.10"
+
 # Serialization
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -204,14 +204,15 @@ pub enum Commands {
     /// sha256, and atomically replaces the running executable. Refuses to touch
     /// a Homebrew-managed install (use `brew upgrade standx-cli`) and never
     /// elevates privileges.
+    ///
+    /// Confirmation is skipped by the global `--yes` (or
+    /// `STANDX_AUTO_CONFIRM=true` — that global flag accepts only `true`/`false`,
+    /// not `1`). There is deliberately no per-command copy of that flag.
     #[command(visible_alias = "self-update")]
     Update {
         /// Only report current vs latest; change nothing
         #[arg(long)]
         check: bool,
-        /// Skip the confirmation prompt (required when stdin is not a TTY)
-        #[arg(short = 'y', long = "yes")]
-        assume_yes: bool,
         /// Consider pre-release versions as update candidates
         #[arg(long)]
         pre: bool,
@@ -798,6 +799,72 @@ mod tests {
         assert!(!should_load_maker_local_env(&args(&[
             "standx", "maker", "run", "XAG-USD",
         ])));
+    }
+
+    /// `--yes` exists exactly once, globally. A second copy on the subcommand
+    /// makes clap panic in debug builds (`Long option names must be unique`) and
+    /// silently splits the confirmation signal in release builds — the update
+    /// command must read the global one.
+    #[test]
+    fn update_confirmation_comes_only_from_the_global_yes() {
+        for argv in [
+            vec!["standx", "update", "--yes"],
+            vec!["standx", "--yes", "update"],
+        ] {
+            let cli = Cli::try_parse_from(&argv)
+                .unwrap_or_else(|error| panic!("{argv:?} should parse: {error}"));
+            assert!(cli.yes, "{argv:?} should set the global confirmation flag");
+            assert!(matches!(cli.command, Commands::Update { .. }));
+        }
+        // The global flag is long-only, so there is no `-y`. Asserting that
+        // keeps a future `-y` from being added on the subcommand alone, which is
+        // how the duplicate crept in the first time.
+        assert!(Cli::try_parse_from(["standx", "update", "-y"]).is_err());
+
+        let cli = Cli::try_parse_from(["standx", "update"]).expect("bare update should parse");
+        assert!(!cli.yes);
+    }
+
+    /// The command's own flags stay on the subcommand and default to off.
+    #[test]
+    fn update_flags_parse_independently() {
+        let cli = Cli::try_parse_from(["standx", "update"]).expect("bare update should parse");
+        let Commands::Update { check, pre, force } = cli.command else {
+            panic!("expected update command");
+        };
+        assert!(!check && !pre && !force);
+
+        let cli = Cli::try_parse_from(["standx", "update", "--check", "--pre", "--force"])
+            .expect("all update flags should parse");
+        let Commands::Update { check, pre, force } = cli.command else {
+            panic!("expected update command");
+        };
+        assert!(check && pre && force);
+
+        // The documented alias must keep working.
+        let cli = Cli::try_parse_from(["standx", "self-update", "--check"])
+            .expect("self-update alias should parse");
+        assert!(matches!(cli.command, Commands::Update { check: true, .. }));
+    }
+
+    /// Clap's duplicate-option assertion only fires in debug builds, so a
+    /// release-only smoke test cannot catch it — that is exactly how the
+    /// duplicate `--yes` shipped through manual testing. This asserts the update
+    /// subtree specifically.
+    ///
+    /// Scoped rather than whole-tree on purpose: `Cli::command().debug_assert()`
+    /// currently fails on a **pre-existing** collision in `block list`, where
+    /// `-s` is claimed by both `--symbol` and `--status` (so `standx block list
+    /// --help` panics in debug builds today). Fixing that changes a published
+    /// short flag and belongs to its own change.
+    #[test]
+    fn update_subcommand_passes_clap_debug_assertions() {
+        use clap::CommandFactory;
+        Cli::command()
+            .find_subcommand("update")
+            .expect("update subcommand exists")
+            .clone()
+            .debug_assert();
     }
 
     #[test]

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -198,6 +198,27 @@ pub enum Commands {
         #[command(subcommand)]
         command: Box<MakerCommands>,
     },
+    /// Update this binary to the latest GitHub release
+    ///
+    /// Downloads the release asset for this platform, verifies its published
+    /// sha256, and atomically replaces the running executable. Refuses to touch
+    /// a Homebrew-managed install (use `brew upgrade standx-cli`) and never
+    /// elevates privileges.
+    #[command(visible_alias = "self-update")]
+    Update {
+        /// Only report current vs latest; change nothing
+        #[arg(long)]
+        check: bool,
+        /// Skip the confirmation prompt (required when stdin is not a TTY)
+        #[arg(short = 'y', long = "yes")]
+        assume_yes: bool,
+        /// Consider pre-release versions as update candidates
+        #[arg(long)]
+        pre: bool,
+        /// Reinstall even when the latest version is already installed
+        #[arg(long)]
+        force: bool,
+    },
     /// Record StandX vs Hyperliquid mark prices to NDJSON to measure StandX's
     /// price lag (read-only diagnostic; no auth, no orders).
     LagRecorder {

--- a/crates/standx-cli/src/commands/mod.rs
+++ b/crates/standx-cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ mod order;
 mod portfolio;
 mod stream;
 mod trade;
+mod update;
 mod util;
 
 pub use account::handle_account;
@@ -33,4 +34,5 @@ pub use order::handle_order;
 pub use portfolio::{handle_portfolio, PortfolioCommand};
 pub use stream::handle_stream;
 pub use trade::handle_trade;
+pub use update::handle_update;
 pub use util::parse_time_string;

--- a/crates/standx-cli/src/commands/update.rs
+++ b/crates/standx-cli/src/commands/update.rs
@@ -11,6 +11,12 @@
 //! implemented, and this comment exists so nobody mistakes checksum verification
 //! for provenance verification.
 //!
+//! Because provenance is unverified, the one place this code runs the downloaded
+//! binary (a `--version` probe) does so with `env_clear()` and a minimal
+//! allow-list, so a hostile release cannot read this process's `STANDX_JWT`,
+//! `STANDX_PRIVATE_KEY` or `GITHUB_TOKEN` on its way in. That bounds the damage;
+//! it does not remove the need for signing.
+//!
 //! ## What this deliberately refuses to do
 //!
 //! - It never escalates privileges. An unwritable install path is an error with
@@ -570,13 +576,36 @@ fn install_from_archive(
         std::fs::set_permissions(&unpacked, std::fs::Permissions::from_mode(0o755))
             .context("could not mark the new binary executable")?;
     }
-    // Confirm the thing we are about to install is the version we asked for.
-    // The archive already matched its published checksum; this catches a
-    // mislabeled release before it replaces a working binary.
-    let reported = std::process::Command::new(&unpacked)
-        .arg("--version")
+    // Confirm the thing we are about to install is the version we asked for,
+    // and that it runs on this machine at all (right arch, loadable). The
+    // archive already matched its published checksum; this catches a mislabeled
+    // or unrunnable release before it replaces a working binary.
+    //
+    // The probe runs with a **cleared environment**. This process may hold
+    // `STANDX_JWT`, `STANDX_PRIVATE_KEY`, `GITHUB_TOKEN` and similar; a
+    // compromised release could publish a matching checksum, print the expected
+    // version, and read whatever it inherited. Only the few variables a process
+    // needs to start are passed back in, and none of them are secrets.
+    //
+    // This narrows the blast radius; it does not make the archive trustworthy.
+    // The checksum ships from the same place as the archive, so provenance still
+    // rests on a signature that is not implemented yet (see the module header).
+    let mut probe = std::process::Command::new(&unpacked);
+    probe.arg("--version").env_clear();
+    for key in ["PATH", "HOME", "LANG", "TMPDIR"] {
+        if let Some(value) = std::env::var_os(key) {
+            probe.env(key, value);
+        }
+    }
+    let reported = probe
         .output()
         .context("could not run the downloaded binary to confirm its version")?;
+    if !reported.status.success() {
+        anyhow::bail!(
+            "downloaded binary exited with {} when asked for its version; nothing was installed",
+            reported.status
+        );
+    }
     let reported = String::from_utf8_lossy(&reported.stdout);
     let reported = reported
         .split_whitespace()

--- a/crates/standx-cli/src/commands/update.rs
+++ b/crates/standx-cli/src/commands/update.rs
@@ -1,0 +1,739 @@
+//! Self-update: check GitHub releases and replace the running binary.
+//!
+//! ## Trust model (read before extending this)
+//!
+//! The tarball is fetched over TLS from the project's own GitHub release and its
+//! SHA-256 is verified against the `checksums.txt` published beside it. That
+//! protects against a truncated or corrupted download — **it does not protect
+//! against a compromised release**, because the checksum comes from the same
+//! place as the archive. Real supply-chain protection needs a detached signature
+//! (minisign / cosign) verified against a key shipped in the binary; that is not
+//! implemented, and this comment exists so nobody mistakes checksum verification
+//! for provenance verification.
+//!
+//! ## What this deliberately refuses to do
+//!
+//! - It never escalates privileges. An unwritable install path is an error with
+//!   instructions, not a `sudo` invocation.
+//! - It never fights a package manager: a Homebrew-managed binary is left alone
+//!   with a pointer to `brew upgrade`.
+//! - It never acts on a version string it cannot parse. Comparison failure
+//!   aborts rather than guessing which side is newer.
+
+use crate::cli::OutputFormat;
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+use std::io::IsTerminal;
+use std::path::Path;
+
+const REPO: &str = "wjllance/standx-cli";
+const LATEST_RELEASE_API: &str = "https://api.github.com/repos/wjllance/standx-cli/releases";
+const USER_AGENT: &str = concat!("standx-cli/", env!("CARGO_PKG_VERSION"));
+
+/// A parsed `MAJOR.MINOR.PATCH[-PRE]` version.
+///
+/// Hand-rolled rather than pulling in `semver`: the only versions this compares
+/// are this project's own release tags, and the parser is strict — anything it
+/// cannot read becomes an error instead of a silent mis-ordering. Pre-release
+/// ordering follows semver's rule that a pre-release sorts *before* its release.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Version {
+    major: u64,
+    minor: u64,
+    patch: u64,
+    pre: Option<String>,
+}
+
+impl Version {
+    pub(crate) fn parse(raw: &str) -> Result<Self> {
+        let text = raw.trim().trim_start_matches('v');
+        let (core, pre) = match text.split_once('-') {
+            Some((core, pre)) if !pre.is_empty() => (core, Some(pre.to_string())),
+            Some((_, _)) => anyhow::bail!("version '{raw}' has an empty pre-release part"),
+            None => (text, None),
+        };
+        let mut parts = core.split('.');
+        let mut next = |field: &str| -> Result<u64> {
+            parts
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("version '{raw}' is missing its {field} component"))?
+                .parse::<u64>()
+                .with_context(|| format!("version '{raw}' has a non-numeric {field} component"))
+        };
+        let major = next("major")?;
+        let minor = next("minor")?;
+        let patch = next("patch")?;
+        if parts.next().is_some() {
+            anyhow::bail!("version '{raw}' has more than three numeric components");
+        }
+        Ok(Self {
+            major,
+            minor,
+            patch,
+            pre,
+        })
+    }
+
+    pub(crate) fn is_prerelease(&self) -> bool {
+        self.pre.is_some()
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
+        match &self.pre {
+            Some(pre) => write!(f, "-{pre}"),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        (self.major, self.minor, self.patch)
+            .cmp(&(other.major, other.minor, other.patch))
+            .then_with(|| match (&self.pre, &other.pre) {
+                // A release outranks any pre-release of the same core version.
+                (None, None) => Ordering::Equal,
+                (None, Some(_)) => Ordering::Greater,
+                (Some(_), None) => Ordering::Less,
+                // Dotted identifiers, numeric ones compared numerically.
+                (Some(left), Some(right)) => compare_pre(left, right),
+            })
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn compare_pre(left: &str, right: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let mut left = left.split('.');
+    let mut right = right.split('.');
+    loop {
+        match (left.next(), right.next()) {
+            (None, None) => return Ordering::Equal,
+            // Fewer identifiers sorts lower ("rc.1" < "rc.1.2").
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(a), Some(b)) => {
+                let ordering = match (a.parse::<u64>(), b.parse::<u64>()) {
+                    (Ok(a), Ok(b)) => a.cmp(&b),
+                    // Numeric identifiers sort below alphanumeric ones.
+                    (Ok(_), Err(_)) => Ordering::Less,
+                    (Err(_), Ok(_)) => Ordering::Greater,
+                    (Err(_), Err(_)) => a.cmp(b),
+                };
+                if ordering != Ordering::Equal {
+                    return ordering;
+                }
+            }
+        }
+    }
+}
+
+/// The release-asset target triple for the running platform.
+///
+/// Only the three targets the release pipeline actually publishes are mapped;
+/// anything else is an explicit error rather than a 404 later.
+pub(crate) fn current_target() -> Result<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
+        ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu"),
+        ("linux", "aarch64") => Ok("aarch64-unknown-linux-gnu"),
+        (os, arch) => anyhow::bail!(
+            "no published release asset for {os}/{arch}; build from source instead \
+             (published targets: aarch64-apple-darwin, x86_64-unknown-linux-gnu, \
+             aarch64-unknown-linux-gnu)"
+        ),
+    }
+}
+
+/// How the running binary was installed, as far as we can tell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstallKind {
+    /// A plain file we may replace.
+    SelfManaged,
+    /// Inside a Homebrew Cellar: the package manager owns it.
+    Homebrew,
+}
+
+/// Classify an executable path. Homebrew installs live under
+/// `<prefix>/Cellar/<formula>/<version>/bin`, and `<prefix>/bin/standx` is a
+/// symlink into it — so this is checked on the *canonical* path.
+pub(crate) fn classify_install(canonical_exe: &Path) -> InstallKind {
+    let looks_like_cellar = canonical_exe
+        .components()
+        .any(|component| component.as_os_str() == "Cellar");
+    if looks_like_cellar {
+        InstallKind::Homebrew
+    } else {
+        InstallKind::SelfManaged
+    }
+}
+
+/// One release as the update flow needs it.
+#[derive(Debug, Clone)]
+pub(crate) struct Release {
+    pub(crate) version: Version,
+    pub(crate) tag: String,
+    pub(crate) url: String,
+}
+
+/// Pick the newest release we are willing to install.
+///
+/// Pre-releases are skipped unless `allow_prerelease`. Entries whose tag cannot
+/// be parsed are skipped rather than failing the whole check: one malformed tag
+/// in release history must not break `update` forever.
+pub(crate) fn select_release(
+    releases: &[(String, String, bool)],
+    allow_prerelease: bool,
+) -> Option<Release> {
+    releases
+        .iter()
+        .filter_map(|(tag, url, flagged_prerelease)| {
+            let version = Version::parse(tag).ok()?;
+            // Trust either signal: a hyphenated tag or GitHub's own flag.
+            if (*flagged_prerelease || version.is_prerelease()) && !allow_prerelease {
+                return None;
+            }
+            Some(Release {
+                version,
+                tag: tag.clone(),
+                url: url.clone(),
+            })
+        })
+        .max_by(|left, right| left.version.cmp(&right.version))
+}
+
+/// Locate the sha256 for `asset` in a `sha256sum`-style checksums file.
+pub(crate) fn checksum_for(checksums: &str, asset: &str) -> Result<String> {
+    for line in checksums.lines() {
+        let mut parts = line.split_whitespace();
+        let (Some(digest), Some(name)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        // sha256sum writes "<digest>  <name>"; the name may carry a `*` marker.
+        if name.trim_start_matches('*') == asset {
+            if digest.len() != 64 || !digest.chars().all(|c| c.is_ascii_hexdigit()) {
+                anyhow::bail!("checksum entry for {asset} is not a sha256 digest: '{digest}'");
+            }
+            return Ok(digest.to_ascii_lowercase());
+        }
+    }
+    anyhow::bail!("checksums.txt has no entry for {asset}")
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+/// Extract the tag from a `.../releases/tag/<tag>` URL.
+pub(crate) fn tag_from_release_url(url: &str) -> Option<String> {
+    let (_, tag) = url.trim_end_matches('/').rsplit_once("/tag/")?;
+    (!tag.is_empty()).then(|| tag.to_string())
+}
+
+/// Resolve the latest **stable** release without touching the REST API.
+///
+/// `github.com/<repo>/releases/latest` redirects to the tagged release page, and
+/// that redirect is not subject to the API's 60-requests-per-hour unauthenticated
+/// limit. Users behind a shared or NAT'd IP would otherwise meet a bare HTTP 403
+/// on a perfectly healthy install.
+async fn resolve_latest_stable(client: &reqwest::Client) -> Result<Release> {
+    let response = client
+        .get(format!("https://github.com/{REPO}/releases/latest"))
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .send()
+        .await
+        .context("could not reach github.com to resolve the latest release")?;
+    if !response.status().is_success() {
+        anyhow::bail!(
+            "resolving the latest release returned HTTP {}",
+            response.status().as_u16()
+        );
+    }
+    let final_url = response.url().to_string();
+    let tag = tag_from_release_url(&final_url)
+        .ok_or_else(|| anyhow::anyhow!("could not read a release tag out of '{final_url}'"))?;
+    let version = Version::parse(&tag).with_context(|| {
+        format!("latest release tag '{tag}' is not a version this build can compare")
+    })?;
+    Ok(Release {
+        version,
+        tag,
+        url: final_url,
+    })
+}
+
+async fn fetch_releases(client: &reqwest::Client) -> Result<Vec<(String, String, bool)>> {
+    let mut request = client
+        .get(format!("{LATEST_RELEASE_API}?per_page=30"))
+        .header(reqwest::header::USER_AGENT, USER_AGENT);
+    // An ambient token only raises the rate limit; the endpoint is public.
+    if let Some(token) = std::env::var("GITHUB_TOKEN")
+        .or_else(|_| std::env::var("GH_TOKEN"))
+        .ok()
+        .filter(|token| !token.is_empty())
+    {
+        request = request.bearer_auth(token);
+    }
+    let response = request
+        .send()
+        .await
+        .context("could not reach the GitHub releases API")?;
+    let status = response.status();
+    if !status.is_success() {
+        // 403/429 here is almost always the unauthenticated hourly limit, which
+        // is worth naming: "HTTP 403" alone reads like a permissions problem.
+        if matches!(status.as_u16(), 403 | 429) {
+            anyhow::bail!(
+                "GitHub API rate limit reached (HTTP {}). Retry later, set GITHUB_TOKEN to raise                  the limit, or drop --pre so the check uses the rate-limit-free redirect instead.",
+                status.as_u16()
+            );
+        }
+        anyhow::bail!("GitHub releases API returned HTTP {}", status.as_u16());
+    }
+    let payload: serde_json::Value = response
+        .json()
+        .await
+        .context("GitHub releases API returned a body that is not JSON")?;
+    let entries = payload
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("GitHub releases API did not return a list"))?;
+    Ok(entries
+        .iter()
+        .filter_map(|entry| {
+            let tag = entry.get("tag_name")?.as_str()?.to_string();
+            let url = entry
+                .get("html_url")
+                .and_then(|url| url.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let prerelease = entry
+                .get("prerelease")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            Some((tag, url, prerelease))
+        })
+        .collect())
+}
+
+async fn download(client: &reqwest::Client, url: &str, what: &str) -> Result<Vec<u8>> {
+    let response = client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .send()
+        .await
+        .with_context(|| format!("could not download {what}"))?;
+    if !response.status().is_success() {
+        anyhow::bail!(
+            "{what} download returned HTTP {}",
+            response.status().as_u16()
+        );
+    }
+    Ok(response
+        .bytes()
+        .await
+        .with_context(|| format!("could not read the {what} body"))?
+        .to_vec())
+}
+
+fn asset_url(tag: &str, asset: &str) -> String {
+    format!("https://github.com/{REPO}/releases/download/{tag}/{asset}")
+}
+
+/// `standx update`.
+pub async fn handle_update(
+    check_only: bool,
+    assume_yes: bool,
+    allow_prerelease: bool,
+    force: bool,
+    output: OutputFormat,
+) -> Result<()> {
+    let current = Version::parse(env!("CARGO_PKG_VERSION"))
+        .context("this build's own version string is unparseable")?;
+    let target = current_target()?;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .context("could not build an HTTP client")?;
+
+    // Stable checks avoid the REST API entirely (see resolve_latest_stable);
+    // only --pre needs the release list, and only that path can be rate-limited.
+    let latest = if allow_prerelease {
+        let releases = fetch_releases(&client).await?;
+        select_release(&releases, true)
+            .ok_or_else(|| anyhow::anyhow!("no installable release found"))?
+    } else {
+        resolve_latest_stable(&client).await?
+    };
+
+    let newer = latest.version > current;
+    if output == OutputFormat::Json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "action": "update_check",
+                "current": current.to_string(),
+                "latest": latest.version.to_string(),
+                "latest_tag": latest.tag,
+                "update_available": newer,
+                "target": target,
+                "release_url": latest.url,
+            })
+        );
+    } else {
+        println!("current: {current}");
+        println!("latest:  {} ({})", latest.version, latest.tag);
+        if !latest.url.is_empty() {
+            println!("notes:   {}", latest.url);
+        }
+    }
+
+    if check_only {
+        if output != OutputFormat::Json {
+            println!(
+                "{}",
+                if newer {
+                    "→ an update is available; run `standx update` to install it"
+                } else {
+                    "→ already up to date"
+                }
+            );
+        }
+        return Ok(());
+    }
+    if !newer && !force {
+        if output != OutputFormat::Json {
+            println!("→ already up to date (use --force to reinstall {current})");
+        }
+        return Ok(());
+    }
+
+    // --- everything below replaces a file on disk ---
+
+    let exe = std::env::current_exe().context("could not locate the running executable")?;
+    let exe = exe
+        .canonicalize()
+        .unwrap_or_else(|_| exe.clone())
+        .to_path_buf();
+    if classify_install(&exe) == InstallKind::Homebrew {
+        anyhow::bail!(
+            "this binary is Homebrew-managed ({}); update it with `brew upgrade standx-cli` \
+             so the formula and the binary stay in agreement",
+            exe.display()
+        );
+    }
+    let parent = exe
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("executable path {} has no parent", exe.display()))?;
+    // Fail before downloading anything if we could not install it anyway.
+    ensure_writable(parent, &exe)?;
+
+    if !assume_yes && !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "refusing to replace {} without confirmation; pass --yes for non-interactive use",
+            exe.display()
+        );
+    }
+    if !assume_yes {
+        eprint!("Replace {} with {}? [y/N] ", exe.display(), latest.version);
+        use std::io::Write;
+        std::io::stderr().flush().ok();
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .context("could not read confirmation")?;
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            println!("aborted; nothing was changed");
+            return Ok(());
+        }
+    }
+
+    let asset = format!("standx-{}-{}.tar.gz", latest.tag, target);
+    if output != OutputFormat::Json {
+        eprintln!("downloading {asset}…");
+    }
+    let archive = download(&client, &asset_url(&latest.tag, &asset), &asset).await?;
+    let checksums = download(
+        &client,
+        &asset_url(&latest.tag, "checksums.txt"),
+        "checksums.txt",
+    )
+    .await?;
+    let checksums = String::from_utf8(checksums).context("checksums.txt is not UTF-8")?;
+
+    let expected = checksum_for(&checksums, &asset)?;
+    let actual = sha256_hex(&archive);
+    if actual != expected {
+        anyhow::bail!(
+            "checksum mismatch for {asset}: expected {expected}, got {actual}. \
+             Nothing was installed."
+        );
+    }
+
+    // Stage inside the install directory so the final rename is atomic (a
+    // cross-filesystem rename is not).
+    let staging = parent.join(format!(".standx-update-{}", std::process::id()));
+    std::fs::create_dir_all(&staging)
+        .with_context(|| format!("could not create staging dir {}", staging.display()))?;
+    let result = install_from_archive(&archive, &staging, &exe, &latest.version);
+    // Best-effort cleanup either way; a leftover staging dir must not mask the
+    // real error.
+    let _ = std::fs::remove_dir_all(&staging);
+    result?;
+
+    if output == OutputFormat::Json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "action": "update_applied",
+                "from": current.to_string(),
+                "to": latest.version.to_string(),
+                "path": exe.display().to_string(),
+            })
+        );
+    } else {
+        println!(
+            "✅ updated {current} → {} ({})",
+            latest.version,
+            exe.display()
+        );
+    }
+    Ok(())
+}
+
+/// Verify the install directory and the target file are writable by us.
+fn ensure_writable(parent: &Path, exe: &Path) -> Result<()> {
+    let probe = parent.join(format!(".standx-update-probe-{}", std::process::id()));
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+        }
+        Err(error) => {
+            anyhow::bail!(
+                "cannot write to {} ({error}); re-run from a writable install or reinstall with \
+                 install.sh into a directory you own. This command deliberately does not \
+                 elevate privileges.",
+                parent.display()
+            );
+        }
+    }
+    let metadata =
+        std::fs::metadata(exe).with_context(|| format!("could not stat {}", exe.display()))?;
+    if metadata.permissions().readonly() {
+        anyhow::bail!("{} is read-only; refusing to replace it", exe.display());
+    }
+    Ok(())
+}
+
+/// Extract, sanity-check and atomically move the new binary into place.
+fn install_from_archive(
+    archive: &[u8],
+    staging: &Path,
+    exe: &Path,
+    expected: &Version,
+) -> Result<()> {
+    let tarball = staging.join("standx.tar.gz");
+    std::fs::write(&tarball, archive)
+        .with_context(|| format!("could not write {}", tarball.display()))?;
+    // System tar rather than two extra crates; both published targets are Unix.
+    let status = std::process::Command::new("tar")
+        .arg("-xzf")
+        .arg(&tarball)
+        .arg("-C")
+        .arg(staging)
+        .status()
+        .context("could not run `tar` to unpack the release")?;
+    if !status.success() {
+        anyhow::bail!("`tar -xzf` failed with {status}; nothing was installed");
+    }
+    let unpacked = staging.join("standx");
+    if !unpacked.is_file() {
+        anyhow::bail!("release archive did not contain a `standx` binary; nothing was installed");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&unpacked, std::fs::Permissions::from_mode(0o755))
+            .context("could not mark the new binary executable")?;
+    }
+    // Confirm the thing we are about to install is the version we asked for.
+    // The archive already matched its published checksum; this catches a
+    // mislabeled release before it replaces a working binary.
+    let reported = std::process::Command::new(&unpacked)
+        .arg("--version")
+        .output()
+        .context("could not run the downloaded binary to confirm its version")?;
+    let reported = String::from_utf8_lossy(&reported.stdout);
+    let reported = reported
+        .split_whitespace()
+        .last()
+        .unwrap_or_default()
+        .to_string();
+    match Version::parse(&reported) {
+        Ok(found) if &found == expected => {}
+        Ok(found) => anyhow::bail!(
+            "downloaded binary reports {found} but the release is {expected}; \
+             nothing was installed"
+        ),
+        Err(error) => anyhow::bail!(
+            "downloaded binary reported an unusable version ('{reported}': {error}); \
+             nothing was installed"
+        ),
+    }
+    // Replacing a running executable by rename is fine on Unix: the old inode
+    // stays alive for this process, and the new name is visible atomically.
+    std::fs::rename(&unpacked, exe)
+        .with_context(|| format!("could not move the new binary onto {}", exe.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_parses_and_orders_releases_above_prereleases() {
+        assert!(Version::parse("1.1.0").unwrap() > Version::parse("1.0.9").unwrap());
+        assert!(Version::parse("v1.1.0").unwrap() > Version::parse("v1.0.9").unwrap());
+        assert!(Version::parse("1.2.0").unwrap() > Version::parse("1.1.9").unwrap());
+        assert!(Version::parse("2.0.0").unwrap() > Version::parse("1.99.99").unwrap());
+        // A release outranks its own pre-releases; that ordering decides whether
+        // an rc build sees the final as an update.
+        assert!(Version::parse("1.1.0").unwrap() > Version::parse("1.1.0-rc.1").unwrap());
+        assert!(Version::parse("1.1.0-rc.2").unwrap() > Version::parse("1.1.0-rc.1").unwrap());
+        assert!(Version::parse("1.1.0-rc.1.1").unwrap() > Version::parse("1.1.0-rc.1").unwrap());
+        // Numeric identifiers compare numerically, not lexically.
+        assert!(Version::parse("1.1.0-rc.10").unwrap() > Version::parse("1.1.0-rc.9").unwrap());
+        assert_eq!(
+            Version::parse("1.1.0").unwrap(),
+            Version::parse("v1.1.0").unwrap()
+        );
+    }
+
+    /// Unparseable versions must never be guessed at: this comparison gates
+    /// overwriting a binary.
+    #[test]
+    fn version_parsing_is_strict() {
+        for bad in ["", "1.1", "1.1.0.0", "1.1.x", "latest", "v", "1.1.0-"] {
+            assert!(Version::parse(bad).is_err(), "should reject '{bad}'");
+        }
+    }
+
+    #[test]
+    fn select_release_skips_prereleases_and_unparseable_tags() {
+        let releases = vec![
+            ("v1.1.0".to_string(), "u1".to_string(), false),
+            ("v1.2.0-rc.1".to_string(), "u2".to_string(), true),
+            ("nightly".to_string(), "u3".to_string(), false),
+            ("v1.0.0".to_string(), "u4".to_string(), false),
+        ];
+        let stable = select_release(&releases, false).expect("a stable release exists");
+        assert_eq!(stable.tag, "v1.1.0");
+        let with_pre = select_release(&releases, true).expect("a prerelease exists");
+        assert_eq!(with_pre.tag, "v1.2.0-rc.1");
+
+        // A hyphenated tag counts as a pre-release even if GitHub's flag says no.
+        let mislabeled = vec![("v2.0.0-beta".to_string(), "u".to_string(), false)];
+        assert!(select_release(&mislabeled, false).is_none());
+        assert!(select_release(&mislabeled, true).is_some());
+        assert!(select_release(&[], false).is_none());
+    }
+
+    #[test]
+    fn checksum_lookup_matches_the_published_format() {
+        let checksums = "\
+abc  standx-v1.1.0-aarch64-apple-darwin.tar.gz
+0000000000000000000000000000000000000000000000000000000000000000 *standx-v1.1.0-x86_64-unknown-linux-gnu.tar.gz
+1111111111111111111111111111111111111111111111111111111111111111  standx-v1.1.0-aarch64-unknown-linux-gnu.tar.gz
+";
+        assert_eq!(
+            checksum_for(checksums, "standx-v1.1.0-aarch64-unknown-linux-gnu.tar.gz").unwrap(),
+            "1".repeat(64)
+        );
+        // sha256sum's binary-mode `*` prefix must not hide the entry.
+        assert_eq!(
+            checksum_for(checksums, "standx-v1.1.0-x86_64-unknown-linux-gnu.tar.gz").unwrap(),
+            "0".repeat(64)
+        );
+        // A truncated digest is rejected rather than compared loosely.
+        assert!(checksum_for(checksums, "standx-v1.1.0-aarch64-apple-darwin.tar.gz").is_err());
+        assert!(checksum_for(checksums, "standx-v9.9.9-unknown.tar.gz").is_err());
+    }
+
+    #[test]
+    fn sha256_matches_a_known_digest() {
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    /// A Homebrew-managed binary must be left to `brew`, or the formula and the
+    /// installed binary silently disagree.
+    #[test]
+    fn homebrew_installs_are_detected_on_the_canonical_path() {
+        assert_eq!(
+            classify_install(Path::new(
+                "/opt/homebrew/Cellar/standx-cli/1.1.0/bin/standx"
+            )),
+            InstallKind::Homebrew
+        );
+        assert_eq!(
+            classify_install(Path::new("/usr/local/Cellar/standx-cli/1.0.0/bin/standx")),
+            InstallKind::Homebrew
+        );
+        assert_eq!(
+            classify_install(Path::new("/usr/local/bin/standx")),
+            InstallKind::SelfManaged
+        );
+        assert_eq!(
+            classify_install(Path::new("/home/me/.local/bin/standx")),
+            InstallKind::SelfManaged
+        );
+    }
+
+    /// The stable path reads the tag out of the redirect target, so this parse
+    /// is what keeps `update` working when the REST API is rate-limited.
+    #[test]
+    fn tag_is_read_from_the_release_redirect_url() {
+        assert_eq!(
+            tag_from_release_url("https://github.com/wjllance/standx-cli/releases/tag/v1.1.0")
+                .as_deref(),
+            Some("v1.1.0")
+        );
+        assert_eq!(
+            tag_from_release_url("https://github.com/wjllance/standx-cli/releases/tag/v1.1.0/")
+                .as_deref(),
+            Some("v1.1.0")
+        );
+        assert_eq!(
+            tag_from_release_url("https://github.com/o/r/releases/tag/v2.0.0-rc.1").as_deref(),
+            Some("v2.0.0-rc.1")
+        );
+        // No tag segment (e.g. a repo with zero releases) must not be guessed.
+        assert!(tag_from_release_url("https://github.com/o/r/releases").is_none());
+        assert!(tag_from_release_url("https://github.com/o/r/releases/tag/").is_none());
+    }
+
+    #[test]
+    fn asset_url_matches_the_release_layout() {
+        assert_eq!(
+            asset_url("v1.1.0", "standx-v1.1.0-aarch64-apple-darwin.tar.gz"),
+            "https://github.com/wjllance/standx-cli/releases/download/v1.1.0/standx-v1.1.0-aarch64-apple-darwin.tar.gz"
+        );
+    }
+}

--- a/crates/standx-cli/src/main.rs
+++ b/crates/standx-cli/src/main.rs
@@ -166,6 +166,7 @@ fn command_name(command: &Commands) -> &'static str {
         Commands::Block { .. } => "block",
         Commands::Maker { .. } => "maker",
         Commands::LagRecorder { .. } => "lag-recorder",
+        Commands::Update { .. } => "update",
     }
 }
 
@@ -301,6 +302,14 @@ async fn execute_command(
             commands::handle_lag_recorder(symbol, hl_coin, out, flush_secs, status_secs, verbose)
                 .await?;
         }
+        Commands::Update {
+            check,
+            assume_yes,
+            pre,
+            force,
+        } => {
+            commands::handle_update(check, assume_yes, pre, force, output).await?;
+        }
     }
     Ok(())
 }
@@ -326,6 +335,12 @@ async fn handle_dry_run(command: &Commands, output: OutputFormat) -> Result<(), 
         Commands::LagRecorder { .. } => {
             "Would record StandX/Hyperliquid prices to NDJSON (read-only, safe to execute)"
         }
+        Commands::Update { check: true, .. } => {
+            "Would report the installed version against the latest GitHub release (read-only)"
+        }
+        Commands::Update { .. } => {
+            "Would download the latest release, verify its published sha256, and replace this binary"
+        }
     };
 
     let command_label = match command {
@@ -343,6 +358,7 @@ async fn handle_dry_run(command: &Commands, output: OutputFormat) -> Result<(), 
         Commands::Block { .. } => "block",
         Commands::Maker { .. } => "maker",
         Commands::LagRecorder { .. } => "lag-recorder",
+        Commands::Update { .. } => "update",
     };
     let dry_run_info = serde_json::json!({
         "dry_run": true,

--- a/crates/standx-cli/src/main.rs
+++ b/crates/standx-cli/src/main.rs
@@ -123,7 +123,7 @@ async fn async_main(args: Vec<String>) {
     };
 
     // Execute command and handle errors
-    match execute_command(cli.command, output, cli.verbose).await {
+    match execute_command(cli.command, output, cli.verbose, cli.yes).await {
         Ok(_) => {
             telemetry.track_command_complete(command_name, true, None);
         }
@@ -233,6 +233,8 @@ async fn execute_command(
     command: Commands,
     output: OutputFormat,
     verbose: bool,
+    // Global --yes / STANDX_AUTO_CONFIRM: the single confirmation source.
+    assume_yes: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match command {
         Commands::Config { command } => {
@@ -302,12 +304,8 @@ async fn execute_command(
             commands::handle_lag_recorder(symbol, hl_coin, out, flush_secs, status_secs, verbose)
                 .await?;
         }
-        Commands::Update {
-            check,
-            assume_yes,
-            pre,
-            force,
-        } => {
+        Commands::Update { check, pre, force } => {
+            // Confirmation comes from the single global --yes / STANDX_AUTO_CONFIRM.
             commands::handle_update(check, assume_yes, pre, force, output).await?;
         }
     }

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -24,6 +24,7 @@ standx --version
 ```bash
 standx update --check   # 只看版本差异，不改任何东西
 standx update           # 下载、校验 sha256、原子替换当前二进制
+standx --yes update     # 跳过确认（脚本用；等价于 STANDX_AUTO_CONFIRM=true）
 ```
 
 Homebrew 装的用 `brew upgrade standx-cli`——`standx update` 会检测到并拒绝自替换，

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -19,6 +19,17 @@ brew install standx-cli
 standx --version
 ```
 
+### 升级
+
+```bash
+standx update --check   # 只看版本差异，不改任何东西
+standx update           # 下载、校验 sha256、原子替换当前二进制
+```
+
+Homebrew 装的用 `brew upgrade standx-cli`——`standx update` 会检测到并拒绝自替换，
+避免 formula 与实际二进制不一致。安装目录不可写时会直接报错并给出说明，**不会**自动
+提权。
+
 ### 方式二：直接下载二进制
 
 ```bash


### PR DESCRIPTION
## 做什么

`standx update`（别名 `self-update`）把当前二进制替换成 GitHub 最新 release。

```bash
standx update --check          # 只报版本差异，不改任何东西
standx update                  # 下载 → 校验 → 替换（非 --yes 时会确认）
standx update --yes            # 脚本用，跳过确认
standx update --pre            # 允许预发布候选
standx update --force          # 重装当前版本
standx -o json update --check  # 机器可读
```

## 流程：任何一步失败都不动现有二进制

1. 下载本平台的 release 资产（TLS）
2. 用同一 release 的 `checksums.txt` 校验 sha256
3. 解包
4. **让解出来的二进制自报 `--version`，确认与 release 一致**（挡住标错版本的 release）
5. 才原子 `rename` 覆盖当前可执行文件

暂存目录建在**安装目录内**，保证 rename 是同文件系统的原子操作——跨文件系统的 rename 不是原子的。

## 明确拒绝做的三件事

| | |
|---|---|
| **不碰 brew** | canonical 路径含 `Cellar` 即判定 Homebrew 管理，报错并指向 `brew upgrade standx-cli`。否则 formula 与实际二进制会静默不一致 |
| **不提权** | 安装目录不可写就报错并给出说明，不会去调 `sudo` |
| **不猜版本** | 版本号解析失败即中止。这个比较是覆盖二进制的唯一闸门，猜错方向就是降级或空转 |

## ⚠️ 信任模型（已写进模块头注释）

**checksum 与压缩包来自同一处，所以它防的是下载损坏/截断，不是被投毒的 release。**

真正的来源验证需要随二进制内置公钥的分离签名（minisign / cosign）。本次**没做**，模块头注释里写明了这一点——就是为了避免后人把 checksum 当成 provenance。这是这个 PR 最需要 reviewer 判断的取舍：如果认为自更新必须先有签名才能上，那这个 PR 应该拆成"先做签名基础设施"。

## 稳定版检查绕开 REST API

`github.com/<repo>/releases/latest` 的重定向就能拿到最新 tag，不受 GitHub API 未认证 **60 次/小时** 的限制。

这不是过度设计——我在本机实测时就撞到了：健康的安装、正确的代码，却因为出口 IP 的 API 配额耗尽而报一个裸 `HTTP 403`。共享/NAT 出口的用户会经常遇到。

只有 `--pre` 需要 API，且该路径会明确说"这是限流"并支持 `GITHUB_TOKEN` 提额，而不是把 403 原样抛出来。

## 版本比较手写而非引入 semver

只比本项目自己的 tag，解析严格（不可解析即报错）。实现了 semver 的两条关键规则并有测试覆盖：预发布排在同核心版本的正式版**之前**（所以 rc 用户会看到正式版是更新）、预发布内的数字标识按**数值**比较（`rc.10 > rc.9`，字符串比较会搞反）。

如果 reviewer 更倾向引 `semver` crate，改动很小——我选手写是考虑到仓库先前刻意精简过依赖树。

## 依赖

`sha2` 提为直接依赖。它**已经**通过 `ed25519-dalek` 在依赖图里，所以不新增编译单元。

## 验证

```bash
cargo test --workspace --offline && cargo clippy --workspace --all-targets --offline -- -D warnings && cargo fmt --all -- --check
```

全绿，cli 218→226。新增 10 项单测：版本解析/排序、解析严格性、release 选择（跳过预发布与不可解析 tag；连字符 tag 即使 GitHub 标记为正式也算预发布）、checksums 查找（含 `sha256sum` 的 `*` 二进制标记、拒绝短摘要）、sha256 已知值、brew 路径判定、资产 URL、重定向 tag 解析。

**手工实测**：
- `update --check` 正常输出（human + JSON）
- 非 TTY 无 `--yes` 被拒
- **对真实 v1.1.0 release 跑通了完整替换路径**——下载→校验→解包→版本确认→替换，替换后二进制 hash 变化（`4cfe37f…` → `b018031…`）且 `--version` 正确

## 已知空白

- **checksum 不匹配的中止分支没有测试**：需要一个能返回坏数据的假服务器；目前靠 `checksum_for` 的解析测试 + 一个直白的字符串比较。
- 不支持的平台只有单测覆盖（无法在本机模拟另一个 `env::consts::OS`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
