### PR TITLE
feat: add WebSocket transport to order CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ standx order create BTC-USD buy market --qty 0.1
 # Limit order
 standx order create BTC-USD buy limit --qty 0.1 --price 64000
 
+# Authenticated WebSocket order with correlated response
+standx --output json --verbose order create BTC-USD buy limit \
+  --qty 0.1 --price 64000 --transport ws
+
 # With stop loss and take profit
 standx order create BTC-USD buy limit --qty 0.1 --price 64000 \
   --sl-price 62000 --tp-price 68000
@@ -265,6 +269,13 @@ standx order create BTC-USD buy limit --qty 0.1 --price 64000 \
 standx order cancel BTC-USD --order-id ord_xxx
 standx order cancel-all BTC-USD
 ```
+
+`order create` and single-order `order cancel` accept
+`--transport <http|ws>` (default `http`) and `--timeout-secs` (default `10`,
+range `1..=30`). WebSocket mode returns the correlated
+`request_id`/`response_code`/`response_message`; `--verbose` writes the raw
+post-authentication inbound response to stderr. A timeout is an unknown
+submission state and never triggers an automatic REST retry.
 
 ### Dashboard
 

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -385,6 +385,12 @@ pub enum OrderCommands {
         sl_price: Option<String>,
         #[arg(long)]
         tp_price: Option<String>,
+        /// Order command transport
+        #[arg(long, value_enum, default_value = "http")]
+        transport: OrderTransport,
+        /// Bound the matching WebSocket response wait (1..=30 seconds)
+        #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..=30))]
+        timeout_secs: u64,
     },
     /// Cancel an order by ID
     #[command(visible_alias = "cxl")]
@@ -392,10 +398,23 @@ pub enum OrderCommands {
         symbol: String,
         #[arg(short = 'i', long)]
         order_id: String,
+        /// Order command transport
+        #[arg(long, value_enum, default_value = "http")]
+        transport: OrderTransport,
+        /// Bound the matching WebSocket response wait (1..=30 seconds)
+        #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..=30))]
+        timeout_secs: u64,
     },
     /// Cancel all orders for a symbol
     #[command(visible_alias = "cxa")]
     CancelAll { symbol: String },
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum OrderTransport {
+    #[default]
+    Http,
+    Ws,
 }
 
 #[derive(Subcommand, Debug)]
@@ -768,6 +787,108 @@ mod tests {
         };
         assert_eq!(symbol.as_deref(), Some("BTC-USD"));
         assert_eq!(status, "all");
+    }
+
+    #[test]
+    fn order_create_defaults_to_http_and_accepts_explicit_ws_transport() {
+        let default = Cli::try_parse_from([
+            "standx", "order", "create", "BTC-USD", "buy", "limit", "--qty", "0.01", "--price",
+            "60000",
+        ])
+        .expect("default order create should parse");
+        let Commands::Order {
+            command:
+                OrderCommands::Create {
+                    transport,
+                    timeout_secs,
+                    ..
+                },
+        } = default.command
+        else {
+            panic!("expected order create command");
+        };
+        assert_eq!(transport, OrderTransport::Http);
+        assert_eq!(timeout_secs, 10);
+
+        let ws = Cli::try_parse_from([
+            "standx",
+            "order",
+            "create",
+            "BTC-USD",
+            "buy",
+            "limit",
+            "--qty",
+            "0.01",
+            "--price",
+            "60000",
+            "--transport",
+            "ws",
+            "--timeout-secs",
+            "7",
+        ])
+        .expect("WebSocket order create should parse");
+        let Commands::Order {
+            command:
+                OrderCommands::Create {
+                    transport,
+                    timeout_secs,
+                    ..
+                },
+        } = ws.command
+        else {
+            panic!("expected order create command");
+        };
+        assert_eq!(transport, OrderTransport::Ws);
+        assert_eq!(timeout_secs, 7);
+    }
+
+    #[test]
+    fn order_cancel_supports_ws_but_cancel_all_does_not() {
+        let ws = Cli::try_parse_from([
+            "standx",
+            "order",
+            "cancel",
+            "BTC-USD",
+            "--order-id",
+            "42",
+            "--transport",
+            "ws",
+        ])
+        .expect("WebSocket order cancel should parse");
+        let Commands::Order {
+            command:
+                OrderCommands::Cancel {
+                    transport,
+                    timeout_secs,
+                    ..
+                },
+        } = ws.command
+        else {
+            panic!("expected order cancel command");
+        };
+        assert_eq!(transport, OrderTransport::Ws);
+        assert_eq!(timeout_secs, 10);
+
+        assert!(Cli::try_parse_from([
+            "standx",
+            "order",
+            "cancel-all",
+            "BTC-USD",
+            "--transport",
+            "ws",
+        ])
+        .is_err());
+        assert!(Cli::try_parse_from([
+            "standx",
+            "order",
+            "cancel",
+            "BTC-USD",
+            "--order-id",
+            "42",
+            "--timeout-secs",
+            "31",
+        ])
+        .is_err());
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/order.rs
+++ b/crates/standx-cli/src/commands/order.rs
@@ -1,13 +1,58 @@
 use crate::cli::*;
+use crate::output;
 use anyhow::Result;
+use serde::Serialize;
 use standx_sdk::client::order::CreateOrderParams;
 use standx_sdk::client::StandXClient;
 use standx_sdk::models::{OrderSide, OrderType, TimeInForce};
+use standx_sdk::order_response::{OrderResponse, OrderResponseStream};
+use std::time::Duration;
+use tokio::sync::mpsc;
 
-/// Handle order commands
-pub async fn handle_order(command: OrderCommands) -> Result<()> {
-    let client = StandXClient::new()?;
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct WsOrderResult {
+    transport: &'static str,
+    operation: &'static str,
+    symbol: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    order_id: Option<String>,
+    request_id: String,
+    response_code: i64,
+    response_message: String,
+    accepted: bool,
+}
 
+impl WsOrderResult {
+    fn new(
+        operation: &'static str,
+        symbol: String,
+        order_id: Option<String>,
+        request_id: String,
+        response: OrderResponse,
+    ) -> Self {
+        let accepted = response.accepted();
+        Self {
+            transport: "ws",
+            operation,
+            symbol,
+            order_id,
+            request_id,
+            response_code: response.code,
+            response_message: response.message,
+            accepted,
+        }
+    }
+}
+
+/// Handle order commands.
+///
+/// `verbose` is passed only to the order-response stream, which writes raw
+/// post-authentication inbound frames to stderr.
+pub async fn handle_order(
+    command: OrderCommands,
+    output_format: OutputFormat,
+    verbose: bool,
+) -> Result<()> {
     match command {
         OrderCommands::Create {
             symbol,
@@ -19,22 +64,21 @@ pub async fn handle_order(command: OrderCommands) -> Result<()> {
             reduce_only,
             sl_price,
             tp_price,
+            transport,
+            timeout_secs,
         } => {
-            // Parse side
             let side = match side.to_lowercase().as_str() {
                 "buy" => OrderSide::Buy,
                 "sell" => OrderSide::Sell,
                 _ => return Err(anyhow::anyhow!("Invalid side: {}", side)),
             };
 
-            // Parse order type
             let order_type = match order_type.to_lowercase().as_str() {
                 "limit" => OrderType::Limit,
                 "market" => OrderType::Market,
                 _ => return Err(anyhow::anyhow!("Invalid order type: {}", order_type)),
             };
 
-            // Parse time in force
             let time_in_force = tif.map(|t| match t.to_uppercase().as_str() {
                 "GTC" => TimeInForce::Gtc,
                 "IOC" => TimeInForce::Ioc,
@@ -44,7 +88,7 @@ pub async fn handle_order(command: OrderCommands) -> Result<()> {
             });
 
             let params = CreateOrderParams {
-                symbol,
+                symbol: symbol.clone(),
                 cl_ord_id: None,
                 side,
                 order_type,
@@ -57,25 +101,356 @@ pub async fn handle_order(command: OrderCommands) -> Result<()> {
                 tp_price,
             };
 
-            let order = client.create_order(params).await?;
-            println!("✅ Order created successfully!");
-            println!("   Order ID: {}", order.id);
-            println!("   Symbol: {}", order.symbol);
-            println!("   Side: {:?}", order.side);
-            println!("   Type: {:?}", order.order_type);
-            println!("   Quantity: {}", order.qty);
-            if !order.price.is_empty() && order.price != "0" {
-                println!("   Price: {}", order.price);
+            match transport {
+                OrderTransport::Http => create_order_http(params).await,
+                OrderTransport::Ws => {
+                    let (request_id, response) =
+                        create_order_ws(&params, Duration::from_secs(timeout_secs), verbose)
+                            .await?;
+                    finish_ws_result(
+                        WsOrderResult::new("create", symbol, None, request_id, response),
+                        output_format,
+                    )
+                }
             }
         }
-        OrderCommands::Cancel { symbol, order_id } => {
-            client.cancel_order(&symbol, &order_id).await?;
-            println!("✅ Order {} cancelled successfully", order_id);
-        }
+        OrderCommands::Cancel {
+            symbol,
+            order_id,
+            transport,
+            timeout_secs,
+        } => match transport {
+            OrderTransport::Http => cancel_order_http(&symbol, &order_id).await,
+            OrderTransport::Ws => {
+                let (request_id, response) =
+                    cancel_order_ws(&order_id, Duration::from_secs(timeout_secs), verbose).await?;
+                finish_ws_result(
+                    WsOrderResult::new("cancel", symbol, Some(order_id), request_id, response),
+                    output_format,
+                )
+            }
+        },
         OrderCommands::CancelAll { symbol } => {
+            let client = StandXClient::new()?;
             client.cancel_all_orders(&symbol).await?;
             println!("✅ All orders for {} cancelled successfully", symbol);
+            Ok(())
         }
     }
+}
+
+async fn create_order_http(params: CreateOrderParams) -> Result<()> {
+    let client = StandXClient::new()?;
+    let order = client.create_order(params).await?;
+    println!("✅ Order created successfully!");
+    println!("   Order ID: {}", order.id);
+    println!("   Symbol: {}", order.symbol);
+    println!("   Side: {:?}", order.side);
+    println!("   Type: {:?}", order.order_type);
+    println!("   Quantity: {}", order.qty);
+    if !order.price.is_empty() && order.price != "0" {
+        println!("   Price: {}", order.price);
+    }
     Ok(())
+}
+
+async fn cancel_order_http(symbol: &str, order_id: &str) -> Result<()> {
+    let client = StandXClient::new()?;
+    client.cancel_order(symbol, order_id).await?;
+    println!("✅ Order {} cancelled successfully", order_id);
+    Ok(())
+}
+
+async fn create_order_ws(
+    params: &CreateOrderParams,
+    timeout: Duration,
+    verbose: bool,
+) -> Result<(String, OrderResponse)> {
+    run_ws_command(WsCommand::Create(params), timeout, verbose).await
+}
+
+async fn cancel_order_ws(
+    order_id: &str,
+    timeout: Duration,
+    verbose: bool,
+) -> Result<(String, OrderResponse)> {
+    run_ws_command(WsCommand::Cancel(order_id), timeout, verbose).await
+}
+
+enum WsCommand<'a> {
+    Create(&'a CreateOrderParams),
+    Cancel(&'a str),
+}
+
+async fn run_ws_command(
+    command: WsCommand<'_>,
+    timeout: Duration,
+    verbose: bool,
+) -> Result<(String, OrderResponse)> {
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let stream = OrderResponseStream::new(session_id)?.with_verbose(verbose);
+    let (commands, mut responses, _health, handle) = stream.connect().await?;
+
+    // Always stop the short-lived connection task, including send/response
+    // failures. A written command is never retried or downgraded to REST:
+    // after that point the venue state may have changed even if no response
+    // reaches this process.
+    let result = async {
+        let prepared = match command {
+            WsCommand::Create(params) => commands.prepare_create_order(params)?,
+            WsCommand::Cancel(order_id) => commands.prepare_cancel_order(order_id)?,
+        };
+        let request_id = prepared.request_id().to_string();
+        commands.send_prepared(prepared).await.map_err(|error| {
+            anyhow::anyhow!(
+                "failed to send WebSocket order command for request_id={request_id}: {error}; \
+                 submission state is unknown, verify account orders before retrying"
+            )
+        })?;
+        let response = await_ws_response(&mut responses, &request_id, timeout).await?;
+        Ok((request_id, response))
+    }
+    .await;
+    handle.abort();
+    result
+}
+
+async fn await_ws_response(
+    responses: &mut mpsc::Receiver<OrderResponse>,
+    request_id: &str,
+    timeout: Duration,
+) -> Result<OrderResponse> {
+    let response = tokio::time::timeout(timeout, responses.recv())
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "timed out waiting for WebSocket order response for request_id={request_id}; \
+                 submission state is unknown, verify account orders before retrying"
+            )
+        })?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "WebSocket order-response stream closed for request_id={request_id}; \
+                 submission state is unknown, verify account orders before retrying"
+            )
+        })?;
+
+    if response.request_id.as_deref() != Some(request_id) {
+        return Err(anyhow::anyhow!(
+            "received uncorrelated WebSocket order response: expected request_id={request_id}, \
+             got request_id={}; submission state is unknown, verify account orders before retrying",
+            response.request_id.as_deref().unwrap_or("<missing>")
+        ));
+    }
+    Ok(response)
+}
+
+fn finish_ws_result(result: WsOrderResult, output_format: OutputFormat) -> Result<()> {
+    emit_ws_result(&result, output_format)?;
+    if result.accepted {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "WebSocket order:{} rejected for request_id={}: code={} message={}",
+            result.operation,
+            result.request_id,
+            result.response_code,
+            result.response_message
+        ))
+    }
+}
+
+fn emit_ws_result(result: &WsOrderResult, output_format: OutputFormat) -> Result<()> {
+    let Some(rendered) = render_ws_result(result, output_format)? else {
+        return Ok(());
+    };
+    if rendered.ends_with('\n') {
+        print!("{rendered}");
+    } else {
+        println!("{rendered}");
+    }
+    Ok(())
+}
+
+fn render_ws_result(result: &WsOrderResult, output_format: OutputFormat) -> Result<Option<String>> {
+    let rendered = match output_format {
+        OutputFormat::Table => {
+            let status = if result.accepted {
+                "✅ WebSocket order command accepted"
+            } else {
+                "❌ WebSocket order command rejected"
+            };
+            let mut rendered = format!(
+                "{status}\n   Transport: {}\n   Operation: {}\n   Symbol: {}\n",
+                result.transport, result.operation, result.symbol
+            );
+            if let Some(order_id) = result.order_id.as_deref() {
+                rendered.push_str(&format!("   Order ID: {order_id}\n"));
+            }
+            rendered.push_str(&format!(
+                "   Request ID: {}\n   Response code: {}\n   Response message: {}\n   Accepted: {}",
+                result.request_id, result.response_code, result.response_message, result.accepted
+            ));
+            Some(rendered)
+        }
+        OutputFormat::Json => Some(output::format_json(result)?),
+        OutputFormat::Csv => Some(output::format_csv(std::slice::from_ref(result))?),
+        OutputFormat::Quiet => None,
+    };
+    Ok(rendered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn response(request_id: Option<&str>, code: i64, message: &str) -> OrderResponse {
+        OrderResponse {
+            code,
+            message: message.to_string(),
+            request_id: request_id.map(str::to_string),
+        }
+    }
+
+    #[tokio::test]
+    async fn awaits_only_the_correlated_response() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.send(response(Some("req-1"), 0, "accepted"))
+            .await
+            .unwrap();
+
+        let received = await_ws_response(&mut rx, "req-1", Duration::from_millis(50))
+            .await
+            .unwrap();
+        assert!(received.accepted());
+    }
+
+    #[tokio::test]
+    async fn reports_unknown_state_on_timeout_or_closed_stream() {
+        let (_tx, mut rx) = mpsc::channel(1);
+        let timeout = await_ws_response(&mut rx, "req-timeout", Duration::from_millis(1))
+            .await
+            .unwrap_err();
+        assert!(timeout.to_string().contains("request_id=req-timeout"));
+        assert!(timeout.to_string().contains("submission state is unknown"));
+
+        let (tx, mut rx) = mpsc::channel(1);
+        drop(tx);
+        let closed = await_ws_response(&mut rx, "req-closed", Duration::from_millis(50))
+            .await
+            .unwrap_err();
+        assert!(closed.to_string().contains("request_id=req-closed"));
+        assert!(closed.to_string().contains("submission state is unknown"));
+    }
+
+    #[tokio::test]
+    async fn rejects_uncorrelated_response_with_both_request_ids() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.send(response(Some("other"), 0, "accepted"))
+            .await
+            .unwrap();
+
+        let error = await_ws_response(&mut rx, "expected", Duration::from_millis(50))
+            .await
+            .unwrap_err();
+        let error = error.to_string();
+        assert!(error.contains("expected request_id=expected"));
+        assert!(error.contains("got request_id=other"));
+        assert!(error.contains("submission state is unknown"));
+    }
+
+    #[test]
+    fn ws_result_has_stable_machine_fields_for_acceptance_and_rejection() {
+        let accepted = WsOrderResult::new(
+            "create",
+            "BTC-USD".to_string(),
+            None,
+            "req-1".to_string(),
+            response(Some("req-1"), 0, "accepted"),
+        );
+        assert_eq!(
+            serde_json::to_value(&accepted).unwrap(),
+            json!({
+                "transport": "ws",
+                "operation": "create",
+                "symbol": "BTC-USD",
+                "request_id": "req-1",
+                "response_code": 0,
+                "response_message": "accepted",
+                "accepted": true,
+            })
+        );
+
+        let rejected = WsOrderResult::new(
+            "cancel",
+            "BTC-USD".to_string(),
+            Some("42".to_string()),
+            "req-2".to_string(),
+            response(Some("req-2"), 400, "order already closed"),
+        );
+        assert!(!rejected.accepted);
+        assert_eq!(rejected.order_id.as_deref(), Some("42"));
+    }
+
+    #[test]
+    fn ws_result_renders_table_json_csv_and_quiet_without_cross_format_noise() {
+        let result = WsOrderResult::new(
+            "cancel",
+            "BTC-USD".to_string(),
+            Some("42".to_string()),
+            "req-1".to_string(),
+            response(Some("req-1"), 0, "accepted"),
+        );
+
+        let table = render_ws_result(&result, OutputFormat::Table)
+            .unwrap()
+            .unwrap();
+        assert!(table.contains("WebSocket order command accepted"));
+        assert!(table.contains("Transport: ws"));
+        assert!(table.contains("Request ID: req-1"));
+        assert!(table.contains("Accepted: true"));
+
+        let json = render_ws_result(&result, OutputFormat::Json)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&json).unwrap()["request_id"],
+            "req-1"
+        );
+        assert!(!json.contains("WebSocket Order Debug"));
+
+        let csv = render_ws_result(&result, OutputFormat::Csv)
+            .unwrap()
+            .unwrap();
+        assert!(csv.starts_with("transport,operation,symbol,order_id,request_id"));
+        assert!(csv.contains("ws,cancel,BTC-USD,42,req-1,0,accepted,true"));
+
+        assert!(render_ws_result(&result, OutputFormat::Quiet)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn ws_acceptance_succeeds_and_rejection_returns_an_error() {
+        let accepted = WsOrderResult::new(
+            "create",
+            "BTC-USD".to_string(),
+            None,
+            "req-ok".to_string(),
+            response(Some("req-ok"), 0, "accepted"),
+        );
+        assert!(finish_ws_result(accepted, OutputFormat::Quiet).is_ok());
+
+        let rejected = WsOrderResult::new(
+            "cancel",
+            "BTC-USD".to_string(),
+            Some("42".to_string()),
+            "req-rejected".to_string(),
+            response(Some("req-rejected"), 400, "order already closed"),
+        );
+        let error = finish_ws_result(rejected, OutputFormat::Quiet).unwrap_err();
+        assert!(error.to_string().contains("request_id=req-rejected"));
+        assert!(error.to_string().contains("code=400"));
+    }
 }

--- a/crates/standx-cli/src/main.rs
+++ b/crates/standx-cli/src/main.rs
@@ -250,7 +250,7 @@ async fn execute_command(
             commands::handle_account(command, output).await?;
         }
         Commands::Order { command } => {
-            commands::handle_order(command).await?;
+            commands::handle_order(command, output, verbose).await?;
         }
         Commands::Trade { command } => {
             commands::handle_trade(command, output).await?;

--- a/crates/standx-sdk/README.md
+++ b/crates/standx-sdk/README.md
@@ -152,7 +152,10 @@ stopped being trustworthy.
 WS command channel instead of REST, for latency-sensitive callers. Commands can
 be `prepare`d to obtain the `request_id` before sending, so an in-flight order
 is still identifiable if the response never arrives. `OrderResponseHealth`
-reports session liveness.
+reports session liveness. Opt-in
+`OrderResponseStream::new(session_id)?.with_verbose(true)` diagnostics print
+only raw post-authentication inbound responses to stderr; signed outbound
+commands and authentication payloads are never logged.
 
 ### `models` and `error`
 

--- a/crates/standx-sdk/src/order_response.rs
+++ b/crates/standx-sdk/src/order_response.rs
@@ -53,6 +53,7 @@ pub struct OrderResponseStream {
     token: String,
     signer: Option<Arc<StandXSigner>>,
     session_id: String,
+    verbose: bool,
     ping_interval: Duration,
     idle_timeout: Duration,
     rotate_after: Duration,
@@ -245,6 +246,7 @@ impl OrderResponseStream {
                 .transpose()?
                 .map(Arc::new),
             session_id: session_id.into(),
+            verbose: false,
             ping_interval: ORDER_RESPONSE_PING_INTERVAL,
             idle_timeout: ORDER_RESPONSE_IDLE_TIMEOUT,
             rotate_after: ORDER_RESPONSE_ROTATE_AFTER,
@@ -262,6 +264,7 @@ impl OrderResponseStream {
             token: token.into(),
             signer: None,
             session_id: session_id.into(),
+            verbose: false,
             ping_interval: ORDER_RESPONSE_PING_INTERVAL,
             idle_timeout: ORDER_RESPONSE_IDLE_TIMEOUT,
             rotate_after: ORDER_RESPONSE_ROTATE_AFTER,
@@ -280,6 +283,7 @@ impl OrderResponseStream {
             token: token.into(),
             signer: Some(Arc::new(signer)),
             session_id: session_id.into(),
+            verbose: false,
             ping_interval: ORDER_RESPONSE_PING_INTERVAL,
             idle_timeout: ORDER_RESPONSE_IDLE_TIMEOUT,
             rotate_after: ORDER_RESPONSE_ROTATE_AFTER,
@@ -307,6 +311,14 @@ impl OrderResponseStream {
 
     pub fn session_id(&self) -> &str {
         &self.session_id
+    }
+
+    /// Print raw post-authentication order responses to stderr.
+    ///
+    /// Outbound signed commands and authentication payloads are never logged.
+    pub fn with_verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
     }
 
     /// Connect, wait for authentication, and return a command sender,
@@ -373,6 +385,7 @@ impl OrderResponseStream {
         };
         let health = OrderResponseHealth::default();
         let task_health = health.clone();
+        let verbose = self.verbose;
         let ping_interval = self.ping_interval;
         let idle_timeout = self.idle_timeout;
         let rotate_after = self.rotate_after;
@@ -430,6 +443,9 @@ impl OrderResponseStream {
                             .reset(tokio::time::Instant::now() + idle_timeout);
                         match message {
                         Some(Ok(Message::Text(text))) => {
+                            if verbose {
+                                eprintln!("[WebSocket Order Debug] Received: {text}");
+                            }
                             let response = match serde_json::from_str::<OrderResponse>(&text) {
                                 Ok(response) if response.request_id.is_some() => response,
                                 Ok(_) => {
@@ -558,6 +574,8 @@ mod tests {
             "maker-session",
         );
         assert_eq!(stream.session_id(), "maker-session");
+        assert!(!stream.verbose);
+        assert!(stream.with_verbose(true).verbose);
     }
 
     #[tokio::test]
@@ -774,7 +792,8 @@ mod tests {
         let private_key = bs58::encode(signing_key.to_bytes()).into_string();
         let signer = StandXSigner::from_base58(&private_key).unwrap();
         let stream =
-            OrderResponseStream::with_url_token_and_signer(url, "jwt", "maker-session", signer);
+            OrderResponseStream::with_url_token_and_signer(url, "jwt", "maker-session", signer)
+                .with_verbose(true);
         let (commands, mut responses, _health, handle) = stream.connect().await.unwrap();
         let command = commands
             .prepare_create_order(&CreateOrderParams {

--- a/docs/05-orders.md
+++ b/docs/05-orders.md
@@ -23,7 +23,9 @@ standx order create <SYMBOL> <SIDE> <TYPE> \
   [--tif <TIF>] \
   [--reduce-only] \
   [--sl-price <PRICE>] \
-  [--tp-price <PRICE>]
+  [--tp-price <PRICE>] \
+  [--transport <http|ws>] \
+  [--timeout-secs <SECONDS>]
 ```
 
 ### 参数
