### PR TITLE
修 block list 的 -s 冲突（--status 改长选项）+ clap 结构检查扩到全命令树

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     unauthenticated API limit. Only `--pre` needs the API, and it names the rate
     limit explicitly (and honours `GITHUB_TOKEN`) instead of surfacing a bare 403
 
+### Fixed
+- `block list`: removed the `-s` short flag from `--status` (it collided with `--symbol`, and clap panics on the collision in debug builds — `standx block list --help` aborted for anyone not on a release build). `-s` keeps its meaning of `--symbol`, matching `block watch` and every other command; use the long `--status` for the status filter
+- The clap structural check now covers the whole command tree (`Cli::command().debug_assert()`) instead of only the `update` subtree, so a duplicate short flag anywhere fails in CI rather than at a user's `--help`
+
 ## [1.1.0] - 2026-07-28
 
 Maker safety-track tier 2 (stage 5-b), complete net-PnL attribution, and the

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -480,7 +480,9 @@ pub enum BlockCommands {
         #[arg(short, long, default_value = "30")]
         limit: u32,
         /// Filter by status: completed, pending, all
-        #[arg(short, long, default_value = "all")]
+        // Deliberately long-only: `-s` belongs to `--symbol` here and in every
+        // other command, and clap panics in debug builds on the collision.
+        #[arg(long, default_value = "all")]
         status: String,
     },
     /// Watch block trades (polling mode)
@@ -727,6 +729,34 @@ mod tests {
     use super::*;
     use clap::CommandFactory;
 
+    /// Clap's structural checks (duplicate short/long options, bad defaults,
+    /// conflicting ids) only run under `debug_assertions`, so a release binary
+    /// happily ships a collision that panics for anyone on a debug build — that
+    /// is how both the duplicate `--yes` on `update` and the `-s` collision on
+    /// `block list` reached users through manual testing.
+    ///
+    /// Deliberately whole-tree rather than scoped to one subcommand: a scoped
+    /// assert only guards the subtree someone remembered to name, and the
+    /// collision it misses still panics at a user's `--help`.
+    #[test]
+    fn command_tree_passes_clap_debug_assertions() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn block_list_short_s_is_symbol_only() {
+        let cli = Cli::try_parse_from(["standx", "block", "list", "-s", "BTC-USD"])
+            .expect("-s should remain the symbol filter");
+        let Commands::Block { command } = cli.command else {
+            panic!("expected block command");
+        };
+        let BlockCommands::List { symbol, status, .. } = command else {
+            panic!("expected block list command");
+        };
+        assert_eq!(symbol.as_deref(), Some("BTC-USD"));
+        assert_eq!(status, "all");
+    }
+
     #[test]
     fn maker_live_and_canary_read_supervisor_webhook_environment() {
         let command = Cli::command();
@@ -845,26 +875,6 @@ mod tests {
         let cli = Cli::try_parse_from(["standx", "self-update", "--check"])
             .expect("self-update alias should parse");
         assert!(matches!(cli.command, Commands::Update { check: true, .. }));
-    }
-
-    /// Clap's duplicate-option assertion only fires in debug builds, so a
-    /// release-only smoke test cannot catch it — that is exactly how the
-    /// duplicate `--yes` shipped through manual testing. This asserts the update
-    /// subtree specifically.
-    ///
-    /// Scoped rather than whole-tree on purpose: `Cli::command().debug_assert()`
-    /// currently fails on a **pre-existing** collision in `block list`, where
-    /// `-s` is claimed by both `--symbol` and `--status` (so `standx block list
-    /// --help` panics in debug builds today). Fixing that changes a published
-    /// short flag and belongs to its own change.
-    #[test]
-    fn update_subcommand_passes_clap_debug_assertions() {
-        use clap::CommandFactory;
-        Cli::command()
-            .find_subcommand("update")
-            .expect("update subcommand exists")
-            .clone()
-            .debug_assert();
     }
 
     #[test]


### PR DESCRIPTION
## 问题

`BlockCommands::List` 里 `-s` 被 `--symbol` 和 `--status` 同时占用。clap 的重复短选项断言只在 `debug_assertions` 下生效，于是：

```
cargo build && ./target/debug/standx block list --help
# thread 'main' panicked at clap_builder/src/builder/debug_asserts.rs:112:17:
# Command list: Short option names must be unique for each argument, but '-s' is in use by both 'symbol' and 'status'
```

release 构建把断言编掉了，所以对用户来说 `standx block list --help` 一直"能用"，但任何跑 debug 构建的人（包括本地开发）都会 panic。

这是 main 上的既有问题，**不是** self-update (#335) 引入的。

## 改动

**1. `-s` 保留给 `--symbol`，`--status` 改为仅长选项** — `crates/standx-cli/src/cli.rs`

选这个方向的理由不只是"和其它命令一致"：release 构建下 clap 把重复短选项解析到第一个匹配项，也就是说 `-s` 现在本来就是 `--symbol`，`--status` 的短形式从来没有真正生效过。所以这次改动不会破坏任何**能工作**的用法——它只是把已经存在的行为写进声明里。

处理方式与 1.0.0 里删掉 `order create` 的 `-q`（和全局 `--quiet` 冲突）完全一致。

**2. clap 结构检查从 update 子树扩到全命令树**

#335 加的 `update_subcommand_passes_clap_debug_assertions` 当初刻意只断言 `update` 子树，注释里写明了原因就是全树断言会撞上 `block list` 这个既有冲突。`-s` 修好后该测试已被取代，改为 `command_tree_passes_clap_debug_assertions` 调用 `Cli::command().debug_assert()`，原测试的历史理由（重复 `--yes` 就是这样漏过手工测试的）保留在新测试的文档注释里。

全树断言通过，顺带证明了 `-s` 是整棵树里唯一的冲突。

**3. 新增 `block_list_short_s_is_symbol_only`**

只断言"不 panic"是不够的：将来有人完全可以反过来把 `-s` 从 `--symbol` 上拿走来"修"冲突，全树断言照样通过。这个测试钉住解析归属。

## Reviewer 需要知道的

- **这是用户可见的 CLI 变更**，已记在 CHANGELOG 的 `[Unreleased] / Fixed` 下。按上面的分析实际影响为零，但短选项的增删仍然值得在评审里被看见一眼。
- 本分支已 rebase 到含 #335 的 `origin/main`（原先落后 2 个 commit）。CHANGELOG 的 `[Unreleased]` 冲突已解决：保留 #335 的 `### Added`，追加本次的 `### Fixed`。
- 文档无需改动：`README.md:355` 是仓库里唯一的调用点，本来就用长选项 `--symbol` / `--status`；shell 补全里也没有把 `-s` 当 status 的地方。
- 维护者说明写成普通 `//` 注释而非 `///`：clap 会把 doc comment 的后续行提升成 `--help` 的 long help，用 `///` 会把这段说明泄漏到用户可见输出里。

## 验证

- `cargo test --workspace` — 全绿（230 + 其余目标，0 失败）
- `cargo clippy --workspace --all-targets -- -D warnings` — 干净
- `cargo fmt --all -- --check` — 干净
- `./target/debug/standx block list --help` — 正常渲染，`--status` 显示为无短形式

🤖 Generated with [Claude Code](https://claude.com/claude-code)