### PR TITLE
feat: add configurable StandX endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ standx order create BTC-USD buy limit --qty 0.1 --price 64000
 standx --output json --verbose order create BTC-USD buy limit \
   --qty 0.1 --price 64000 --transport ws
 
-# Route every StandX REST/WS connection in this invocation to canary
-standx --endpoint https://canary-perps.standx.org \
+# Route every StandX REST/WS connection to a custom environment
+standx --endpoint https://perps.example.com \
   --output json --verbose order create BTC-USD buy limit \
   --qty 0.0001 --price 60000 --transport ws
 
@@ -391,7 +391,7 @@ Available on every command:
 
 Endpoint selection uses `--endpoint`, then `STANDX_BASE_URL`, then
 `config.base_url`, then `https://perps.standx.com`. A base such as
-`https://canary-perps.standx.org` derives REST from the base itself, public and
+`https://perps.example.com` derives REST from the base itself, public and
 account streams from `/ws-stream/v1`, and order responses from `/ws-api/v1`.
 Only root-level HTTPS URLs are accepted; plaintext HTTP is limited to local
 loopback testing. Invalid endpoint configuration fails closed and never falls

--- a/README.md
+++ b/README.md
@@ -261,6 +261,11 @@ standx order create BTC-USD buy limit --qty 0.1 --price 64000
 standx --output json --verbose order create BTC-USD buy limit \
   --qty 0.1 --price 64000 --transport ws
 
+# Route every StandX REST/WS connection in this invocation to canary
+standx --endpoint https://canary-perps.standx.org \
+  --output json --verbose order create BTC-USD buy limit \
+  --qty 0.0001 --price 60000 --transport ws
+
 # With stop loss and take profit
 standx order create BTC-USD buy limit --qty 0.1 --price 64000 \
   --sl-price 62000 --tp-price 68000
@@ -380,8 +385,18 @@ Available on every command:
 | `--openclaw` | Machine-oriented defaults for agent execution (env: `STANDX_OPENCLAW_MODE`) |
 | `--dry-run` | Report the command's financial-impact class and exit without touching the network |
 | `--yes` | Skip the `standx update` confirmation (env: `STANDX_AUTO_CONFIRM=true`). Today `update` is the only command that prompts — trading commands are non-interactive and have nothing to skip |
-| `--config <PATH>` | Use a specific config file |
+| `--config <PATH>` | Use a specific config file or config directory |
+| `--endpoint <BASE_URL>` | Route all StandX REST/WS traffic to a root HTTPS endpoint |
 | `--verbose` / `--quiet` | Log verbosity |