@@ -39,6 +41,8 @@ standx order create <SYMBOL> <SIDE> <TYPE> \
 | --reduce-only | 仅减仓 | 否 | - |
 | --sl-price | 止损价格 | 否 | 55000 |
 | --tp-price | 止盈价格 | 否 | 70000 |
+| --transport | 下单传输方式，默认 `http` | 否 | ws |
+| --timeout-secs | 等待匹配 WS 回报的秒数，范围 1–30，默认 10 | 否 | 10 |
 
 ### Time in Force 说明
 
@@ -104,6 +108,34 @@ standx order create BTC-USD sell limit \
   --reduce-only
 ```
 
+### WebSocket 下单并查看回报
+
+```bash
+standx --output json --verbose order create BTC-USD buy limit \
+  --qty 0.01 \
+  --price 60000 \
+  --transport ws
+```
+
+标准输出是稳定的结构化结果：
+
+```json
+{
+  "transport": "ws",
+  "operation": "create",
+  "symbol": "BTC-USD",
+  "request_id": "…",
+  "response_code": 0,
+  "response_message": "accepted",
+  "accepted": true
+}
+```
+
+`--verbose` 会把认证完成后的原始入站 WS response 写到 stderr；不会记录 JWT、签名、
+认证载荷或出站订单。CLI 收到首个匹配 `request_id` 的回报即结束，不额外等待 REST
+可见性。若等待超时或连接中断，订单提交状态未知；请先查询账户订单，避免直接重试造成
+重复下单。
+
 ---
 
 ## 5.2 取消订单
@@ -111,7 +143,9 @@ standx order create BTC-USD sell limit \
 ### 命令
 
 ```bash
