### PR TITLE
fix(install): 修复一行安装脚本在 GitHub API 限流下必然失败

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ You have an AI Agent (Claude, Cursor, OpenClaw, AutoGPT, …). You want it to tr
 curl -sSL https://raw.githubusercontent.com/wjllance/standx-cli/main/install.sh | sh
 ```
 
+Optional environment variables:
+
+- `STANDX_VERSION` — install a specific tag instead of the latest release (e.g. `STANDX_VERSION=v1.2.0`).
+- `INSTALL_DIR` — install somewhere other than `/usr/local/bin`.
+
 #### Option 2: Homebrew (macOS)
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 # StandX CLI One-line Installer
-# Supports macOS (Intel/Apple Silicon) and Linux (x86_64/ARM64)
+# Supports macOS (Apple Silicon) and Linux (x86_64/ARM64)
 
 set -e
 
 REPO="wjllance/standx-cli"
 BINARY_NAME="standx"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 # Colors
 RED='\033[0;31m'
@@ -14,10 +14,23 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+say() {
+    printf '%b\n' "$*"
+}
+
+warn() {
+    printf '%b\n' "${YELLOW}$*${NC}" >&2
+}
+
+die() {
+    printf '%b\n' "${RED}Error: $*${NC}" >&2
+    exit 1
+}
+
 # Detect target platform
 get_target() {
-    local os=$(uname -s)
-    local arch=$(uname -m)
+    os=$(uname -s)
+    arch=$(uname -m)
 
     case "$os" in
         Darwin)
@@ -26,8 +39,7 @@ get_target() {
                     echo "aarch64-apple-darwin"
                     ;;
                 *)
-                    echo "${RED}Error: Unsupported macOS architecture: $arch${NC}" >&2
-                    exit 1
+                    die "Unsupported macOS architecture: $arch"
                     ;;
             esac
             ;;
@@ -40,76 +52,106 @@ get_target() {
                     echo "x86_64-unknown-linux-gnu"
                     ;;
                 *)
-                    echo "${RED}Error: Unsupported Linux architecture: $arch${NC}" >&2
-                    exit 1
+                    die "Unsupported Linux architecture: $arch"
                     ;;
             esac
             ;;
         *)
-            echo "${RED}Error: Unsupported operating system: $os${NC}" >&2
-            exit 1
+            die "Unsupported operating system: $os"
             ;;
     esac
 }
 
-# Get latest version tag
+# Get latest version tag.
+# Prefers the github.com redirect (not subject to API rate limits) and falls
+# back to the REST API. Prints nothing and returns 1 when both fail.
 get_latest_tag() {
-    local api_url="https://api.github.com/repos/${REPO}/releases/latest"
-    local tag=$(curl -sSL "$api_url" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    tag=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+        "https://github.com/${REPO}/releases/latest" 2>/dev/null \
+        | sed -n 's#.*/releases/tag/##p')
 
     if [ -z "$tag" ]; then
-        echo "${RED}Error: Unable to get latest version information${NC}" >&2
-        exit 1
+        tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
+            | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
     fi
 
+    [ -n "$tag" ] || return 1
     echo "$tag"
+}
+
+# Compute the SHA256 of a file. Returns 2 when no hashing tool is available.
+sha256_of() {
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        return 2
+    fi
 }
 
 # Main installation logic
 main() {
-    echo "${GREEN}=== StandX CLI Installer ===${NC}"
+    say "${GREEN}=== StandX CLI Installer ===${NC}"
     echo ""
 
-    # Detect platform
-    local target=$(get_target)
-    echo "Detected platform: ${YELLOW}$target${NC}"
+    command -v curl >/dev/null 2>&1 || die "curl is required but was not found"
+    command -v tar >/dev/null 2>&1 || die "tar is required but was not found"
 
-    # Get latest version
-    echo "Fetching latest version information..."
-    local tag=$(get_latest_tag)
-    echo "Latest version: ${YELLOW}$tag${NC}"
+    # Detect platform
+    target=$(get_target)
+    say "Detected platform: ${YELLOW}$target${NC}"
+
+    # Resolve version (STANDX_VERSION overrides discovery, e.g. STANDX_VERSION=v1.2.0)
+    if [ -n "${STANDX_VERSION:-}" ]; then
+        tag="$STANDX_VERSION"
+        say "Requested version: ${YELLOW}$tag${NC}"
+    else
+        echo "Fetching latest version information..."
+        tag=$(get_latest_tag) || die "Unable to determine the latest version.
+GitHub may be rate-limiting or blocking this network. Retry later, or pin a
+version explicitly:
+  curl -sSL https://raw.githubusercontent.com/${REPO}/main/install.sh | STANDX_VERSION=v1.2.0 sh"
+        say "Latest version: ${YELLOW}$tag${NC}"
+    fi
 
     # Construct download URL
-    local tarball_name="${BINARY_NAME}-${tag}-${target}.tar.gz"
-    local download_url="https://github.com/${REPO}/releases/download/${tag}/${tarball_name}"
-    local checksums_url="https://github.com/${REPO}/releases/download/${tag}/checksums.txt"
+    tarball_name="${BINARY_NAME}-${tag}-${target}.tar.gz"
+    download_url="https://github.com/${REPO}/releases/download/${tag}/${tarball_name}"
+    checksums_url="https://github.com/${REPO}/releases/download/${tag}/checksums.txt"
 
     # Create temp directory
-    local tmp_dir=$(mktemp -d)
-    trap "rm -rf $tmp_dir" EXIT
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "$tmp_dir"' EXIT
 
     # Download tarball
     echo ""
     echo "Downloading ${tarball_name}..."
-    if ! curl -sSL -o "${tmp_dir}/${tarball_name}" "$download_url"; then
-        echo "${RED}Error: Download failed${NC}" >&2
-        exit 1
+    if ! curl -fsSL -o "${tmp_dir}/${tarball_name}" "$download_url"; then
+        die "Download failed: $download_url
+No release asset for this platform and version. Check
+https://github.com/${REPO}/releases/tag/${tag} for available downloads."
     fi
 
     # Download checksums.txt
     echo "Downloading checksums.txt..."
-    if ! curl -sSL -o "${tmp_dir}/checksums.txt" "$checksums_url"; then
-        echo "${YELLOW}Warning: Unable to download checksums.txt, skipping verification${NC}"
+    if ! curl -fsSL -o "${tmp_dir}/checksums.txt" "$checksums_url"; then
+        warn "Warning: Unable to download checksums.txt, skipping verification"
     else
-        # Verify SHA256
         echo "Verifying file integrity..."
-        cd "$tmp_dir"
-        if ! sha256sum -c checksums.txt --ignore-missing 2>/dev/null | grep -q "${tarball_name}: OK"; then
-            echo "${RED}Error: SHA256 verification failed, file may be corrupted or tampered${NC}" >&2
-            exit 1
+        expected=$(awk -v f="$tarball_name" \
+            '$2 == f || $2 == "*" f {print $1; exit}' "${tmp_dir}/checksums.txt")
+        if [ -z "$expected" ]; then
+            warn "Warning: ${tarball_name} is not listed in checksums.txt, skipping verification"
+        elif ! actual=$(sha256_of "${tmp_dir}/${tarball_name}"); then
+            warn "Warning: no sha256 tool (shasum/sha256sum) found, skipping verification"
+        elif [ "$actual" != "$expected" ]; then
+            die "SHA256 verification failed, file may be corrupted or tampered
+  expected: $expected
+  actual:   $actual"
+        else
+            say "${GREEN}✓ Verification passed${NC}"
         fi
-        echo "${GREEN}✓ Verification passed${NC}"
-        cd - >/dev/null
     fi
 
     # Extract
@@ -118,19 +160,15 @@ main() {
     tar -xzf "${tmp_dir}/${tarball_name}" -C "$tmp_dir"
 
     # Check extracted binary
-    local binary_path="${tmp_dir}/${BINARY_NAME}"
+    binary_path="${tmp_dir}/${BINARY_NAME}"
     if [ ! -f "$binary_path" ]; then
-        echo "${RED}Error: Binary file ${BINARY_NAME} not found after extraction${NC}" >&2
-        exit 1
+        die "Binary file ${BINARY_NAME} not found after extraction"
     fi
 
     # Check install directory permissions
     if [ ! -d "$INSTALL_DIR" ]; then
-        echo "${YELLOW}Install directory $INSTALL_DIR does not not exist, attempting to create...${NC}"
-        if ! sudo mkdir -p "$INSTALL_DIR"; then
-            echo "${RED}Error: Unable to create install directory${NC}" >&2
-            exit 1
-        fi
+        warn "Install directory $INSTALL_DIR does not exist, attempting to create..."
+        sudo mkdir -p "$INSTALL_DIR" || die "Unable to create install directory"
     fi
 
     # Install
@@ -140,8 +178,9 @@ main() {
         mv "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
         chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
     else
-        echo "${YELLOW}Administrator privileges required to install to $INSTALL_DIR${NC}"
-        sudo mv "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
+        warn "Administrator privileges required to install to $INSTALL_DIR"
+        sudo mv "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}" \
+            || die "Unable to install to ${INSTALL_DIR} (sudo failed)"
         sudo chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
     fi
 
@@ -149,17 +188,17 @@ main() {
     echo ""
     echo "Verifying installation..."
     if command -v "$BINARY_NAME" >/dev/null 2>&1; then
-        local version=$($BINARY_NAME --version 2>/dev/null || echo "unknown")
-        echo "${GREEN}✓ Installation successful!${NC}"
+        version=$($BINARY_NAME --version 2>/dev/null || echo "unknown")
+        say "${GREEN}✓ Installation successful!${NC}"
         echo ""
-        echo "Version: ${YELLOW}$version${NC}"
+        say "Version: ${YELLOW}$version${NC}"
         echo ""
         echo "Get started with:"
-        echo "  ${YELLOW}standx --help${NC}          Show help"
-        echo "  ${YELLOW}standx --version${NC}       Show version"
-        echo "  ${YELLOW}standx auth login${NC}      Authenticate"
+        say "  ${YELLOW}standx --help${NC}          Show help"
+        say "  ${YELLOW}standx --version${NC}       Show version"
+        say "  ${YELLOW}standx auth login${NC}      Authenticate"
     else
-        echo "${YELLOW}Warning: Installation complete, but $BINARY_NAME is not in PATH${NC}"
+        warn "Warning: Installation complete, but $BINARY_NAME is not in PATH"
         echo "Please ensure $INSTALL_DIR is in your PATH environment variable"
     fi
 }


### PR DESCRIPTION
## 问题

`curl -sSL .../install.sh | sh` 在被 GitHub 匿名 REST API 限流（或该网络访问 api.github.com 受阻）的环境下必然失败，而且报出的错误完全误导用户：

```
Downloading standx--aarch64-apple-darwin.tar.gz...
Error: SHA256 verification failed, file may be corrupted or tampered
```

看起来像资产被篡改，实际是**根本没拿到版本号**。链路如下：

1. `get_latest_tag()` 走 `api.github.com`，返回 `403 {"message":"API rate limit exceeded..."}`
2. `curl -sSL` 未带 `-f`，403 不视为失败，`grep '"tag_name":'` 空手而归
3. `exit 1` 写在 `$(get_latest_tag)` 的命令替换子 shell 里，只杀掉子 shell；且 `local tag=$(...)` 掩盖了退出码，`set -e` 不触发 → 主流程带着空 `tag` 继续跑
4. 拼出 `standx--aarch64-apple-darwin.tar.gz`，下载到 GitHub 的 404 HTML 页面
5. 校验环节 `sha256sum -c ... | grep -q OK` 失败，报"文件可能被篡改"

Release 资产本身是健康的（v1.2.0 的 tarball 与 checksums.txt 均 HTTP 200），纯粹是脚本问题。

## 改动

`install.sh`：

- **版本探测改走 `github.com/<repo>/releases/latest` 的 302 重定向**取 tag —— 这条路径不受 API 限流约束；REST API 降级为兜底。
- **致命错误真的致命**：引入 `die()`，函数返回值在调用处判断，不再带着空变量往下走。
- **所有 `curl` 加 `-f`**，HTTP 错误立即暴露，而不是把错误页当成文件保存下来。
- **校验逻辑重写**：原来的 `sha256sum -c | grep OK` 在未安装 `sha256sum` 的 macOS 上会**误报"文件被篡改"**。现改为从 checksums.txt 取期望值、用 `shasum -a 256` / `sha256sum` 任一计算实际值再比对，并把「无哈希工具」「文件未列入清单」「哈希不匹配」区分为三种输出 —— **只有真正不匹配才 fail**，篡改检测能力未削弱。
- 新增 `STANDX_VERSION` / `INSTALL_DIR` 两个环境变量（README 已同步），限流时可直接指定版本绕过。
- 修掉 `does not not exist` 笔误。

## 验证

在被限流的网络环境下实测四条路径：

| 场景 | 结果 |
| --- | --- |
| 正常安装（API 仍处于 403 限流） | ✅ 成功装出 `standx 1.2.0`，校验通过，退出 0 |
| `STANDX_VERSION=v9.9.9`（版本不存在） | ✅ 明确报 404 + 给出 releases 页面链接，退出 1 |
| tag 探测彻底失败 | ✅ 明确提示可能被限流 + 给出 `STANDX_VERSION` 绕过命令，退出 1 |
| 故意损坏 tarball | ✅ 报出 expected/actual 哈希不匹配，退出 1 |

`sh -n install.sh` 通过。未安装 shellcheck，故未跑静态检查。

## Reviewer 注意

- 仅改 shell 脚本与 README，无 Rust 代码变更。
- 重定向探测与 API 一致地**排除 prerelease**，取最新正式 release，行为无变化。
- `INSTALL_DIR` 变为可覆盖（默认仍是 `/usr/local/bin`），这也是本次能在不写系统目录的前提下端到端实测的原因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)