+
+Endpoint selection uses `--endpoint`, then `STANDX_BASE_URL`, then
+`config.base_url`, then `https://perps.standx.com`. A base such as
+`https://canary-perps.standx.org` derives REST from the base itself, public and
+account streams from `/ws-stream/v1`, and order responses from `/ws-api/v1`.
+Only root-level HTTPS URLs are accepted; plaintext HTTP is limited to local
+loopback testing. Invalid endpoint configuration fails closed and never falls
+back to production. Authentication and update-download services are not
+overridden.
 
 ### Maker Bot (SIP-5A Community Maker Yield)
 

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -798,14 +798,14 @@ mod tests {
         let before = Cli::try_parse_from([
             "standx",
             "--endpoint",
-            "https://canary-perps.standx.org",
+            "https://perps.example.com",
             "market",
             "symbols",
         ])
         .expect("global endpoint before the subcommand should parse");
         assert_eq!(
             before.endpoint.as_deref(),
-            Some("https://canary-perps.standx.org")
+            Some("https://perps.example.com")
         );
 
         let after = Cli::try_parse_from([
@@ -813,12 +813,12 @@ mod tests {
             "account",
             "orders",
             "--endpoint",
-            "https://canary-perps.standx.org/",
+            "https://perps.example.com/",
         ])
         .expect("global endpoint after the subcommand should parse");
         assert_eq!(
             after.endpoint.as_deref(),
-            Some("https://canary-perps.standx.org/")
+            Some("https://perps.example.com/")
         );
     }
 

--- a/crates/standx-cli/src/cli.rs
+++ b/crates/standx-cli/src/cli.rs
@@ -84,6 +84,10 @@ pub struct Cli {
     #[arg(short, long, global = true)]
     pub config: Option<String>,
 
+    /// Override the StandX REST/WS environment for this invocation
+    #[arg(long, global = true)]
+    pub endpoint: Option<String>,
+
     /// Output format
     #[arg(short, long, global = true, value_enum, default_value = "table")]
     pub output: OutputFormat,
@@ -787,6 +791,35 @@ mod tests {
         };
         assert_eq!(symbol.as_deref(), Some("BTC-USD"));
         assert_eq!(status, "all");
+    }
+
+    #[test]
+    fn endpoint_is_a_global_one_shot_override() {
+        let before = Cli::try_parse_from([
+            "standx",
+            "--endpoint",
+            "https://canary-perps.standx.org",
+            "market",
+            "symbols",
+        ])
+        .expect("global endpoint before the subcommand should parse");
+        assert_eq!(
+            before.endpoint.as_deref(),
+            Some("https://canary-perps.standx.org")
+        );
+
+        let after = Cli::try_parse_from([
+            "standx",
+            "account",
+            "orders",
+            "--endpoint",
+            "https://canary-perps.standx.org/",
+        ])
+        .expect("global endpoint after the subcommand should parse");
+        assert_eq!(
+            after.endpoint.as_deref(),
+            Some("https://canary-perps.standx.org/")
+        );
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/account.rs
+++ b/crates/standx-cli/src/commands/account.rs
@@ -2,10 +2,15 @@ use crate::cli::*;
 use crate::output;
 use anyhow::Result;
 use standx_sdk::client::StandXClient;
+use standx_sdk::StandXEndpoints;
 
 /// Handle account commands
-pub async fn handle_account(command: AccountCommands, output_format: OutputFormat) -> Result<()> {
-    let client = StandXClient::new()?;
+pub async fn handle_account(
+    command: AccountCommands,
+    output_format: OutputFormat,
+    endpoints: &StandXEndpoints,
+) -> Result<()> {
+    let client = StandXClient::from_endpoints(endpoints)?;
 
     match command {
         AccountCommands::Balances => {

--- a/crates/standx-cli/src/commands/block.rs
+++ b/crates/standx-cli/src/commands/block.rs
@@ -2,11 +2,16 @@ use crate::cli::*;
 use anyhow::Result;
 use standx_sdk::client::StandXClient;
 use standx_sdk::models::BlockTrade;
+use standx_sdk::StandXEndpoints;
 use std::time::Duration;
 
 /// Handle block trade commands
-pub async fn handle_block(command: BlockCommands, output_format: OutputFormat) -> Result<()> {
-    let client = StandXClient::new()?;
+pub async fn handle_block(
+    command: BlockCommands,
+    output_format: OutputFormat,
+    endpoints: &StandXEndpoints,
+) -> Result<()> {
+    let client = StandXClient::from_endpoints(endpoints)?;
 
     match command {
         BlockCommands::List {

--- a/crates/standx-cli/src/commands/config.rs
+++ b/crates/standx-cli/src/commands/config.rs
@@ -3,10 +3,14 @@ use crate::config::Config;
 use anyhow::Result;
 
 /// Handle config commands
-pub async fn handle_config(command: ConfigCommands, output_format: OutputFormat) -> Result<()> {
+pub async fn handle_config(
+    command: ConfigCommands,
+    output_format: OutputFormat,
+    config_path: Option<&str>,
+) -> Result<()> {
     match command {
         ConfigCommands::Init => {
-            let config = Config::default();
+            let config = Config::load_selected(config_path)?;
             config.save()?;
             match output_format {
                 OutputFormat::Json => {
@@ -22,7 +26,7 @@ pub async fn handle_config(command: ConfigCommands, output_format: OutputFormat)
             }
         }
         ConfigCommands::Set { key, value } => {
-            let mut config = Config::load().unwrap_or_default();
+            let mut config = Config::load_selected(config_path)?;
             config.set(&key, &value)?;
             match output_format {
                 OutputFormat::Json => {
@@ -38,7 +42,7 @@ pub async fn handle_config(command: ConfigCommands, output_format: OutputFormat)
             }
         }
         ConfigCommands::Get { key } => {
-            let config = Config::load().unwrap_or_default();
+            let config = Config::load_selected(config_path)?;
             let value = config.get(&key)?;
             match output_format {
                 OutputFormat::Json => {
@@ -53,7 +57,7 @@ pub async fn handle_config(command: ConfigCommands, output_format: OutputFormat)
             }
         }
         ConfigCommands::Show => {
-            let config = Config::load().unwrap_or_default();
+            let config = Config::load_selected(config_path)?;
             match output_format {
                 OutputFormat::Json => {
                     let json = serde_json::json!({

--- a/crates/standx-cli/src/commands/dashboard.rs
+++ b/crates/standx-cli/src/commands/dashboard.rs
@@ -6,6 +6,7 @@ use futures::future::join_all;
 use standx_sdk::client::StandXClient;
 use standx_sdk::models::{DashboardSnapshot, Trade};
 use standx_sdk::websocket::{StandXWebSocket, WsMessage};
+use standx_sdk::StandXEndpoints;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
@@ -17,6 +18,7 @@ pub async fn handle_dashboard(
     watch: Option<u64>,
     compact: bool,
     output_format: OutputFormat,
+    endpoints: &StandXEndpoints,
 ) -> Result<()> {
     // Build list of symbols to track
     let symbol_list: Vec<String> = if let Some(s) = symbols {
@@ -28,7 +30,7 @@ pub async fn handle_dashboard(
     } else {
         vec![]
     };
-    let client = StandXClient::new()?;
+    let client = StandXClient::from_endpoints(endpoints)?;
     let ws_trades: Arc<RwLock<VecDeque<Trade>>> = Arc::new(RwLock::new(VecDeque::new()));
     let mut ws_trade_updates_rx: Option<watch::Receiver<u64>> = None;
     let mut ws_trades_enabled = false;
@@ -56,7 +58,9 @@ pub async fn handle_dashboard(
                 }
             }
 
-            if let Ok(ws) = StandXWebSocket::without_auth() {
+            if let Ok(ws) =
+                StandXWebSocket::without_auth_from_endpoints_with_verbose(endpoints, false)
+            {
                 if ws
                     .subscribe("public_trade", Some(&first_symbol))
                     .await

--- a/crates/standx-cli/src/commands/lag_recorder.rs
+++ b/crates/standx-cli/src/commands/lag_recorder.rs
@@ -22,6 +22,7 @@ use std::io::{BufWriter, Write};
 use std::time::{Duration, Instant};
 
 use standx_sdk::websocket::{StandXWebSocket, WsMessage};
+use standx_sdk::StandXEndpoints;
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 
@@ -118,6 +119,7 @@ pub async fn handle_lag_recorder(
     flush_secs: u64,
     status_secs: u64,
     verbose: bool,
+    endpoints: &StandXEndpoints,
 ) -> Result<()> {
     let hl_coin = hl_coin.unwrap_or_else(|| derive_hl_coin(&symbol));
     let origin = Instant::now();
@@ -135,7 +137,13 @@ pub async fn handle_lag_recorder(
     );
 
     let (tx, mut rx) = mpsc::channel::<LagRecord>(4096);
-    let standx = tokio::spawn(run_standx(symbol.clone(), origin, tx.clone(), verbose));
+    let standx = tokio::spawn(run_standx(
+        symbol.clone(),
+        origin,
+        tx.clone(),
+        verbose,
+        endpoints.clone(),
+    ));
     let hyperliquid = tokio::spawn(run_hyperliquid(hl_coin.clone(), origin, tx));
 
     let flush_secs = flush_secs.max(1);
@@ -258,9 +266,15 @@ async fn shutdown_signal() {
 /// StandX producer: subscribe to the public `price` and `depth_book` channels
 /// (no auth) and forward each update as a `LagRecord`. Rebuilds the connection
 /// when the managed stream ends.
-async fn run_standx(symbol: String, origin: Instant, tx: mpsc::Sender<LagRecord>, verbose: bool) {
+async fn run_standx(
+    symbol: String,
+    origin: Instant,
+    tx: mpsc::Sender<LagRecord>,
+    verbose: bool,
+    endpoints: StandXEndpoints,
+) {
     loop {
-        if let Err(error) = standx_session(&symbol, origin, &tx, verbose).await {
+        if let Err(error) = standx_session(&symbol, origin, &tx, verbose, &endpoints).await {
             eprintln!("lag-recorder: StandX feed error: {error:#}");
         }
         if tx.is_closed() {
@@ -275,8 +289,9 @@ async fn standx_session(
     origin: Instant,
     tx: &mpsc::Sender<LagRecord>,
     verbose: bool,
+    endpoints: &StandXEndpoints,
 ) -> Result<()> {
-    let ws = StandXWebSocket::without_auth_with_verbose(verbose)
+    let ws = StandXWebSocket::without_auth_from_endpoints_with_verbose(endpoints, verbose)
         .context("failed to build StandX websocket client")?;
     let _ = ws.subscribe("price", Some(symbol)).await;
     let _ = ws.subscribe("depth_book", Some(symbol)).await;

--- a/crates/standx-cli/src/commands/leverage.rs
+++ b/crates/standx-cli/src/commands/leverage.rs
@@ -2,10 +2,15 @@ use crate::cli::*;
 use crate::output;
 use anyhow::Result;
 use standx_sdk::client::StandXClient;
+use standx_sdk::StandXEndpoints;
 
 /// Handle leverage commands
-pub async fn handle_leverage(command: LeverageCommands, output_format: OutputFormat) -> Result<()> {
-    let client = StandXClient::new()?;
+pub async fn handle_leverage(
+    command: LeverageCommands,
+    output_format: OutputFormat,
+    endpoints: &StandXEndpoints,
+) -> Result<()> {
+    let client = StandXClient::from_endpoints(endpoints)?;
 
     match command {
         LeverageCommands::Get { symbol } => {

--- a/crates/standx-cli/src/commands/maker/canary.rs
+++ b/crates/standx-cli/src/commands/maker/canary.rs
@@ -222,15 +222,29 @@ async fn cleanup_current_order(
     Ok(None)
 }
 
+pub(super) struct WsCommandCanaryRequest {
+    pub(super) symbol: String,
+    pub(super) size: Option<f64>,
+    pub(super) price_offset_bps: f64,
+    pub(super) timeout_secs: u64,
+    pub(super) alert_webhook: String,
+    pub(super) alert_webhook_format: AlertWebhookFormat,
+    pub(super) output_format: OutputFormat,
+}
+
 pub(super) async fn run_ws_command_canary(
-    symbol: String,
-    size: Option<f64>,
-    price_offset_bps: f64,
-    timeout_secs: u64,
-    alert_webhook: String,
-    alert_webhook_format: AlertWebhookFormat,
-    output_format: OutputFormat,
+    request: WsCommandCanaryRequest,
+    endpoints: &standx_sdk::StandXEndpoints,
 ) -> Result<()> {
+    let WsCommandCanaryRequest {
+        symbol,
+        size,
+        price_offset_bps,
+        timeout_secs,
+        alert_webhook,
+        alert_webhook_format,
+        output_format,
+    } = request;
     // --timeout-secs (1..=30) and the required --alert-webhook are now enforced
     // by clap, so --help documents them and they cannot reach here invalid.
     if std::env::var(LIVE_MAKER_ENV).ok().as_deref() != Some("1") {
@@ -248,7 +262,7 @@ pub(super) async fn run_ws_command_canary(
     }
 
     let session_id = uuid::Uuid::new_v4().to_string();
-    let client = StandXClient::new()?.with_session_id(session_id.clone());
+    let client = StandXClient::from_endpoints(endpoints)?.with_session_id(session_id.clone());
     let notifier = MakerNotifier::new(output_format, Some(alert_webhook), alert_webhook_format);
     let timeout = Duration::from_secs(timeout_secs);
     let infos = client.get_symbol_info().await?;
@@ -298,7 +312,7 @@ pub(super) async fn run_ws_command_canary(
         price: format_decimals(price, info.price_tick_decimals),
     };
     evidence.emit_position(CanaryStage::PreflightVerified, None, 0.0);
-    let stream = OrderResponseStream::new(session_id)?;
+    let stream = OrderResponseStream::from_endpoints(session_id, endpoints)?;
     let (commands, mut responses, _health, handle) = stream.connect().await?;
     notifier
         .lifecycle(

--- a/crates/standx-cli/src/commands/maker/feed.rs
+++ b/crates/standx-cli/src/commands/maker/feed.rs
@@ -338,6 +338,7 @@ async fn reset_feed_state(state: &RwLock<FeedState>, issue: WsSnapshotIssue) {
 pub(super) fn spawn_market_feed(
     symbol: String,
     verbose: bool,
+    endpoints: standx_sdk::StandXEndpoints,
 ) -> (
     Arc<RwLock<FeedState>>,
     watch::Receiver<u64>,
@@ -350,7 +351,9 @@ pub(super) fn spawn_market_feed(
     let handle = tokio::spawn(async move {
         let mut seq = 0u64;
         loop {
-            let ws = match StandXWebSocket::without_auth_with_verbose(verbose) {
+            let ws = match StandXWebSocket::without_auth_from_endpoints_with_verbose(
+                &endpoints, verbose,
+            ) {
                 Ok(ws) => ws,
                 Err(e) => {
                     eprintln!("⚠️  market feed setup failed: {e}; retrying in 10s");

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -102,6 +102,7 @@ pub async fn handle_maker(
     command: MakerCommands,
     output_format: OutputFormat,
     verbose: bool,
+    endpoints: &standx_sdk::StandXEndpoints,
 ) -> Result<()> {
     // Maker output is emitted as JSON lines or a human table; there is no CSV
     // renderer, so `--output csv` would silently fall back to the table. Reject
@@ -118,7 +119,7 @@ pub async fn handle_maker(
             flags,
         } => {
             let args = config::merge(flags, config::load(maker_config.as_deref())?, verbose)?;
-            runtime::run_maker(symbol, args, output_format).await
+            runtime::run_maker(symbol, args, output_format, endpoints).await
         }
         MakerCommands::WsCommandCanary {
             symbol,
@@ -129,13 +130,16 @@ pub async fn handle_maker(
             alert_webhook_format,
         } => {
             canary::run_ws_command_canary(
-                symbol,
-                size,
-                price_offset_bps,
-                timeout_secs,
-                alert_webhook,
-                alert_webhook_format,
-                output_format,
+                canary::WsCommandCanaryRequest {
+                    symbol,
+                    size,
+                    price_offset_bps,
+                    timeout_secs,
+                    alert_webhook,
+                    alert_webhook_format,
+                    output_format,
+                },
+                endpoints,
             )
             .await
         }

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -785,13 +785,14 @@ pub(super) async fn reconnect_account_stream(
     max_attempts: u32,
     backoff_secs: u64,
     ctrl_c: &mut tokio::sync::watch::Receiver<bool>,
+    endpoints: &standx_sdk::StandXEndpoints,
 ) -> AccountStreamReconnect {
     let mut last_connect_error: Option<String> = None;
     for attempt in 1..=max_attempts {
         *epoch = epoch.saturating_add(1);
         let connect_epoch = *epoch;
         let reconnect = async {
-            let stream = AccountStream::new(connect_epoch)?;
+            let stream = AccountStream::from_endpoints(connect_epoch, endpoints)?;
             stream
                 .connect(&[
                     AccountChannel::Order,
@@ -851,6 +852,7 @@ pub(super) struct ReconnectRequest<'a> {
     pub(super) base_backoff: Duration,
     pub(super) original_failure: &'a str,
     pub(super) ctrl_c: tokio::sync::watch::Receiver<bool>,
+    pub(super) endpoints: &'a standx_sdk::StandXEndpoints,
 }
 
 pub(super) async fn reconnect_order_response(
@@ -871,6 +873,7 @@ pub(super) async fn reconnect_order_response(
         base_backoff,
         original_failure,
         ctrl_c,
+        endpoints,
     } = request;
     let mut ctrl_c = ctrl_c;
     let mut last_error = None;
@@ -914,7 +917,7 @@ pub(super) async fn reconnect_order_response(
                 _ = tokio::time::sleep(Duration::from_secs(1)) => {}
             }
             let session_id = uuid::Uuid::new_v4().to_string();
-            let stream = OrderResponseStream::new(&session_id)?;
+            let stream = OrderResponseStream::from_endpoints(&session_id, endpoints)?;
             let connect_attempt = tokio::select! {
                 biased;
                 _ = ctrl_c_latched(&mut ctrl_c) => {

--- a/crates/standx-cli/src/commands/maker/runtime/mod.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/mod.rs
@@ -52,8 +52,9 @@ pub(super) async fn run_maker(
     symbol: String,
     args: MakerRunArgs,
     output_format: OutputFormat,
+    endpoints: &standx_sdk::StandXEndpoints,
 ) -> Result<()> {
-    let startup = run_startup(symbol, &args, output_format).await?;
+    let startup = run_startup(symbol, &args, output_format, endpoints).await?;
     MakerRuntime::announce_start(&args, output_format, &startup).await;
     let runtime = MakerRuntime::new(args, output_format, startup)?;
     let (runtime, exit) = runtime.drive().await;

--- a/crates/standx-cli/src/commands/maker/runtime/recovery_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/recovery_flow.rs
@@ -744,6 +744,7 @@ impl MakerRuntime {
                             args.account_stream_reconnect_attempts,
                             args.account_stream_reconnect_backoff,
                             &mut self.ctrl_c_rx,
+                            &self.deps.endpoints,
                         )
                         .await
                         {
@@ -1136,6 +1137,7 @@ impl MakerRuntime {
                                     ),
                                     original_failure: &detail,
                                     ctrl_c: self.ctrl_c_rx.clone(),
+                                    endpoints: &self.deps.endpoints,
                                 },
                                 &mut self.loop_state.ledger,
                                 &mut self.loop_state.stats,

--- a/crates/standx-cli/src/commands/maker/runtime/state.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/state.rs
@@ -6,6 +6,7 @@ pub(super) struct RuntimeDeps {
     pub(super) args: MakerRunArgs,
     pub(super) output_format: OutputFormat,
     pub(super) client: StandXClient,
+    pub(super) endpoints: standx_sdk::StandXEndpoints,
     pub(super) cfg: MakerConfig,
     pub(super) symbol: String,
     pub(super) notifier: MakerNotifier,
@@ -117,6 +118,7 @@ impl MakerRuntime {
         let MakerStartup {
             live_process_lock,
             client,
+            endpoints,
             cfg,
             symbol,
             notifier,
@@ -131,7 +133,8 @@ impl MakerRuntime {
         let (feed, updates, feed_handle) = if args.no_ws {
             (None, None, None)
         } else {
-            let (state, rx, handle) = spawn_market_feed(symbol.clone(), args.verbose);
+            let (state, rx, handle) =
+                spawn_market_feed(symbol.clone(), args.verbose, endpoints.clone());
             (Some(state), Some(rx), Some(handle))
         };
         let market_watchdog_updates = updates.as_ref().cloned();
@@ -242,6 +245,7 @@ impl MakerRuntime {
                 args,
                 output_format,
                 client,
+                endpoints,
                 cfg,
                 symbol,
                 notifier,

--- a/crates/standx-cli/src/commands/maker/runtime/tests/runtime_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/tests/runtime_flow.rs
@@ -131,7 +131,9 @@ fn effect_failure_stop_maps_each_flow_variant() {
 
 #[test]
 fn maker_rest_client_is_isolated_from_order_response_session() {
-    let client = new_maker_rest_client().expect("maker REST client is constructible");
+    let endpoints = standx_sdk::StandXEndpoints::new("https://canary-perps.standx.org").unwrap();
+    let client = new_maker_rest_client(&endpoints).expect("maker REST client is constructible");
+    assert_eq!(client.base_url(), "https://canary-perps.standx.org");
     assert_eq!(client.session_id(), None);
 }
 

--- a/crates/standx-cli/src/commands/maker/runtime/tests/runtime_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/tests/runtime_flow.rs
@@ -131,9 +131,9 @@ fn effect_failure_stop_maps_each_flow_variant() {
 
 #[test]
 fn maker_rest_client_is_isolated_from_order_response_session() {
-    let endpoints = standx_sdk::StandXEndpoints::new("https://canary-perps.standx.org").unwrap();
+    let endpoints = standx_sdk::StandXEndpoints::new("https://perps.example.com").unwrap();
     let client = new_maker_rest_client(&endpoints).expect("maker REST client is constructible");
-    assert_eq!(client.base_url(), "https://canary-perps.standx.org");
+    assert_eq!(client.base_url(), "https://perps.example.com");
     assert_eq!(client.session_id(), None);
 }
 

--- a/crates/standx-cli/src/commands/maker/startup.rs
+++ b/crates/standx-cli/src/commands/maker/startup.rs
@@ -1,6 +1,7 @@
 use super::output::{emit_ledger_sync, emit_startup_rejected};
 use super::*;
 use standx_sdk::order_response::{OrderCommandSender, OrderResponse, OrderResponseHealth};
+use standx_sdk::StandXEndpoints;
 
 /// Everything that exists exactly when the maker runs `--live`: the
 /// order-response stream, the authenticated account stream, the projection
@@ -28,8 +29,8 @@ pub(super) struct LiveSession {
     pub(super) latency_started: std::time::Instant,
 }
 
-pub(super) fn new_maker_rest_client() -> Result<StandXClient> {
-    let client = StandXClient::new()?;
+pub(super) fn new_maker_rest_client(endpoints: &StandXEndpoints) -> Result<StandXClient> {
+    let client = StandXClient::from_endpoints(endpoints)?;
     debug_assert!(client.session_id().is_none());
     Ok(client)
 }
@@ -68,6 +69,7 @@ pub(super) fn validate_alert_thresholds(
 pub(super) struct MakerStartup {
     pub(super) live_process_lock: Option<super::process_lock::LiveProcessLock>,
     pub(super) client: StandXClient,
+    pub(super) endpoints: StandXEndpoints,
     pub(super) cfg: MakerConfig,
     pub(super) symbol: String,
     pub(super) notifier: MakerNotifier,
@@ -89,6 +91,7 @@ pub(super) async fn run_startup(
     symbol: String,
     args: &MakerRunArgs,
     output_format: OutputFormat,
+    endpoints: &StandXEndpoints,
 ) -> Result<MakerStartup> {
     let live_process_lock = args
         .live
@@ -141,7 +144,7 @@ pub(super) async fn run_startup(
     // order-response session. Attaching x-session-id to REST cancellation
     // would route its asynchronous response into the command response stream,
     // where it has no projection request entry and would look uncorrelated.
-    let client = new_maker_rest_client()?;
+    let client = new_maker_rest_client(endpoints)?;
 
     // ---- Startup: symbol metadata + invariants (fail fast) ----
     let infos = client.get_symbol_info().await?;
@@ -413,7 +416,7 @@ pub(super) async fn run_startup(
         // snapshot so events buffered during authentication cannot create an
         // unobserved startup gap.
         let account_stream_epoch = 1_u64;
-        let account_stream = AccountStream::new(account_stream_epoch)?;
+        let account_stream = AccountStream::from_endpoints(account_stream_epoch, endpoints)?;
         let (account_events, account_stream_health, account_stream_handle) = account_stream
             .connect(&[
                 AccountChannel::Order,
@@ -445,7 +448,7 @@ pub(super) async fn run_startup(
                 "position changed while account stream was authenticating: baseline {starting_position:+.8}, snapshot {post_auth_position:+.8}"
             ));
         }
-        let stream = OrderResponseStream::new(order_session_id)?;
+        let stream = OrderResponseStream::from_endpoints(order_session_id, endpoints)?;
         let (order_commands, order_responses, order_response_health, order_response_handle) =
             stream.connect().await?;
         if let Some(after) = args.controlled_disconnect_after {
@@ -511,6 +514,7 @@ pub(super) async fn run_startup(
     Ok(MakerStartup {
         live_process_lock,
         client,
+        endpoints: endpoints.clone(),
         cfg,
         symbol,
         notifier,

--- a/crates/standx-cli/src/commands/margin.rs
+++ b/crates/standx-cli/src/commands/margin.rs
@@ -1,10 +1,11 @@
 use crate::cli::*;
 use anyhow::Result;
 use standx_sdk::client::StandXClient;
+use standx_sdk::StandXEndpoints;
 
 /// Handle margin commands
-pub async fn handle_margin(command: MarginCommands) -> Result<()> {
-    let client = StandXClient::new()?;
+pub async fn handle_margin(command: MarginCommands, endpoints: &StandXEndpoints) -> Result<()> {
+    let client = StandXClient::from_endpoints(endpoints)?;
 
     match command {
         MarginCommands::Transfer {

--- a/crates/standx-cli/src/commands/market.rs
+++ b/crates/standx-cli/src/commands/market.rs
@@ -3,10 +3,15 @@ use crate::cli::*;
 use crate::output;
 use anyhow::Result;
 use standx_sdk::client::StandXClient;
+use standx_sdk::StandXEndpoints;
 
 /// Handle market commands
-pub async fn handle_market(command: MarketCommands, output_format: OutputFormat) -> Result<()> {
-    let client = StandXClient::new()?;
+pub async fn handle_market(
+    command: MarketCommands,
+    output_format: OutputFormat,
+    endpoints: &StandXEndpoints,
+) -> Result<()> {
+    let client = StandXClient::from_endpoints(endpoints)?;
 
     match command {
         MarketCommands::Symbols => {

--- a/crates/standx-cli/src/commands/order.rs
+++ b/crates/standx-cli/src/commands/order.rs
@@ -6,6 +6,7 @@ use standx_sdk::client::order::CreateOrderParams;
 use standx_sdk::client::StandXClient;
 use standx_sdk::models::{OrderSide, OrderType, TimeInForce};
 use standx_sdk::order_response::{OrderResponse, OrderResponseStream};
+use standx_sdk::StandXEndpoints;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -52,6 +53,7 @@ pub async fn handle_order(
     command: OrderCommands,
     output_format: OutputFormat,
     verbose: bool,
+    endpoints: &StandXEndpoints,
 ) -> Result<()> {
     match command {
         OrderCommands::Create {
@@ -102,11 +104,15 @@ pub async fn handle_order(
             };
 
             match transport {
-                OrderTransport::Http => create_order_http(params).await,
+                OrderTransport::Http => create_order_http(params, endpoints).await,
                 OrderTransport::Ws => {
-                    let (request_id, response) =
-                        create_order_ws(&params, Duration::from_secs(timeout_secs), verbose)
-                            .await?;
+                    let (request_id, response) = create_order_ws(
+                        &params,
+                        Duration::from_secs(timeout_secs),
+                        verbose,
+                        endpoints,
+                    )
+                    .await?;
                     finish_ws_result(
                         WsOrderResult::new("create", symbol, None, request_id, response),
                         output_format,
@@ -120,10 +126,15 @@ pub async fn handle_order(
             transport,
             timeout_secs,
         } => match transport {
-            OrderTransport::Http => cancel_order_http(&symbol, &order_id).await,
+            OrderTransport::Http => cancel_order_http(&symbol, &order_id, endpoints).await,
             OrderTransport::Ws => {
-                let (request_id, response) =
-                    cancel_order_ws(&order_id, Duration::from_secs(timeout_secs), verbose).await?;
+                let (request_id, response) = cancel_order_ws(
+                    &order_id,
+                    Duration::from_secs(timeout_secs),
+                    verbose,
+                    endpoints,
+                )
+                .await?;
                 finish_ws_result(
                     WsOrderResult::new("cancel", symbol, Some(order_id), request_id, response),
                     output_format,
@@ -131,7 +142,7 @@ pub async fn handle_order(
             }
         },
         OrderCommands::CancelAll { symbol } => {
-            let client = StandXClient::new()?;
+            let client = StandXClient::from_endpoints(endpoints)?;
             client.cancel_all_orders(&symbol).await?;
             println!("✅ All orders for {} cancelled successfully", symbol);
             Ok(())
@@ -139,8 +150,8 @@ pub async fn handle_order(
     }
 }
 
-async fn create_order_http(params: CreateOrderParams) -> Result<()> {
-    let client = StandXClient::new()?;
+async fn create_order_http(params: CreateOrderParams, endpoints: &StandXEndpoints) -> Result<()> {
+    let client = StandXClient::from_endpoints(endpoints)?;
     let order = client.create_order(params).await?;
     println!("✅ Order created successfully!");
     println!("   Order ID: {}", order.id);
@@ -154,8 +165,12 @@ async fn create_order_http(params: CreateOrderParams) -> Result<()> {
     Ok(())
 }
 
-async fn cancel_order_http(symbol: &str, order_id: &str) -> Result<()> {
-    let client = StandXClient::new()?;
+async fn cancel_order_http(
+    symbol: &str,
+    order_id: &str,
+    endpoints: &StandXEndpoints,
+) -> Result<()> {
+    let client = StandXClient::from_endpoints(endpoints)?;
     client.cancel_order(symbol, order_id).await?;
     println!("✅ Order {} cancelled successfully", order_id);
     Ok(())
@@ -165,16 +180,18 @@ async fn create_order_ws(
     params: &CreateOrderParams,
     timeout: Duration,
     verbose: bool,
+    endpoints: &StandXEndpoints,
 ) -> Result<(String, OrderResponse)> {
-    run_ws_command(WsCommand::Create(params), timeout, verbose).await
+    run_ws_command(WsCommand::Create(params), timeout, verbose, endpoints).await
 }
 
 async fn cancel_order_ws(
     order_id: &str,
     timeout: Duration,
     verbose: bool,
+    endpoints: &StandXEndpoints,
 ) -> Result<(String, OrderResponse)> {
-    run_ws_command(WsCommand::Cancel(order_id), timeout, verbose).await
+    run_ws_command(WsCommand::Cancel(order_id), timeout, verbose, endpoints).await
 }
 
 enum WsCommand<'a> {
@@ -186,9 +203,10 @@ async fn run_ws_command(
     command: WsCommand<'_>,
     timeout: Duration,
     verbose: bool,
+    endpoints: &StandXEndpoints,
 ) -> Result<(String, OrderResponse)> {
     let session_id = uuid::Uuid::new_v4().to_string();
-    let stream = OrderResponseStream::new(session_id)?.with_verbose(verbose);
+    let stream = OrderResponseStream::from_endpoints(session_id, endpoints)?.with_verbose(verbose);
     let (commands, mut responses, _health, handle) = stream.connect().await?;
 
     // Always stop the short-lived connection task, including send/response
@@ -303,7 +321,9 @@ fn render_ws_result(result: &WsOrderResult, output_format: OutputFormat) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::{SinkExt, StreamExt};
     use serde_json::json;
+    use tokio_tungstenite::{accept_async, tungstenite::Message};
 
     fn response(request_id: Option<&str>, code: i64, message: &str) -> OrderResponse {
         OrderResponse {
@@ -311,6 +331,119 @@ mod tests {
             message: message.to_string(),
             request_id: request_id.map(str::to_string),
         }
+    }
+
+    struct EnvironmentRestore {
+        values: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl Drop for EnvironmentRestore {
+        fn drop(&mut self) {
+            for (key, value) in self.values.drain(..) {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    // Environment credentials are process-global, so this test deliberately
+    // holds the crate-wide lock for the full current-thread async exchange.
+    #[allow(clippy::await_holding_lock)]
+    async fn custom_endpoint_drives_authenticated_signed_ws_command_without_fallback() {
+        let _lock = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let restore = EnvironmentRestore {
+            values: ["STANDX_JWT", "STANDX_PRIVATE_KEY"]
+                .into_iter()
+                .map(|key| (key, std::env::var(key).ok()))
+                .collect(),
+        };
+        std::env::set_var("STANDX_JWT", "loopback-jwt");
+        // Base58 encoding of a 32-byte all-zero Ed25519 seed.
+        std::env::set_var("STANDX_PRIVATE_KEY", "11111111111111111111111111111111");
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoints =
+            StandXEndpoints::new(format!("http://{}", listener.local_addr().unwrap())).unwrap();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(socket).await.unwrap();
+            let auth: serde_json::Value = serde_json::from_str(
+                &websocket
+                    .next()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .into_text()
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(auth["method"], "auth:login");
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "code": 0,
+                        "message": "authenticated",
+                        "request_id": auth["request_id"],
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+
+            let command: serde_json::Value = serde_json::from_str(
+                &websocket
+                    .next()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .into_text()
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(command["method"], "order:new");
+            assert_eq!(command["header"]["x-request-sign-version"], "v1");
+            assert!(command["header"]["x-request-signature"].as_str().is_some());
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "code": 0,
+                        "message": "accepted",
+                        "request_id": command["request_id"],
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        });
+
+        let params = CreateOrderParams {
+            symbol: "BTC-USD".to_string(),
+            cl_ord_id: None,
+            side: OrderSide::Buy,
+            order_type: OrderType::Limit,
+            quantity: "0.001".to_string(),
+            price: Some("50000".to_string()),
+            time_in_force: Some(TimeInForce::Alo),
+            reduce_only: false,
+            stop_price: None,
+            sl_price: None,
+            tp_price: None,
+        };
+        let (request_id, response) =
+            create_order_ws(&params, Duration::from_secs(1), false, &endpoints)
+                .await
+                .unwrap();
+        assert_eq!(response.request_id.as_deref(), Some(request_id.as_str()));
+        assert!(response.accepted());
+        server.await.unwrap();
+        drop(restore);
     }
 
     #[tokio::test]

--- a/crates/standx-cli/src/commands/portfolio.rs
+++ b/crates/standx-cli/src/commands/portfolio.rs
@@ -4,6 +4,7 @@ use crate::output;
 use anyhow::Result;
 use standx_sdk::client::StandXClient;
 use standx_sdk::models::PortfolioSnapshot;
+use standx_sdk::StandXEndpoints;
 
 /// Portfolio command for direct execution (without subcommands)
 #[derive(Debug)]
@@ -15,10 +16,11 @@ pub enum PortfolioCommand {
 pub async fn handle_portfolio(
     command: PortfolioCommand,
     output_format: OutputFormat,
+    endpoints: &StandXEndpoints,
 ) -> Result<()> {
     match command {
         PortfolioCommand::Snapshot { _verbose, watch } => {
-            let client = StandXClient::new()?;
+            let client = StandXClient::from_endpoints(endpoints)?;
             run_watch_loop(
                 watch,
                 || build_portfolio_output(&client, _verbose, output_format),

--- a/crates/standx-cli/src/commands/stream.rs
+++ b/crates/standx-cli/src/commands/stream.rs
@@ -2,13 +2,18 @@ use crate::cli::*;
 use anyhow::Result;
 use standx_sdk::account_stream::{AccountChannel, AccountEvent, AccountStream};
 use standx_sdk::websocket::{StandXWebSocket, WsMessage};
+use standx_sdk::StandXEndpoints;
 
 /// Handle stream commands
-pub async fn handle_stream(command: StreamCommands, verbose: bool) -> Result<()> {
+pub async fn handle_stream(
+    command: StreamCommands,
+    verbose: bool,
+    endpoints: &StandXEndpoints,
+) -> Result<()> {
     match command {
         // Public channels - no auth required
         StreamCommands::Price { symbol } => {
-            let ws = StandXWebSocket::without_auth_with_verbose(verbose)?;
+            let ws = StandXWebSocket::without_auth_from_endpoints_with_verbose(endpoints, verbose)?;
             let _ = ws.subscribe("price", Some(&symbol)).await;
             let mut rx = ws.connect().await?;
 
@@ -28,7 +33,7 @@ pub async fn handle_stream(command: StreamCommands, verbose: bool) -> Result<()>
             }
         }
         StreamCommands::Depth { symbol, levels } => {
-            let ws = StandXWebSocket::without_auth_with_verbose(verbose)?;
+            let ws = StandXWebSocket::without_auth_from_endpoints_with_verbose(endpoints, verbose)?;
             let _ = ws.subscribe("depth_book", Some(&symbol)).await;
             let mut rx = ws.connect().await?;
 
@@ -50,7 +55,7 @@ pub async fn handle_stream(command: StreamCommands, verbose: bool) -> Result<()>
             }
         }
         StreamCommands::Trade { symbol } => {
-            let ws = StandXWebSocket::without_auth_with_verbose(verbose)?;
+            let ws = StandXWebSocket::without_auth_from_endpoints_with_verbose(endpoints, verbose)?;
             let _ = ws.subscribe("public_trade", Some(&symbol)).await;
             let mut rx = ws.connect().await?;
 
@@ -79,7 +84,7 @@ pub async fn handle_stream(command: StreamCommands, verbose: bool) -> Result<()>
             }
         }
         StreamCommands::Kline { symbol, interval } => {
-            let ws = StandXWebSocket::without_auth_with_verbose(verbose)?;
+            let ws = StandXWebSocket::without_auth_from_endpoints_with_verbose(endpoints, verbose)?;
             // Subscribe with interval parameter embedded in topic
             ws.subscribe_with_interval("kline", Some(&symbol), Some(&interval))
                 .await?;
@@ -111,7 +116,7 @@ pub async fn handle_stream(command: StreamCommands, verbose: bool) -> Result<()>
         }
         // User-level authenticated channels
         StreamCommands::Order => {
-            let stream = AccountStream::new(1)?;
+            let stream = AccountStream::from_endpoints(1, endpoints)?;
             let (mut rx, _health, _handle) = stream.connect(&[AccountChannel::Order]).await?;
 
             println!("Streaming order updates");
@@ -124,7 +129,7 @@ pub async fn handle_stream(command: StreamCommands, verbose: bool) -> Result<()>
             }
         }
         StreamCommands::Position => {
-            let stream = AccountStream::new(1)?;
+            let stream = AccountStream::from_endpoints(1, endpoints)?;
             let (mut rx, _health, _handle) = stream.connect(&[AccountChannel::Position]).await?;
 
             println!("Streaming position updates");
@@ -137,7 +142,7 @@ pub async fn handle_stream(command: StreamCommands, verbose: bool) -> Result<()>
             }
         }
         StreamCommands::Balance => {
-            let stream = AccountStream::new(1)?;
+            let stream = AccountStream::from_endpoints(1, endpoints)?;
             let (mut rx, _health, _handle) = stream.connect(&[AccountChannel::Balance]).await?;
 
             println!("Streaming balance updates");
@@ -150,7 +155,7 @@ pub async fn handle_stream(command: StreamCommands, verbose: bool) -> Result<()>
             }
         }
         StreamCommands::Fills => {
-            let stream = AccountStream::new(1)?;
+            let stream = AccountStream::from_endpoints(1, endpoints)?;
             let (mut rx, _health, _handle) = stream.connect(&[AccountChannel::Trade]).await?;
 
             println!("Streaming fill/trade updates");

--- a/crates/standx-cli/src/commands/trade.rs
+++ b/crates/standx-cli/src/commands/trade.rs
@@ -3,10 +3,15 @@ use crate::cli::*;
 use crate::output;
 use anyhow::Result;
 use standx_sdk::client::StandXClient;
+use standx_sdk::StandXEndpoints;
 
 /// Handle trade commands
-pub async fn handle_trade(command: TradeCommands, output_format: OutputFormat) -> Result<()> {
-    let client = StandXClient::new()?;
+pub async fn handle_trade(
+    command: TradeCommands,
+    output_format: OutputFormat,
+    endpoints: &StandXEndpoints,
+) -> Result<()> {
+    let client = StandXClient::from_endpoints(endpoints)?;
 
     match command {
         TradeCommands::History {

--- a/crates/standx-cli/src/config.rs
+++ b/crates/standx-cli/src/config.rs
@@ -603,13 +603,13 @@ mod tests {
         let selected = temp_dir.path().join("canary.toml");
         let mut config = Config::load_from_path(Some(&selected)).unwrap();
         config
-            .set("base_url", "https://canary-perps.standx.org/")
+            .set("base_url", "https://perps.example.com/")
             .unwrap();
 
         assert!(selected.exists());
         assert!(!temp_dir.path().join("config.toml").exists());
         let loaded = Config::load_from_path(Some(&selected)).unwrap();
-        assert_eq!(loaded.base_url, "https://canary-perps.standx.org");
+        assert_eq!(loaded.base_url, "https://perps.example.com");
         assert_eq!(loaded.config_file(), selected);
     }
 
@@ -620,9 +620,7 @@ mod tests {
         std::fs::create_dir(&selected).unwrap();
 
         let mut config = Config::load_from_path(Some(&selected)).unwrap();
-        config
-            .set("base_url", "https://canary-perps.standx.org")
-            .unwrap();
+        config.set("base_url", "https://perps.example.com").unwrap();
 
         assert_eq!(config.config_file(), selected.join("config.toml"));
         assert!(selected.join("config.toml").is_file());
@@ -633,14 +631,14 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let mut config = Config::load_from_path(Some(temp_dir.path())).unwrap();
         config
-            .set("base_url", "https://canary-perps.standx.org/")
+            .set("base_url", "https://perps.example.com/")
             .unwrap();
-        assert_eq!(config.base_url, "https://canary-perps.standx.org");
+        assert_eq!(config.base_url, "https://perps.example.com");
 
         let error = config
-            .set("base_url", "http://canary-perps.standx.org")
+            .set("base_url", "http://perps.example.com")
             .unwrap_err();
         assert!(error.to_string().contains("plain HTTP"));
-        assert_eq!(config.base_url, "https://canary-perps.standx.org");
+        assert_eq!(config.base_url, "https://perps.example.com");
     }
 }

--- a/crates/standx-cli/src/config.rs
+++ b/crates/standx-cli/src/config.rs
@@ -7,11 +7,48 @@ use std::path::PathBuf;
 
 pub const BASE_URL_ENV: &str = "STANDX_BASE_URL";
 
+/// Must be set to a non-empty value before an authenticated command (anything
+/// but `market`) is allowed to run against a plain-HTTP/WS endpoint.
+pub const ALLOW_INSECURE_ENDPOINT_ENV: &str = "STANDX_ALLOW_INSECURE_ENDPOINT";
+
+/// Refuse to run an authenticated command against a non-TLS endpoint unless the
+/// operator explicitly opts in. `StandXEndpoints::new` already restricts plain
+/// HTTP/WS to loopback addresses, but that alone doesn't stop a normal
+/// invocation — e.g. a mistyped `--endpoint` or a `STANDX_BASE_URL` picked up
+/// from a compromised script — from pointing the JWT and signing key at an
+/// unintended local listener in clear text. This is a second, explicit signal
+/// that the operator means it.
+pub fn ensure_authenticated_endpoint_is_secure(endpoints: &StandXEndpoints) -> Result<()> {
+    if endpoints.is_secure() {
+        return Ok(());
+    }
+    if std::env::var_os(ALLOW_INSECURE_ENDPOINT_ENV).is_some_and(|value| !value.is_empty()) {
+        return Ok(());
+    }
+    Err(Error::Config {
+        message: format!(
+            "refusing to send credentials to insecure endpoint '{}': plain HTTP/WS exposes the \
+             JWT and signing key to anything listening on that address. Set \
+             {ALLOW_INSECURE_ENDPOINT_ENV}=1 to confirm this is a trusted local test endpoint.",
+            endpoints.base_url()
+        ),
+    })
+}
+
 /// Application configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// API base URL
     pub base_url: String,
+
+    /// Whether `base_url` was explicitly confirmed through `config set` (or a fresh
+    /// default config). Config files written before endpoint routing existed have no
+    /// such field and deserialize this as `false`, so a stale custom `base_url` that
+    /// was previously cosmetic-only stays inactive after upgrading until the user
+    /// re-confirms it — an upgrade must never silently turn an old value into live
+    /// routing for financial commands.
+    #[serde(default)]
+    pub base_url_confirmed: bool,
 
     /// Default output format
     pub output_format: String,
@@ -32,6 +69,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             base_url: "https://perps.standx.com".to_string(),
+            base_url_confirmed: true,
             output_format: "table".to_string(),
             default_symbol: "BTC-USD".to_string(),
             config_dir: Self::default_config_dir(),
@@ -145,6 +183,18 @@ impl Config {
                 ),
             });
         }
+        if config.base_url != standx_sdk::endpoints::DEFAULT_BASE_URL && !config.base_url_confirmed
+        {
+            eprintln!(
+                "warning: ignoring unconfirmed base_url '{}' in {} — it predates endpoint \
+                 routing and was never active; run `standx config set base_url {}` to confirm \
+                 and use it, or pass --endpoint. Falling back to the default endpoint.",
+                config.base_url,
+                config.config_file().display(),
+                config.base_url,
+            );
+            return StandXEndpoints::new(standx_sdk::endpoints::DEFAULT_BASE_URL);
+        }
         StandXEndpoints::new(&config.base_url)
     }
 
@@ -170,6 +220,7 @@ impl Config {
         match key {
             "base_url" => {
                 self.base_url = StandXEndpoints::new(value)?.base_url().to_string();
+                self.base_url_confirmed = true;
             }
             "output_format" => self.output_format = value.to_string(),
             "default_symbol" => self.default_symbol = value.to_string(),
@@ -276,6 +327,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let config = Config {
             base_url: "https://test.standx.com".to_string(),
+            base_url_confirmed: true,
             output_format: "json".to_string(),
             default_symbol: "ETH-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
@@ -340,6 +392,7 @@ mod tests {
         // 由于 Config::load() 使用固定路径，我们测试 save/load 循环
         let config = Config {
             base_url: "https://test.com".to_string(),
+            base_url_confirmed: true,
             output_format: "json".to_string(),
             default_symbol: "ETH-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
@@ -395,6 +448,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let config = Config {
             base_url: "https://file.standx.com".to_string(),
+            base_url_confirmed: true,
             output_format: "table".to_string(),
             default_symbol: "BTC-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
@@ -453,6 +507,7 @@ mod tests {
 
         let config = Config {
             base_url: "https://specific.test.com".to_string(),
+            base_url_confirmed: true,
             output_format: "json".to_string(),
             default_symbol: "ETH-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
@@ -477,6 +532,7 @@ mod tests {
 
         let config = Config {
             base_url: "https://string.test.com".to_string(),
+            base_url_confirmed: true,
             output_format: "csv".to_string(),
             default_symbol: "DOGE-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
@@ -495,6 +551,7 @@ mod tests {
 
         let config = Config {
             base_url: "https://pathbuf.test.com".to_string(),
+            base_url_confirmed: true,
             output_format: "csv".to_string(),
             default_symbol: "DOGE-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
@@ -519,6 +576,7 @@ mod tests {
 
         let config = Config {
             base_url: "https://backward.compat.com".to_string(),
+            base_url_confirmed: true,
             output_format: "table".to_string(),
             default_symbol: "BTC-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
@@ -573,6 +631,37 @@ mod tests {
         let default = Config::resolve_endpoints(None, None).unwrap();
         assert_eq!(default, StandXEndpoints::default());
         drop(env);
+    }
+
+    #[test]
+    fn pre_existing_unconfirmed_base_url_stays_inactive_after_upgrade() {
+        // Simulates a config.toml written by a version of the CLI that predates
+        // endpoint routing: `base_url` was persisted but had no functional effect
+        // (no `base_url_confirmed` field exists). Upgrading must not silently turn
+        // that stale value into live routing for financial commands.
+        let _env = EnvGuard::unset(BASE_URL_ENV);
+        let temp_dir = TempDir::new().unwrap();
+        let config_file = temp_dir.path().join("config.toml");
+        std::fs::write(
+            &config_file,
+            "base_url = \"https://stale-legacy.example.com\"\n\
+             output_format = \"table\"\n\
+             default_symbol = \"BTC-USD\"\n",
+        )
+        .unwrap();
+        let config_path = temp_dir.path().to_str().unwrap();
+
+        let resolved = Config::resolve_endpoints(None, Some(config_path)).unwrap();
+        assert_eq!(resolved, StandXEndpoints::default());
+
+        // Once the user explicitly re-confirms the same value via `config set`, it
+        // becomes active.
+        let mut config = Config::load_from_path(Some(temp_dir.path())).unwrap();
+        config
+            .set("base_url", "https://stale-legacy.example.com")
+            .unwrap();
+        let resolved = Config::resolve_endpoints(None, Some(config_path)).unwrap();
+        assert_eq!(resolved.base_url(), "https://stale-legacy.example.com");
     }
 
     #[test]
@@ -640,5 +729,25 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("plain HTTP"));
         assert_eq!(config.base_url, "https://perps.example.com");
+    }
+
+    #[test]
+    fn insecure_endpoint_requires_explicit_opt_in() {
+        let insecure = StandXEndpoints::new("http://127.0.0.1:8080").unwrap();
+
+        {
+            let _env = EnvGuard::unset(ALLOW_INSECURE_ENDPOINT_ENV);
+            let error = ensure_authenticated_endpoint_is_secure(&insecure).unwrap_err();
+            assert!(error.to_string().contains(ALLOW_INSECURE_ENDPOINT_ENV));
+        }
+
+        let _opt_in = EnvGuard::set(ALLOW_INSECURE_ENDPOINT_ENV, "1");
+        ensure_authenticated_endpoint_is_secure(&insecure).unwrap();
+    }
+
+    #[test]
+    fn secure_endpoint_never_needs_opt_in() {
+        let _env = EnvGuard::unset(ALLOW_INSECURE_ENDPOINT_ENV);
+        ensure_authenticated_endpoint_is_secure(&StandXEndpoints::default()).unwrap();
     }
 }

--- a/crates/standx-cli/src/config.rs
+++ b/crates/standx-cli/src/config.rs
@@ -2,7 +2,10 @@
 
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
+use standx_sdk::StandXEndpoints;
 use std::path::PathBuf;
+
+pub const BASE_URL_ENV: &str = "STANDX_BASE_URL";
 
 /// Application configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -19,6 +22,10 @@ pub struct Config {
     /// Configuration directory
     #[serde(skip)]
     pub config_dir: PathBuf,
+
+    /// Exact configuration file selected through `--config`, when present.
+    #[serde(skip)]
+    config_file_override: Option<PathBuf>,
 }
 
 impl Default for Config {
@@ -28,6 +35,7 @@ impl Default for Config {
             output_format: "table".to_string(),
             default_symbol: "BTC-USD".to_string(),
             config_dir: Self::default_config_dir(),
+            config_file_override: None,
         }
     }
 }
@@ -42,7 +50,9 @@ impl Config {
 
     /// Get configuration file path
     pub fn config_file(&self) -> PathBuf {
-        self.config_dir.join("config.toml")
+        self.config_file_override
+            .clone()
+            .unwrap_or_else(|| self.config_dir.join("config.toml"))
     }
 
     /// Load configuration from file
@@ -70,14 +80,28 @@ impl Config {
     /// let config = Config::load_from_path(Some("/tmp/my-config"))?;
     /// ```
     pub fn load_from_path<T: Into<PathBuf>>(path: Option<T>) -> Result<Self> {
-        let config_dir = match path {
-            Some(p) => p.into(),
-            None => Self::default_config_dir(),
+        let selected = path.map(Into::into);
+        let (config_dir, config_file_override) = match selected {
+            Some(path) if is_config_file_path(&path) => {
+                let parent = path
+                    .parent()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from("."));
+                (parent, Some(path))
+            }
+            Some(path) => (path, None),
+            None => (Self::default_config_dir(), None),
         };
-        let config_file = config_dir.join("config.toml");
+        let config_file = config_file_override
+            .clone()
+            .unwrap_or_else(|| config_dir.join("config.toml"));
 
         if !config_file.exists() {
-            return Ok(Self::default());
+            return Ok(Self {
+                config_dir,
+                config_file_override,
+                ..Self::default()
+            });
         }
 
         let content = std::fs::read_to_string(&config_file).map_err(|e| Error::Config {
@@ -89,7 +113,39 @@ impl Config {
         })?;
 
         config.config_dir = config_dir;
+        config.config_file_override = config_file_override;
         Ok(config)
+    }
+
+    /// Load the configuration selected by the global `--config` option.
+    pub fn load_selected(path: Option<&str>) -> Result<Self> {
+        Self::load_from_path(path.map(PathBuf::from))
+    }
+
+    /// Resolve the effective endpoint using CLI > environment > file > default.
+    pub fn resolve_endpoints(
+        cli_endpoint: Option<&str>,
+        config_path: Option<&str>,
+    ) -> Result<StandXEndpoints> {
+        if let Some(endpoint) = cli_endpoint {
+            return StandXEndpoints::new(endpoint);
+        }
+        if let Some(endpoint) = std::env::var_os(BASE_URL_ENV) {
+            let endpoint = endpoint.into_string().map_err(|_| Error::Config {
+                message: format!("{BASE_URL_ENV} is not valid UTF-8"),
+            })?;
+            return StandXEndpoints::new(endpoint);
+        }
+        let config = Self::load_selected(config_path)?;
+        if config_path.is_some() && !config.config_file().exists() {
+            return Err(Error::Config {
+                message: format!(
+                    "Selected config file does not exist: {}",
+                    config.config_file().display()
+                ),
+            });
+        }
+        StandXEndpoints::new(&config.base_url)
     }
 
     /// Save configuration to file
@@ -112,7 +168,9 @@ impl Config {
     /// Set a configuration value
     pub fn set(&mut self, key: &str, value: &str) -> Result<()> {
         match key {
-            "base_url" => self.base_url = value.to_string(),
+            "base_url" => {
+                self.base_url = StandXEndpoints::new(value)?.base_url().to_string();
+            }
             "output_format" => self.output_format = value.to_string(),
             "default_symbol" => self.default_symbol = value.to_string(),
             _ => {
@@ -137,6 +195,16 @@ impl Config {
     }
 }
 
+fn is_config_file_path(path: &std::path::Path) -> bool {
+    if path.is_dir() {
+        return false;
+    }
+    path.is_file()
+        || path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("toml"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -149,21 +217,36 @@ mod tests {
     /// tests never overlap — including across modules (telemetry, maker,
     /// pipeline).
     struct EnvGuard {
-        key: String,
-        original_value: Option<String>,
+        values: Vec<(String, Option<std::ffi::OsString>)>,
         _lock: std::sync::MutexGuard<'static, ()>,
     }
 
     impl EnvGuard {
         fn set(key: &str, value: &str) -> Self {
+            Self::set_many(&[(key, Some(value))])
+        }
+
+        fn unset(key: &str) -> Self {
+            Self::set_many(&[(key, None)])
+        }
+
+        fn set_many(values: &[(&str, Option<&str>)]) -> Self {
             let lock = crate::TEST_ENV_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let original_value = std::env::var(key).ok();
-            std::env::set_var(key, value);
+            let original_values = values
+                .iter()
+                .map(|(key, value)| {
+                    let original = std::env::var_os(key);
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                    ((*key).to_string(), original)
+                })
+                .collect();
             Self {
-                key: key.to_string(),
-                original_value,
+                values: original_values,
                 _lock: lock,
             }
         }
@@ -171,9 +254,11 @@ mod tests {
 
     impl Drop for EnvGuard {
         fn drop(&mut self) {
-            match &self.original_value {
-                Some(val) => std::env::set_var(&self.key, val),
-                None => std::env::remove_var(&self.key),
+            for (key, original) in self.values.drain(..).rev() {
+                match original {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
             }
         }
     }
@@ -194,6 +279,7 @@ mod tests {
             output_format: "json".to_string(),
             default_symbol: "ETH-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
+            config_file_override: None,
         };
 
         // Save config
@@ -210,7 +296,8 @@ mod tests {
 
     #[test]
     fn test_set_get() {
-        let mut config = Config::default();
+        let temp_dir = TempDir::new().unwrap();
+        let mut config = Config::load_from_path(Some(temp_dir.path())).unwrap();
 
         config.set("base_url", "https://test.com").unwrap();
         assert_eq!(config.get("base_url").unwrap(), "https://test.com");
@@ -256,6 +343,7 @@ mod tests {
             output_format: "json".to_string(),
             default_symbol: "ETH-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
+            config_file_override: None,
         };
 
         // 先保存有效配置
@@ -310,6 +398,7 @@ mod tests {
             output_format: "table".to_string(),
             default_symbol: "BTC-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
+            config_file_override: None,
         };
         config.save().unwrap();
 
@@ -367,6 +456,7 @@ mod tests {
             output_format: "json".to_string(),
             default_symbol: "ETH-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
+            config_file_override: None,
         };
         config.save().unwrap();
 
@@ -390,6 +480,7 @@ mod tests {
             output_format: "csv".to_string(),
             default_symbol: "DOGE-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
+            config_file_override: None,
         };
         config.save().unwrap();
 
@@ -407,6 +498,7 @@ mod tests {
             output_format: "csv".to_string(),
             default_symbol: "DOGE-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
+            config_file_override: None,
         };
         config.save().unwrap();
 
@@ -430,6 +522,7 @@ mod tests {
             output_format: "table".to_string(),
             default_symbol: "BTC-USD".to_string(),
             config_dir: temp_dir.path().to_path_buf(),
+            config_file_override: None,
         };
         config.save().unwrap();
 
@@ -448,5 +541,106 @@ mod tests {
 
         let result = Config::load_from_path(Some(temp_dir.path()));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn endpoint_resolution_precedence_is_cli_then_env_then_file_then_default() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut config = Config::load_from_path(Some(temp_dir.path())).unwrap();
+        config
+            .set("base_url", "https://file.standx.example")
+            .unwrap();
+        let config_path = temp_dir.path().to_str().unwrap();
+        let isolated_home = TempDir::new().unwrap();
+
+        let env = EnvGuard::set_many(&[
+            (BASE_URL_ENV, Some("https://env.standx.example")),
+            ("HOME", isolated_home.path().to_str()),
+        ]);
+        let cli = Config::resolve_endpoints(Some("https://cli.standx.example/"), Some(config_path))
+            .unwrap();
+        assert_eq!(cli.base_url(), "https://cli.standx.example");
+
+        let from_env = Config::resolve_endpoints(None, Some(config_path)).unwrap();
+        assert_eq!(from_env.base_url(), "https://env.standx.example");
+
+        // Keep the process-wide lock while temporarily clearing the test value;
+        // dropping the guard below restores the caller's original environment.
+        std::env::remove_var(BASE_URL_ENV);
+        let from_file = Config::resolve_endpoints(None, Some(config_path)).unwrap();
+        assert_eq!(from_file.base_url(), "https://file.standx.example");
+
+        let default = Config::resolve_endpoints(None, None).unwrap();
+        assert_eq!(default, StandXEndpoints::default());
+        drop(env);
+    }
+
+    #[test]
+    fn explicit_empty_environment_endpoint_fails_closed() {
+        let _env = EnvGuard::set(BASE_URL_ENV, "");
+        let error = Config::resolve_endpoints(None, None).unwrap_err();
+        assert!(error.to_string().contains("invalid StandX endpoint"));
+    }
+
+    #[test]
+    fn explicitly_selected_missing_config_fails_closed_for_endpoint_resolution() {
+        let _env = EnvGuard::unset(BASE_URL_ENV);
+        let temp_dir = TempDir::new().unwrap();
+        let missing_file = temp_dir.path().join("missing.toml");
+        let error =
+            Config::resolve_endpoints(None, missing_file.to_str()).expect_err("must fail closed");
+        assert!(error.to_string().contains("does not exist"));
+
+        let missing_directory = temp_dir.path().join("missing-directory");
+        let error = Config::resolve_endpoints(None, missing_directory.to_str())
+            .expect_err("must fail closed");
+        assert!(error.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn selected_toml_file_is_loaded_and_saved_without_directory_rewriting() {
+        let temp_dir = TempDir::new().unwrap();
+        let selected = temp_dir.path().join("canary.toml");
+        let mut config = Config::load_from_path(Some(&selected)).unwrap();
+        config
+            .set("base_url", "https://canary-perps.standx.org/")
+            .unwrap();
+
+        assert!(selected.exists());
+        assert!(!temp_dir.path().join("config.toml").exists());
+        let loaded = Config::load_from_path(Some(&selected)).unwrap();
+        assert_eq!(loaded.base_url, "https://canary-perps.standx.org");
+        assert_eq!(loaded.config_file(), selected);
+    }
+
+    #[test]
+    fn existing_directory_named_with_toml_suffix_remains_a_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let selected = temp_dir.path().join("profile.toml");
+        std::fs::create_dir(&selected).unwrap();
+
+        let mut config = Config::load_from_path(Some(&selected)).unwrap();
+        config
+            .set("base_url", "https://canary-perps.standx.org")
+            .unwrap();
+
+        assert_eq!(config.config_file(), selected.join("config.toml"));
+        assert!(selected.join("config.toml").is_file());
+    }
+
+    #[test]
+    fn setting_base_url_normalizes_valid_values_and_rejects_invalid_ones() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut config = Config::load_from_path(Some(temp_dir.path())).unwrap();
+        config
+            .set("base_url", "https://canary-perps.standx.org/")
+            .unwrap();
+        assert_eq!(config.base_url, "https://canary-perps.standx.org");
+
+        let error = config
+            .set("base_url", "http://canary-perps.standx.org")
+            .unwrap_err();
+        assert!(error.to_string().contains("plain HTTP"));
+        assert_eq!(config.base_url, "https://canary-perps.standx.org");
     }
 }

--- a/crates/standx-cli/src/main.rs
+++ b/crates/standx-cli/src/main.rs
@@ -123,7 +123,16 @@ async fn async_main(args: Vec<String>) {
     };
 
     // Execute command and handle errors
-    match execute_command(cli.command, output, cli.verbose, cli.yes).await {
+    match execute_command(
+        cli.command,
+        output,
+        cli.verbose,
+        cli.yes,
+        cli.endpoint.as_deref(),
+        cli.config.as_deref(),
+    )
+    .await
+    {
         Ok(_) => {
             telemetry.track_command_complete(command_name, true, None);
         }
@@ -235,34 +244,75 @@ async fn execute_command(
     verbose: bool,
     // Global --yes / STANDX_AUTO_CONFIRM: the single confirmation source.
     assume_yes: bool,
+    endpoint_override: Option<&str>,
+    config_path: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let endpoints = command_uses_perps_endpoint(&command)
+        .then(|| standx_cli::config::Config::resolve_endpoints(endpoint_override, config_path))
+        .transpose()?;
+
     match command {
         Commands::Config { command } => {
-            commands::handle_config(command, output).await?;
+            commands::handle_config(command, output, config_path).await?;
         }
         Commands::Auth { command } => {
             commands::handle_auth(command).await?;
         }
         Commands::Market { command } => {
-            commands::handle_market(command, output).await?;
+            commands::handle_market(
+                command,
+                output,
+                endpoints.as_ref().expect("market uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Account { command } => {
-            commands::handle_account(command, output).await?;
+            commands::handle_account(
+                command,
+                output,
+                endpoints.as_ref().expect("account uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Order { command } => {
-            commands::handle_order(command, output, verbose).await?;
+            commands::handle_order(
+                command,
+                output,
+                verbose,
+                endpoints.as_ref().expect("order uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Trade { command } => {
-            commands::handle_trade(command, output).await?;
+            commands::handle_trade(
+                command,
+                output,
+                endpoints.as_ref().expect("trade uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Leverage { command } => {
-            commands::handle_leverage(command, output).await?;
+            commands::handle_leverage(
+                command,
+                output,
+                endpoints.as_ref().expect("leverage uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Margin { command } => {
-            commands::handle_margin(command).await?;
+            commands::handle_margin(
+                command,
+                endpoints.as_ref().expect("margin uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Stream { command } => {
-            commands::handle_stream(command, verbose).await?;
+            commands::handle_stream(
+                command,
+                verbose,
+                endpoints.as_ref().expect("stream uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Dashboard {
             symbols,
@@ -270,24 +320,49 @@ async fn execute_command(
             watch,
             compact,
         } => {
-            commands::handle_dashboard(symbols, verbose, watch, compact, output).await?;
+            commands::handle_dashboard(
+                symbols,
+                verbose,
+                watch,
+                compact,
+                output,
+                endpoints.as_ref().expect("dashboard uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Portfolio { verbose, watch } => {
             let command = commands::PortfolioCommand::Snapshot {
                 _verbose: verbose,
                 watch,
             };
-            commands::handle_portfolio(command, output).await?;
+            commands::handle_portfolio(
+                command,
+                output,
+                endpoints.as_ref().expect("portfolio uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Block { command } => {
-            commands::handle_block(command, output).await?;
+            commands::handle_block(
+                command,
+                output,
+                endpoints.as_ref().expect("block uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Maker { command } => {
             // anyhow flattens the concrete error type when it is boxed into a
             // `Box<dyn Error>`, so downcast the fail-safe marker here (where the
             // original `anyhow::Error` is still intact) and re-box it concretely
             // so `exit_code_for` can recognise it and pick the fail-safe code.
-            if let Err(err) = commands::handle_maker(*command, output, verbose).await {
+            if let Err(err) = commands::handle_maker(
+                *command,
+                output,
+                verbose,
+                endpoints.as_ref().expect("maker uses perps endpoint"),
+            )
+            .await
+            {
                 return Err(match err.downcast::<FailSafeShutdown>() {
                     Ok(fail_safe) => Box::new(fail_safe) as Box<dyn std::error::Error>,
                     Err(other) => other.into(),
@@ -301,8 +376,18 @@ async fn execute_command(
             flush_secs,
             status_secs,
         } => {
-            commands::handle_lag_recorder(symbol, hl_coin, out, flush_secs, status_secs, verbose)
-                .await?;
+            commands::handle_lag_recorder(
+                symbol,
+                hl_coin,
+                out,
+                flush_secs,
+                status_secs,
+                verbose,
+                endpoints
+                    .as_ref()
+                    .expect("lag-recorder uses perps endpoint"),
+            )
+            .await?;
         }
         Commands::Update { check, pre, force } => {
             // Confirmation comes from the single global --yes / STANDX_AUTO_CONFIRM.
@@ -310,6 +395,13 @@ async fn execute_command(
         }
     }
     Ok(())
+}
+
+fn command_uses_perps_endpoint(command: &Commands) -> bool {
+    !matches!(
+        command,
+        Commands::Config { .. } | Commands::Auth { .. } | Commands::Update { .. }
+    )
 }
 
 /// Handle dry run mode - show what would be executed

--- a/crates/standx-cli/src/main.rs
+++ b/crates/standx-cli/src/main.rs
@@ -251,6 +251,15 @@ async fn execute_command(
         .then(|| standx_cli::config::Config::resolve_endpoints(endpoint_override, config_path))
         .transpose()?;
 
+    // `market` is the only perps-endpoint command that never loads credentials;
+    // everything else attaches the JWT (and, for order/maker, the signing key).
+    // Refuse to send those over plain HTTP/WS to an unconfirmed local listener.
+    if let Some(endpoints) = endpoints.as_ref() {
+        if !matches!(command, Commands::Market { .. }) {
+            standx_cli::config::ensure_authenticated_endpoint_is_secure(endpoints)?;
+        }
+    }
+
     match command {
         Commands::Config { command } => {
             commands::handle_config(command, output, config_path).await?;

--- a/crates/standx-cli/src/telemetry.rs
+++ b/crates/standx-cli/src/telemetry.rs
@@ -215,7 +215,13 @@ impl Telemetry {
 /// Redact secrets from CLI argv while preserving the flag names needed for
 /// aggregate usage analysis. Handles both `--flag value` and `--flag=value`.
 fn sanitize_args(args: &[String]) -> Vec<String> {
-    const SENSITIVE_FLAGS: &[&str] = &["--private-key", "--token", "--alert-webhook", "-p"];
+    const SENSITIVE_FLAGS: &[&str] = &[
+        "--private-key",
+        "--token",
+        "--alert-webhook",
+        "--endpoint",
+        "-p",
+    ];
 
     let mut sanitized = Vec::with_capacity(args.len());
     let mut redact_next = false;
@@ -305,6 +311,8 @@ mod tests {
             "https://api.telegram.org/bot-secret/sendMessage".to_string(),
             "--token".to_string(),
             "jwt-secret".to_string(),
+            "--endpoint".to_string(),
+            "https://alice:endpoint-secret@example.com".to_string(),
         ];
 
         let sanitized = sanitize_args(&args);
@@ -312,6 +320,8 @@ mod tests {
         assert_eq!(sanitized[5], "***");
         assert_eq!(sanitized[6], "--token");
         assert_eq!(sanitized[7], "***");
+        assert_eq!(sanitized[8], "--endpoint");
+        assert_eq!(sanitized[9], "***");
         assert!(!sanitized.join(" ").contains("secret"));
     }
 
@@ -323,6 +333,7 @@ mod tests {
             "login".to_string(),
             "--private-key=private-secret".to_string(),
             "--alert-webhook=https://hooks.example/secret".to_string(),
+            "--endpoint=https://alice:endpoint-secret@example.com".to_string(),
             "--output=json".to_string(),
         ];
 
@@ -334,6 +345,7 @@ mod tests {
                 "login",
                 "--private-key=***",
                 "--alert-webhook=***",
+                "--endpoint=***",
                 "--output=json",
             ]
         );

--- a/crates/standx-cli/tests/integration/api_flows.rs
+++ b/crates/standx-cli/tests/integration/api_flows.rs
@@ -1,7 +1,9 @@
 //! API Flow Integration Tests
 //! Tests API workflows using mock servers
 
+use assert_cmd::cargo::cargo_bin_cmd;
 use mockito::Server;
+use predicates::str::contains;
 use standx_cli::client::StandXClient;
 
 #[tokio::test]
@@ -52,4 +54,33 @@ async fn test_api_error_handling_flow() {
     // Should handle 401 gracefully
     let result = client.get_positions(None).await;
     assert!(result.is_err());
+}
+
+#[test]
+fn cli_endpoint_override_routes_market_request_to_loopback() {
+    let mut server = Server::new();
+    let symbols = server
+        .mock("GET", "/api/query_symbol_info")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"[{"symbol":"MOCK-USD","base_asset":"MOCK","quote_asset":"DUSD","base_decimals":9,"price_tick_decimals":2,"qty_tick_decimals":4,"min_order_qty":"0.0001","def_leverage":"10","max_leverage":"40","maker_fee":"0.0001","taker_fee":"0.0004","status":"trading"}]"#,
+        )
+        .expect(1)
+        .create();
+
+    let mut command = cargo_bin_cmd!("standx");
+    command.args([
+        "--endpoint",
+        &server.url(),
+        "--output",
+        "json",
+        "market",
+        "symbols",
+    ]);
+    command
+        .assert()
+        .success()
+        .stdout(contains("\"symbol\": \"MOCK-USD\""));
+    symbols.assert();
 }

--- a/crates/standx-sdk/README.md
+++ b/crates/standx-sdk/README.md
@@ -102,6 +102,22 @@ let order = client
 println!("order id: {}", order.id);
 ```
 
+### Custom StandX endpoints
+
+`StandXEndpoints` validates one root base URL and derives the matching REST,
+market/account WebSocket, and order-response WebSocket addresses:
+
+```rust
+use standx_sdk::{StandXClient, StandXEndpoints};
+
+let endpoints = StandXEndpoints::new("https://canary-perps.standx.org")?;
+let client = StandXClient::from_endpoints(&endpoints)?;
+```
+
+The existing no-argument constructors keep using production. Custom plaintext
+HTTP is accepted only for localhost or loopback test servers; invalid custom
+configuration returns an error rather than falling back.
+
 ### `auth` — credentials and signing
 
 - `Credentials` — load from env (`STANDX_JWT` / `STANDX_PRIVATE_KEY`) or the

--- a/crates/standx-sdk/README.md
+++ b/crates/standx-sdk/README.md
@@ -110,7 +110,7 @@ market/account WebSocket, and order-response WebSocket addresses:
 ```rust
 use standx_sdk::{StandXClient, StandXEndpoints};
 
-let endpoints = StandXEndpoints::new("https://canary-perps.standx.org")?;
+let endpoints = StandXEndpoints::new("https://perps.example.com")?;
 let client = StandXClient::from_endpoints(&endpoints)?;
 ```
 

--- a/crates/standx-sdk/src/account_stream.rs
+++ b/crates/standx-sdk/src/account_stream.rs
@@ -1,6 +1,7 @@
 //! Authenticated user order, position, and trade notifications.
 
 use crate::auth::Credentials;
+use crate::endpoints::StandXEndpoints;
 use crate::error::{Error, Result};
 use crate::models::{deserialize_order_side_optional, OrderSide, OrderStatus};
 use futures::{SinkExt, StreamExt};
@@ -13,7 +14,6 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-const DEFAULT_ACCOUNT_STREAM_URL: &str = "wss://perps.standx.com/ws-stream/v1";
 const ACCOUNT_STREAM_ROTATE_AFTER: Duration = Duration::from_secs(23 * 60 * 60 + 50 * 60);
 /// How often we send a client-side ping to keep the connection observably
 /// alive and to elicit a pong (which resets the idle deadline).
@@ -260,6 +260,10 @@ pub struct AccountStream {
 
 impl AccountStream {
     pub fn new(epoch: u64) -> Result<Self> {
+        Self::from_endpoints(epoch, &StandXEndpoints::default())
+    }
+
+    pub fn from_endpoints(epoch: u64, endpoints: &StandXEndpoints) -> Result<Self> {
         let credentials = Credentials::load()?;
         if credentials.is_expired() {
             return Err(Error::AuthRequired {
@@ -268,7 +272,7 @@ impl AccountStream {
             });
         }
         Ok(Self {
-            url: DEFAULT_ACCOUNT_STREAM_URL.to_string(),
+            url: endpoints.stream_url().to_string(),
             token: credentials.token,
             epoch,
             ping_interval: ACCOUNT_STREAM_PING_INTERVAL,

--- a/crates/standx-sdk/src/client/mod.rs
+++ b/crates/standx-sdk/src/client/mod.rs
@@ -4,6 +4,7 @@ pub mod account;
 pub mod order;
 
 use crate::auth::{Credentials, StandXSigner};
+use crate::endpoints::StandXEndpoints;
 use crate::error::{Error, Result};
 use crate::models::*;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
@@ -12,8 +13,6 @@ use reqwest::{Client, ClientBuilder};
 use std::time::Duration;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
-const DEFAULT_BASE_URL: &str = "https://perps.standx.com";
-
 /// StandX API client
 #[derive(Debug, Clone)]
 pub struct StandXClient {
@@ -25,6 +24,11 @@ pub struct StandXClient {
 impl StandXClient {
     /// Create a new client
     pub fn new() -> Result<Self> {
+        Self::from_endpoints(&StandXEndpoints::default())
+    }
+
+    /// Create a new client from a validated StandX endpoint set.
+    pub fn from_endpoints(endpoints: &StandXEndpoints) -> Result<Self> {
         let client = ClientBuilder::new()
             .timeout(DEFAULT_TIMEOUT)
             .connect_timeout(Duration::from_secs(10))
@@ -32,23 +36,14 @@ impl StandXClient {
 
         Ok(Self {
             client,
-            base_url: DEFAULT_BASE_URL.to_string(),
+            base_url: endpoints.base_url().to_string(),
             session_id: None,
         })
     }
 
     /// Create a new client with custom base URL
     pub fn with_base_url(base_url: String) -> Result<Self> {
-        let client = ClientBuilder::new()
-            .timeout(DEFAULT_TIMEOUT)
-            .connect_timeout(Duration::from_secs(10))
-            .build()?;
-
-        Ok(Self {
-            client,
-            base_url,
-            session_id: None,
-        })
+        Self::from_endpoints(&StandXEndpoints::new(base_url)?)
     }
 
     /// Get the base URL

--- a/crates/standx-sdk/src/endpoints.rs
+++ b/crates/standx-sdk/src/endpoints.rs
@@ -1,0 +1,177 @@
+//! Validated StandX REST and WebSocket endpoint selection.
+
+use crate::error::{Error, Result};
+use std::net::IpAddr;
+use url::{Host, Url};
+
+pub const DEFAULT_BASE_URL: &str = "https://perps.standx.com";
+
+/// All StandX transport endpoints derived from one REST base URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StandXEndpoints {
+    base_url: String,
+    stream_url: String,
+    order_response_url: String,
+}
+
+impl Default for StandXEndpoints {
+    fn default() -> Self {
+        Self::new(DEFAULT_BASE_URL).expect("the production endpoint must be valid")
+    }
+}
+
+impl StandXEndpoints {
+    /// Validate a root-level HTTP(S) base URL and derive its WebSocket URLs.
+    pub fn new(base_url: impl AsRef<str>) -> Result<Self> {
+        let raw = base_url.as_ref().trim();
+        let mut parsed = Url::parse(raw).map_err(|error| endpoint_error(error.to_string()))?;
+
+        if parsed.host_str().is_none() {
+            return Err(endpoint_error("a host is required"));
+        }
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            return Err(endpoint_error("userinfo is not allowed"));
+        }
+        if parsed.query().is_some() {
+            return Err(endpoint_error("query parameters are not allowed"));
+        }
+        if parsed.fragment().is_some() {
+            return Err(endpoint_error("fragments are not allowed"));
+        }
+        if !matches!(parsed.path(), "" | "/") {
+            return Err(endpoint_error("the base URL path must be empty or '/'"));
+        }
+
+        match parsed.scheme() {
+            "https" => {}
+            "http" if is_loopback(&parsed) => {}
+            "http" => {
+                return Err(endpoint_error(
+                    "plain HTTP is allowed only for localhost or loopback addresses",
+                ));
+            }
+            _ => {
+                return Err(endpoint_error(
+                    "scheme must be https (or http for loopback testing)",
+                ));
+            }
+        }
+
+        parsed.set_path("");
+        let base_url = parsed.as_str().trim_end_matches('/').to_string();
+        let ws_scheme = if parsed.scheme() == "https" {
+            "wss"
+        } else {
+            "ws"
+        };
+        parsed
+            .set_scheme(ws_scheme)
+            .map_err(|_| endpoint_error("could not derive WebSocket scheme"))?;
+
+        parsed.set_path("/ws-stream/v1");
+        let stream_url = parsed.to_string();
+        parsed.set_path("/ws-api/v1");
+        let order_response_url = parsed.to_string();
+
+        Ok(Self {
+            base_url,
+            stream_url,
+            order_response_url,
+        })
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn stream_url(&self) -> &str {
+        &self.stream_url
+    }
+
+    pub fn order_response_url(&self) -> &str {
+        &self.order_response_url
+    }
+}
+
+fn is_loopback(url: &Url) -> bool {
+    match url.host() {
+        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => IpAddr::V4(address).is_loopback(),
+        Some(Host::Ipv6(address)) => IpAddr::V6(address).is_loopback(),
+        None => false,
+    }
+}
+
+fn endpoint_error(detail: impl std::fmt::Display) -> Error {
+    Error::Config {
+        message: format!("invalid StandX endpoint: {detail}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_production_and_canary_transport_urls() {
+        let production = StandXEndpoints::default();
+        assert_eq!(production.base_url(), "https://perps.standx.com");
+        assert_eq!(
+            production.stream_url(),
+            "wss://perps.standx.com/ws-stream/v1"
+        );
+        assert_eq!(
+            production.order_response_url(),
+            "wss://perps.standx.com/ws-api/v1"
+        );
+
+        let canary = StandXEndpoints::new("https://canary-perps.standx.org/").unwrap();
+        assert_eq!(canary.base_url(), "https://canary-perps.standx.org");
+        assert_eq!(
+            canary.stream_url(),
+            "wss://canary-perps.standx.org/ws-stream/v1"
+        );
+        assert_eq!(
+            canary.order_response_url(),
+            "wss://canary-perps.standx.org/ws-api/v1"
+        );
+    }
+
+    #[test]
+    fn permits_plain_http_only_for_loopback_testing() {
+        let ipv4 = StandXEndpoints::new("http://127.0.0.1:8080").unwrap();
+        assert_eq!(ipv4.stream_url(), "ws://127.0.0.1:8080/ws-stream/v1");
+
+        let ipv6 = StandXEndpoints::new("http://[::1]:8080/").unwrap();
+        assert_eq!(ipv6.order_response_url(), "ws://[::1]:8080/ws-api/v1");
+
+        let localhost = StandXEndpoints::new("http://localhost:8080").unwrap();
+        assert_eq!(localhost.base_url(), "http://localhost:8080");
+
+        assert!(StandXEndpoints::new("http://example.com").is_err());
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_credential_bearing_urls() {
+        for value in [
+            "",
+            "canary-perps.standx.org",
+            "ftp://example.com",
+            "https://user@example.com",
+            "https://example.com/api",
+            "https://example.com?env=canary",
+            "https://example.com/#fragment",
+        ] {
+            assert!(StandXEndpoints::new(value).is_err(), "{value} must fail");
+        }
+    }
+
+    #[test]
+    fn validation_errors_never_echo_endpoint_secrets() {
+        let secret = "endpoint-secret";
+        let error =
+            StandXEndpoints::new(format!("https://alice:{secret}@example.com")).unwrap_err();
+        assert!(!error.to_string().contains(secret));
+        assert!(error.to_string().contains("userinfo is not allowed"));
+    }
+}

--- a/crates/standx-sdk/src/endpoints.rs
+++ b/crates/standx-sdk/src/endpoints.rs
@@ -113,7 +113,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn derives_production_and_canary_transport_urls() {
+    fn derives_production_and_custom_transport_urls() {
         let production = StandXEndpoints::default();
         assert_eq!(production.base_url(), "https://perps.standx.com");
         assert_eq!(
@@ -125,15 +125,12 @@ mod tests {
             "wss://perps.standx.com/ws-api/v1"
         );
 
-        let canary = StandXEndpoints::new("https://canary-perps.standx.org/").unwrap();
-        assert_eq!(canary.base_url(), "https://canary-perps.standx.org");
+        let custom = StandXEndpoints::new("https://perps.example.com/").unwrap();
+        assert_eq!(custom.base_url(), "https://perps.example.com");
+        assert_eq!(custom.stream_url(), "wss://perps.example.com/ws-stream/v1");
         assert_eq!(
-            canary.stream_url(),
-            "wss://canary-perps.standx.org/ws-stream/v1"
-        );
-        assert_eq!(
-            canary.order_response_url(),
-            "wss://canary-perps.standx.org/ws-api/v1"
+            custom.order_response_url(),
+            "wss://perps.example.com/ws-api/v1"
         );
     }
 
@@ -155,7 +152,7 @@ mod tests {
     fn rejects_ambiguous_or_credential_bearing_urls() {
         for value in [
             "",
-            "canary-perps.standx.org",
+            "perps.example.com",
             "ftp://example.com",
             "https://user@example.com",
             "https://example.com/api",

--- a/crates/standx-sdk/src/endpoints.rs
+++ b/crates/standx-sdk/src/endpoints.rs
@@ -91,6 +91,13 @@ impl StandXEndpoints {
     pub fn order_response_url(&self) -> &str {
         &self.order_response_url
     }
+
+    /// Whether every derived transport (REST, account-stream, order-response) is
+    /// TLS-protected. `new` ties the WS/WSS scheme to the REST scheme, so the
+    /// base URL alone determines this for the whole set.
+    pub fn is_secure(&self) -> bool {
+        self.base_url.starts_with("https://")
+    }
 }
 
 fn is_loopback(url: &Url) -> bool {
@@ -138,6 +145,7 @@ mod tests {
     fn permits_plain_http_only_for_loopback_testing() {
         let ipv4 = StandXEndpoints::new("http://127.0.0.1:8080").unwrap();
         assert_eq!(ipv4.stream_url(), "ws://127.0.0.1:8080/ws-stream/v1");
+        assert!(!ipv4.is_secure());
 
         let ipv6 = StandXEndpoints::new("http://[::1]:8080/").unwrap();
         assert_eq!(ipv6.order_response_url(), "ws://[::1]:8080/ws-api/v1");
@@ -146,6 +154,17 @@ mod tests {
         assert_eq!(localhost.base_url(), "http://localhost:8080");
 
         assert!(StandXEndpoints::new("http://example.com").is_err());
+    }
+
+    #[test]
+    fn is_secure_reflects_the_rest_scheme() {
+        assert!(StandXEndpoints::default().is_secure());
+        assert!(StandXEndpoints::new("https://perps.example.com")
+            .unwrap()
+            .is_secure());
+        assert!(!StandXEndpoints::new("http://127.0.0.1:8080")
+            .unwrap()
+            .is_secure());
     }
 
     #[test]

--- a/crates/standx-sdk/src/error.rs
+++ b/crates/standx-sdk/src/error.rs
@@ -59,7 +59,7 @@ pub enum Error {
         retry_after: Option<u64>,
     },
 
-    #[error("Configuration error")]
+    #[error("Configuration error: {message}")]
     #[serde(rename = "CONFIG_ERROR")]
     Config { message: String },
 

--- a/crates/standx-sdk/src/lib.rs
+++ b/crates/standx-sdk/src/lib.rs
@@ -40,9 +40,11 @@
 pub mod account_stream;
 pub mod auth;
 pub mod client;
+pub mod endpoints;
 pub mod error;
 pub mod models;
 pub mod order_response;
 pub mod websocket;
 
+pub use endpoints::StandXEndpoints;
 pub use error::{Error, Result};

--- a/crates/standx-sdk/src/order_response.rs
+++ b/crates/standx-sdk/src/order_response.rs
@@ -2,6 +2,7 @@
 
 use crate::auth::{Credentials, StandXSigner};
 use crate::client::order::{cancel_order_body, create_order_body, CreateOrderParams};
+use crate::endpoints::StandXEndpoints;
 use crate::error::{Error, Result};
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -14,7 +15,6 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-const DEFAULT_ORDER_RESPONSE_URL: &str = "wss://perps.standx.com/ws-api/v1";
 const ORDER_RESPONSE_ROTATE_AFTER: Duration = Duration::from_secs(23 * 60 * 60 + 50 * 60);
 const ORDER_RESPONSE_PING_INTERVAL: Duration = Duration::from_secs(30);
 /// A healthy server sends a ping about every 10 seconds; a longer silent
@@ -229,6 +229,14 @@ impl OrderResponseHealth {
 impl OrderResponseStream {
     /// Construct a production stream from the currently-loaded credentials.
     pub fn new(session_id: impl Into<String>) -> Result<Self> {
+        Self::from_endpoints(session_id, &StandXEndpoints::default())
+    }
+
+    /// Construct a stream for a validated endpoint set.
+    pub fn from_endpoints(
+        session_id: impl Into<String>,
+        endpoints: &StandXEndpoints,
+    ) -> Result<Self> {
         let credentials = Credentials::load()?;
         if credentials.is_expired() {
             return Err(Error::AuthRequired {
@@ -239,7 +247,7 @@ impl OrderResponseStream {
         }
 
         Ok(Self {
-            url: DEFAULT_ORDER_RESPONSE_URL.to_string(),
+            url: endpoints.order_response_url().to_string(),
             token: credentials.token,
             signer: (!credentials.private_key.is_empty())
                 .then(|| StandXSigner::from_base58(&credentials.private_key))

--- a/crates/standx-sdk/src/websocket.rs
+++ b/crates/standx-sdk/src/websocket.rs
@@ -1,6 +1,7 @@
 //! WebSocket client for real-time data
 
 use crate::auth::Credentials;
+use crate::endpoints::StandXEndpoints;
 use crate::error::{Error, Result};
 use crate::models::*;
 use futures::{SinkExt, StreamExt};
@@ -11,7 +12,6 @@ use tokio::sync::{mpsc, RwLock};
 use tokio::task::JoinHandle;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-const DEFAULT_WS_URL: &str = "wss://perps.standx.com/ws-stream/v1";
 const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 const RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 
@@ -128,6 +128,16 @@ impl StandXWebSocket {
 
     /// Create a new WebSocket client with verbose mode
     pub fn new_with_verbose(verbose: bool) -> Result<Self> {
+        Self::from_endpoints_with_verbose(&StandXEndpoints::default(), verbose)
+    }
+
+    /// Create an authenticated client for a validated endpoint set.
+    pub fn from_endpoints(endpoints: &StandXEndpoints) -> Result<Self> {
+        Self::from_endpoints_with_verbose(endpoints, false)
+    }
+
+    /// Create an authenticated client for a validated endpoint set.
+    pub fn from_endpoints_with_verbose(endpoints: &StandXEndpoints, verbose: bool) -> Result<Self> {
         let creds = Credentials::load()?;
 
         if creds.is_expired() {
@@ -141,7 +151,7 @@ impl StandXWebSocket {
         let (message_tx, message_rx) = mpsc::channel(100);
 
         Ok(Self {
-            url: DEFAULT_WS_URL.to_string(),
+            url: endpoints.stream_url().to_string(),
             token: Some(creds.token),
             state: Arc::new(RwLock::new(WsState::Disconnected)),
             subscriptions: Arc::new(RwLock::new(Vec::new())),
@@ -161,10 +171,23 @@ impl StandXWebSocket {
 
     /// Create without authentication with verbose mode
     pub fn without_auth_with_verbose(verbose: bool) -> Result<Self> {
+        Self::without_auth_from_endpoints_with_verbose(&StandXEndpoints::default(), verbose)
+    }
+
+    /// Create an unauthenticated client for a validated endpoint set.
+    pub fn without_auth_from_endpoints(endpoints: &StandXEndpoints) -> Result<Self> {
+        Self::without_auth_from_endpoints_with_verbose(endpoints, false)
+    }
+
+    /// Create an unauthenticated client for a validated endpoint set.
+    pub fn without_auth_from_endpoints_with_verbose(
+        endpoints: &StandXEndpoints,
+        verbose: bool,
+    ) -> Result<Self> {
         let (message_tx, message_rx) = mpsc::channel(100);
 
         Ok(Self {
-            url: DEFAULT_WS_URL.to_string(),
+            url: endpoints.stream_url().to_string(),
             token: None,
             state: Arc::new(RwLock::new(WsState::Disconnected)),
             subscriptions: Arc::new(RwLock::new(Vec::new())),

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -153,7 +153,7 @@ Configuration:
 standx config set default_symbol ETH-USD
 
 # 持久化 StandX API endpoint（写入前会校验并规范化）
-standx config set base_url https://canary-perps.standx.org
+standx config set base_url https://perps.example.com
 
 # 验证
 standx config get default_symbol

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -105,6 +105,8 @@ Commands:
 
 Options:
   -c, --config <CONFIG>    Configuration file path
+      --endpoint <BASE_URL>
+                           StandX REST/WebSocket base URL
   -o, --output <OUTPUT>    Output format [default: table] [possible values: table, json, csv, quiet]
   -v, --verbose            Verbose output
   -q, --quiet              Quiet mode
@@ -150,10 +152,18 @@ Configuration:
 # 设置默认交易对
 standx config set default_symbol ETH-USD
 
+# 持久化 StandX API endpoint（写入前会校验并规范化）
+standx config set base_url https://canary-perps.standx.org
+
 # 验证
 standx config get default_symbol
 # 输出: ETH-USD
 ```
+
+`--config` 可以指向配置文件或配置目录。Endpoint 优先级为：
+`--endpoint` > `STANDX_BASE_URL` > 配置文件中的 `base_url` > 生产默认值。
+根级 HTTPS base 会自动推导 `/ws-stream/v1` 和 `/ws-api/v1`；无效值会直接
+报错，不会回退到生产环境。仅本地 loopback 测试允许明文 HTTP。
 
 ---
 

--- a/docs/05-orders.md
+++ b/docs/05-orders.md
@@ -117,6 +117,19 @@ standx --output json --verbose order create BTC-USD buy limit \
   --transport ws
 ```
 
+要让同一次调用中的 REST、账户/行情 WS 和订单 WS 全部进入 canary，可指定全局
+endpoint：
+
+```bash
+standx --endpoint https://canary-perps.standx.org \
+  --output json --verbose \
+  order create BTC-USD buy limit \
+  --qty 0.0001 --price 60000 --transport ws
+```
+
+自定义 endpoint 仍使用当前 JWT 和签名私钥；凭证不适用时会返回认证错误，并且
+不会降级到生产环境。
+
 标准输出是稳定的结构化结果：
 
 ```json

--- a/docs/05-orders.md
+++ b/docs/05-orders.md
@@ -117,11 +117,11 @@ standx --output json --verbose order create BTC-USD buy limit \
   --transport ws
 ```
 
-要让同一次调用中的 REST、账户/行情 WS 和订单 WS 全部进入 canary，可指定全局
+要让同一次调用中的 REST、账户/行情 WS 和订单 WS 全部进入自定义环境，可指定全局
 endpoint：
 
 ```bash
-standx --endpoint https://canary-perps.standx.org \
+standx --endpoint https://perps.example.com \
   --output json --verbose \
   order create BTC-USD buy limit \
   --qty 0.0001 --price 60000 --transport ws


### PR DESCRIPTION
## Summary

- add a validated global `--endpoint <BASE_URL>` with CLI > `STANDX_BASE_URL` > config > production precedence
- derive and consistently route REST, market/account WebSocket, and order-response WebSocket connections through one `StandXEndpoints` value
- apply the selected endpoint to market/account/order/maker/dashboard/lag-recorder flows, including maker reconnect and cleanup paths
- support both config files and config directories, with normalized `config set base_url` validation

## Safety and compatibility

- preserve existing no-argument SDK constructors and production defaults
- fail closed for invalid endpoints and explicitly selected missing config; never fall back to production
- redact `--endpoint` values from local telemetry and avoid echoing credential-bearing invalid URLs
- keep auth services, update downloads, and the Hyperliquid feed unchanged
- no custom-environment or production order was submitted during this change

## Validation

- `HOME=/tmp/standx-test-home CARGO_HOME=/Users/junlin/.cargo RUSTUP_HOME=/Users/junlin/.rustup cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --offline -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 -m py_compile scripts/openobserve_dashboard.py`
- local loopback REST and authenticated signed order WebSocket tests
- mutation checks for endpoint precedence, no fallback, missing config, and endpoint-secret redaction
- independent adversarial review; two reproducible Major findings fixed and re-reviewed with no remaining Critical/Major findings
- public read-only custom-endpoint smoke test completed successfully
