### PR TITLE
ci: HOMEBREW_TAP_TOKEN 缺失即明确失败，并断言 formula 真的被改写

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,11 +208,24 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && !contains(github.event.release.tag_name, '-')
     steps:
+      # Fail loudly on a missing secret. The previous
+      # `HOMEBREW_TAP_TOKEN || GITHUB_TOKEN` fallback silently degraded to a
+      # token that cannot reach another repository, so "secret not configured"
+      # surfaced as `Bad credentials` — which reads like a permissions problem
+      # and cost real debugging time on both the v1.1.0 and v1.2.0 releases.
+      # `secrets` is not available in a job-level `if`, so this is a step.
+      - name: Require the tap token
+        run: |
+          if [ -z "${{ secrets.HOMEBREW_TAP_TOKEN }}" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN is not configured, so the Homebrew tap cannot be updated. Add a token with contents:write on wjllance/homebrew-standx-cli (Settings > Secrets and variables > Actions), then re-run this job. The release itself is already published; only the formula is stale."
+            exit 1
+          fi
+
       - name: Checkout homebrew tap
         uses: actions/checkout@v4
         with:
           repository: wjllance/homebrew-standx-cli
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
       - name: Download source tarball
@@ -227,6 +240,17 @@ jobs:
           cd homebrew-tap
           sed -i "s|url \"https://github.com/wjllance/standx-cli/archive/refs/tags/v.*.tar.gz\"|url \"https://github.com/wjllance/standx-cli/archive/refs/tags/${{ env.VERSION }}.tar.gz\"|" Formula/standx-cli.rb
           sed -i "s|sha256 \"[^\"]*\"|sha256 \"${{ env.SHA256 }}\"|" Formula/standx-cli.rb
+          # A sed whose pattern stops matching (formula reformatted, url moved)
+          # would leave the formula untouched and still exit 0. Assert the two
+          # values we came here to write are actually present.
+          grep -q "archive/refs/tags/${{ env.VERSION }}.tar.gz" Formula/standx-cli.rb || {
+            echo "::error::formula url was not rewritten to ${{ env.VERSION }}; check the sed patterns against the current Formula/standx-cli.rb"
+            exit 1
+          }
+          grep -q "sha256 \"${{ env.SHA256 }}\"" Formula/standx-cli.rb || {
+            echo "::error::formula sha256 was not rewritten; check the sed patterns against the current Formula/standx-cli.rb"
+            exit 1
+          }
 
       - name: Commit and push to tap
         run: |

--- a/docs/12-version-checklist.md
+++ b/docs/12-version-checklist.md
@@ -71,11 +71,37 @@ https://github.com/wjllance/standx-cli/releases/download/vx.y.z/standx-vx.y.z-aa
 
 ### 4. 发布阶段
 
-- [ ] 合并 PR 到 main 分支
-- [ ] 创建 GitHub Release
-- [ ] 上传二进制文件
-- [ ] 更新 Pre-release 状态 (如适用)
+- [ ] 合并 PR 到 main 分支，等 main 的 CI 变绿
+- [ ] **发布 GitHub Release**（不是只推 tag，见下面的触发矩阵）：
+
+  ```bash
+  gh release create vX.Y.Z --target <全长 SHA> --title vX.Y.Z \
+    --notes-file RELEASE_NOTES_vX.Y.Z.md
+  ```
+
+  `--target` 只接受**全长 SHA 或分支名**，短 SHA 会报
+  `Release.target_commitish is invalid`。
+
+- [ ] 确认 workflow 里 **`release` 与 `update-homebrew` 两个 job 都绿**
+- [ ] 复核 tap 里的 formula 真的指向新版本（job 绿不等于 sed 写对了）：
+
+  ```bash
+  curl -s https://raw.githubusercontent.com/wjllance/homebrew-standx-cli/main/Formula/standx-cli.rb | grep -E 'url|sha256'
+  curl -sL https://github.com/wjllance/standx-cli/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+  ```
+
 - [ ] 通知用户
+
+#### 触发矩阵（2026-07-28 补，v1.1.0/v1.2.0 两次发版踩到）
+
+| 动作 | 跑哪些 job | 结果 |
+|---|---|---|
+| 推 `vX.Y.Z-rc.N`（**带**连字符） | `auto-prerelease` | 自动建 prerelease + 上传产物，不动 homebrew |
+| 推 `vX.Y.Z`（**不带**连字符） | 仅 `check` + `build-matrix` | **什么都不发布**——`auto-prerelease` 的条件是 `contains(github.ref, '-')` |
+| 发布 GitHub Release（无连字符 tag） | `release` → `update-homebrew` | 上传产物 + 更新 formula |
+
+`RELEASE_NOTES_<tag>.md` 的取用规则也不对称：`auto-prerelease` 会自动读它当正文，
+而 `release` job **不读**——正式版必须自己用 `--notes-file` 传。
 
 ## ⚠️ 常见错误
 


### PR DESCRIPTION
Closes #338 的建议部分（token 本身已由 owner 配好，v1.2.0 的 tap 已更新）。

## 1. 去掉有害的 fallback

```yaml
token: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
```

secret 缺失时这个 fallback 会**静默退化**成一个够不到另一个仓库的 token，于是"secret 没配"表现为：

```
Retrieving the default branch name
Bad credentials - https://docs.github.com/rest
```

看起来像权限问题。**v1.1.0 和 v1.2.0 两次发版都因此浪费了排查时间**——两次都得去翻 job 日志才发现真正的原因是 secret 缺失。

改为 token 只取 `HOMEBREW_TAP_TOKEN`，并在 checkout 之前加一步显式检查，缺失就报：

```
::error::HOMEBREW_TAP_TOKEN is not configured, so the Homebrew tap cannot be
updated. Add a token with contents:write on wjllance/homebrew-standx-cli
(Settings > Secrets and variables > Actions), then re-run this job. The release
itself is already published; only the formula is stale.
```

最后那句是刻意写的：这个 job 失败时**release 已经发出去了**，只有 formula 旧，别让人以为整次发版废了。

（`secrets` 在 job 级 `if` 里不可用，所以只能做成 step 而不是 job 条件。）

## 2. 顺带：断言 formula 真的被改写

两条 `sed -i` 如果模式不再匹配（formula 被重排、url 位置变化），会**原样留下文件并且 exit 0**——job 变绿而 formula 是旧的。

今天手工复核 v1.2.0 时，我是靠人眼把 formula 里的 `sha256` 和源码 tarball 的实际摘要对了一遍才确认没坏。这不该依赖人。

改后用 `grep` 断言 url 与 sha256 两个值确实写进去了，否则报错退出。

## 3. docs/12 补触发矩阵

发布阶段此前只写「创建 GitHub Release / 上传二进制文件」，漏了几条实际踩到的规则：

| 动作 | 跑哪些 job | 结果 |
|---|---|---|
| 推 `vX.Y.Z-rc.N`（**带**连字符） | `auto-prerelease` | 自动建 prerelease + 上传产物 |
| 推 `vX.Y.Z`（**不带**连字符） | 仅 check + build | **什么都不发布** |
| 发布 GitHub Release | `release` → `update-homebrew` | 上传产物 + 更新 formula |

以及：`--target` 不接受短 SHA；`RELEASE_NOTES_<tag>.md` 的取用不对称（`auto-prerelease` 自动读，`release` job 不读，正式版要自己 `--notes-file` 传）；收尾要复核 tap 的 formula 真的指向新版本，因为 **job 绿 ≠ sed 写对**。

关联 #340。

## 验证

YAML 解析通过，`update-homebrew` 的 5 个 step 顺序符合预期，checkout 的 token 表达式已无 fallback。`cargo test --workspace` / `fmt --check` 不受影响（纯 CI + 文档改动）。

**没法在合并前端到端验证**：这个 job 只在 `release` 事件上跑，要等下一次发版才会真正执行。两条新增断言都是"失败才报错"的路径，正常路径与现状一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
