### PR TITLE
fix(scripts): supervisor notify() 只发飞书格式

### DIFF
--- a/scripts/run_maker_observed.sh
+++ b/scripts/run_maker_observed.sh
@@ -74,9 +74,12 @@ notify() {
     # Escape backslashes and double quotes so the message is valid JSON.
     local escaped="${message//\\/\\\\}"
     escaped="${escaped//\"/\\\"}"
+    # Feishu custom bot only. The Slack shape gets `{"code":19002,"msg":
+    # "params error, msg_type need"}` at HTTP 200, which curl -f cannot see —
+    # the notice would vanish silently.
     curl -fsS -m 5 -X POST \
       -H 'Content-Type: application/json' \
-      --data "{\"text\":\"$escaped\"}" \
+      --data "{\"msg_type\":\"text\",\"content\":{\"text\":\"$escaped\"}}" \
       "$STANDX_SUPERVISOR_WEBHOOK" >/dev/null 2>&1 ||
       printf 'supervisor webhook post failed (message logged above)\n' >&2
   fi


### PR DESCRIPTION
前置检查 webhook 实测时发现：飞书自定义机器人对 Slack 形状的 `{"text":...}` 返回 HTTP 200 + `{"code":19002,"msg":"params error, msg_type need"}`，`curl -f` 无法识别——wrapper 的 uploader died/relaunched 通知会被静默丢弃。

按 owner 决定去掉 Slack 分支：`notify()` 固定发 Feishu `msg_type=text`。已在 maker-dev 群用 lark-cli 双向验证（错误格式不落群、feishu 格式落群）。