-standx order cancel <SYMBOL> --order-id <ID>
+standx order cancel <SYMBOL> --order-id <ID> \
+  [--transport <http|ws>] \
+  [--timeout-secs <SECONDS>]
 ```
 
 ### 参数
@@ -120,11 +154,21 @@ standx order cancel <SYMBOL> --order-id <ID>
 |------|------|------|------|
 | SYMBOL | 交易对 | 是 | BTC-USD |
 | --order-id | 订单ID | 是 | 123456 |
+| --transport | 撤单传输方式，默认 `http` | 否 | ws |
+| --timeout-secs | 等待匹配 WS 回报的秒数，范围 1–30，默认 10 | 否 | 10 |
 
 ### 示例
 
 ```bash
 standx order cancel BTC-USD --order-id 123456
+```
+
+WebSocket 撤单：
+
+```bash
+standx --output json order cancel BTC-USD \
+  --order-id 123456 \
+  --transport ws
 ```
 
 **预期输出（成功）：**
@@ -159,6 +203,8 @@ standx order cancel-all <SYMBOL>
 ```bash
 standx order cancel-all BTC-USD
 ```
+
+`cancel-all` 继续使用 REST，不接受 `--transport ws`。
 
 **预期输出（成功）：**
 ```


### PR DESCRIPTION
## Summary

- add opt-in `--transport ws` for `order create` and single-order `order cancel`, keeping HTTP as the default
- correlate the first WebSocket response by `request_id` and report accepted/rejected results in table, JSON, CSV, or quiet output
- keep raw post-authentication inbound responses on stderr under `--verbose`, without logging auth payloads, JWTs, signatures, or outbound commands
- treat timeout, connection closure, and request-ID mismatch as unknown submission state without REST retry or downgrade

## Compatibility and safety

- existing HTTP behavior and default table output remain unchanged
- `cancel-all` remains REST-only
- rejected venue responses are fully rendered and exit non-zero
- custom canary endpoints are not part of this change; HTTP and WS continue to target the existing production endpoints

## Validation

- `HOME=/tmp/standx-test-home CARGO_HOME=~/.cargo cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --offline -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 -m py_compile scripts/openobserve_dashboard.py`
- request-correlation and rejection tests were mutation-verified
- independent adversarial review found no reproducible high-severity issues
- supervised minimum-size production validation: WS create accepted, matching order immediately cancelled over WS, final open orders and positions both empty