### PR TITLE
fix(maker): 两帧 cancel ack 不再击穿 fail-closed（07-30 事故修复）

### DIFF
--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -597,7 +597,10 @@ enum CleanupVerification {
 /// Result of draining the order-response stream for cleanup-minted cancel acks.
 #[derive(Debug)]
 struct WsCancelDrain {
-    /// Orders whose cancel ack carried the venue's terminal `success`.
+    /// Orders whose cancel ack carried the venue's terminal `success`. Under
+    /// the venue's observed two-frame behavior (gateway `accepted` first) the
+    /// drain usually releases the ID on that first frame, so in practice this
+    /// list stays empty and the REST point query is the common verdict path.
     confirmed: Vec<(String, i64)>,
     /// Orders that still need the REST verdict: the ack was not `success`
     /// (gateway-level `accepted` or a rejection), or never arrived in time.

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -376,6 +376,7 @@ fn cleanup_orders_json(snapshots: &[OrderStatusSnapshot]) -> Vec<serde_json::Val
                 "status": format!("{:?}", s.status).to_lowercase(),
                 "updated_at": s.updated_at,
                 "confirmed_by": s.confirmed_by,
+                "ws_request_id": s.ws_request_id,
             })
         })
         .collect()
@@ -571,6 +572,11 @@ struct OrderStatusSnapshot {
     /// `success` ack (`"ws_success"`) or the REST `/api/query_order` point
     /// query (`"query_order"`).
     confirmed_by: &'static str,
+    /// The cleanup-minted WS cancel request ID for this order, when the WS
+    /// phase ran. Recorded so a later two-frame ack can be tied back to the
+    /// cancel that minted it — the 07-30 incident was only inferable because
+    /// this link was missing from the telemetry.
+    ws_request_id: Option<String>,
 }
 
 /// Outcome of a single cleanup verification pass.
@@ -599,19 +605,28 @@ struct WsCancelDrain {
     /// Responses for request IDs the cleanup did not mint (pre-freeze cycle
     /// requests); ownership returns to the caller.
     leftover: Vec<OrderResponse>,
+    /// Frames dropped because their request ID is an earlier cleanup-minted
+    /// cancel (e.g. the terminal half of a two-frame ack arriving in a later
+    /// attempt's drain). Diagnostic only.
+    tombstoned: usize,
     /// The response channel closed mid-drain; the caller marks it unhealthy.
     channel_closed: bool,
+    /// Every cancel actually put on the wire, as `(order_id, request_id)`, so
+    /// the telemetry can tie a WS attempt to its request ID.
+    attempts: Vec<(i64, String)>,
 }
 
 async fn drain_ws_cancel_responses(
     responses: &mut tokio::sync::mpsc::Receiver<OrderResponse>,
     pending: &mut HashMap<String, (String, i64)>,
+    minted: &CleanupTombstones,
     timeout: Duration,
 ) -> WsCancelDrain {
     let deadline = tokio::time::Instant::now() + timeout;
     let mut confirmed = Vec::new();
     let mut unresolved = Vec::new();
     let mut leftover = Vec::new();
+    let mut tombstoned = 0_usize;
     let mut channel_closed = false;
     while !pending.is_empty() {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -635,7 +650,22 @@ async fn drain_ws_cancel_responses(
                             unresolved.push(order);
                         }
                     }
-                    None => leftover.push(response),
+                    None => {
+                        // A frame for a cancel the cleanup itself minted in an
+                        // earlier attempt or round (the terminal half of a
+                        // two-frame ack arrives after that attempt's pending
+                        // map was released): the venue state was already
+                        // established through `/api/query_order`, so the frame
+                        // is informational only. Forwarding it as leftover
+                        // would fail the replay closed on an `Orphan` — this is
+                        // what stopped run `baseline-pnl-20260730T153920Z`.
+                        match response.request_id.as_deref() {
+                            Some(request_id) if minted.covers(request_id) => {
+                                tombstoned += 1;
+                            }
+                            _ => leftover.push(response),
+                        }
+                    }
                 }
             }
             Ok(None) => {
@@ -656,7 +686,9 @@ async fn drain_ws_cancel_responses(
         confirmed,
         unresolved,
         leftover,
+        tombstoned,
         channel_closed,
+        attempts: Vec::new(),
     }
 }
 
@@ -673,6 +705,7 @@ async fn ws_cancel_orders(
 ) -> WsCancelDrain {
     let mut pending: HashMap<String, (String, i64)> = HashMap::new();
     let mut unsent: Vec<(String, i64)> = Vec::new();
+    let mut attempts: Vec<(i64, String)> = Vec::new();
     let mut send_failed = false;
     for (id_str, id_i64) in orders {
         if send_failed {
@@ -702,11 +735,13 @@ async fn ws_cancel_orders(
         // the window would otherwise reach the runtime drain as an unknown
         // request ID and fail the run closed.
         ctx.minted.remember(request_id.clone());
+        attempts.push((id_i64, request_id.clone()));
         pending.insert(request_id, (id_str, id_i64));
     }
     let mut drain = drain_ws_cancel_responses(
         ctx.responses,
         &mut pending,
+        ctx.minted,
         MAKER_CLEANUP_WS_RESPONSE_TIMEOUT,
     )
     .await;
@@ -714,11 +749,18 @@ async fn ws_cancel_orders(
         ctx.health
             .mark_unhealthy("order-response channel closed during cleanup".to_string());
     }
+    if drain.tombstoned > 0 {
+        eprintln!(
+            "cleanup WS drain dropped {} cleanup-minted frame(s) (two-frame ack terminal halves)",
+            drain.tombstoned
+        );
+    }
     // Handed over immediately so the frames outlive any later failure in this
     // cleanup attempt.
     ctx.leftover.append(&mut drain.leftover);
     drain.unresolved.extend(unsent);
     drain.unresolved.sort_by_key(|(_, id)| *id);
+    drain.attempts = attempts;
     drain
 }
 
@@ -740,6 +782,7 @@ async fn query_order_status(client: &StandXClient, id: &str) -> Result<OrderStat
         status: order.status,
         updated_at: order.updated_at,
         confirmed_by: "query_order",
+        ws_request_id: None,
     })
 }
 
@@ -771,6 +814,13 @@ async fn cleanup_once(
 
     let mut snapshots: Vec<OrderStatusSnapshot> = Vec::with_capacity(maker_orders.len());
     let mut unresolved: Vec<(String, i64)> = maker_orders.clone();
+    let mut ws_attempts: Vec<(i64, String)> = Vec::new();
+    let ws_request_id_for = |attempts: &[(i64, String)], order_id: i64| {
+        attempts
+            .iter()
+            .find(|(id, _)| *id == order_id)
+            .map(|(_, request_id)| request_id.clone())
+    };
 
     // Primary verdict: a WS cancel acknowledged with `success` is
     // processing-complete at the venue, so that order needs no further query.
@@ -778,12 +828,14 @@ async fn cleanup_once(
         if ctx.health.is_healthy() {
             let drain = ws_cancel_orders(ctx, unresolved).await;
             unresolved = drain.unresolved;
+            ws_attempts = drain.attempts;
             for (_, id_i64) in drain.confirmed {
                 snapshots.push(OrderStatusSnapshot {
                     order_id: id_i64 as u64,
                     status: OrderStatus::Canceled,
                     updated_at: String::new(),
                     confirmed_by: "ws_success",
+                    ws_request_id: ws_request_id_for(&ws_attempts, id_i64),
                 });
             }
         }
@@ -797,7 +849,7 @@ async fn cleanup_once(
         let order_ids_i64: Vec<i64> = unresolved.iter().map(|(_, id)| *id).collect();
         client.cancel_orders(&order_ids_i64).await?;
         tokio::time::sleep(MAKER_CLEANUP_VERIFY_INITIAL_DELAY).await;
-        for (id_str, _) in &unresolved {
+        for (id_str, id_i64) in &unresolved {
             let mut observed = query_order_status(client, id_str).await?;
             let mut polls = 1;
             while !observed.status.is_terminal() && polls < MAKER_CLEANUP_VERIFY_MAX_ATTEMPTS {
@@ -805,6 +857,7 @@ async fn cleanup_once(
                 observed = query_order_status(client, id_str).await?;
                 polls += 1;
             }
+            observed.ws_request_id = ws_request_id_for(&ws_attempts, *id_i64);
             if !observed.status.is_terminal() {
                 residual_ids.push(id_str.clone());
             }
@@ -1391,8 +1444,13 @@ mod tests {
             .await
             .unwrap();
 
-        let drain =
-            drain_ws_cancel_responses(&mut rx, &mut pending, Duration::from_millis(50)).await;
+        let drain = drain_ws_cancel_responses(
+            &mut rx,
+            &mut pending,
+            &CleanupTombstones::default(),
+            Duration::from_millis(50),
+        )
+        .await;
 
         assert_eq!(drain.confirmed, vec![("1".to_string(), 1)]);
         assert_eq!(
@@ -1414,8 +1472,13 @@ mod tests {
                 .into_iter()
                 .collect();
 
-        let drain =
-            drain_ws_cancel_responses(&mut rx, &mut pending, Duration::from_millis(20)).await;
+        let drain = drain_ws_cancel_responses(
+            &mut rx,
+            &mut pending,
+            &CleanupTombstones::default(),
+            Duration::from_millis(20),
+        )
+        .await;
 
         assert!(drain.confirmed.is_empty());
         assert_eq!(drain.unresolved, vec![("7".to_string(), 7)]);
@@ -1488,8 +1551,13 @@ mod tests {
             .await
             .unwrap();
 
-        let drain =
-            drain_ws_cancel_responses(&mut rx, &mut pending, Duration::from_millis(50)).await;
+        let drain = drain_ws_cancel_responses(
+            &mut rx,
+            &mut pending,
+            &CleanupTombstones::default(),
+            Duration::from_millis(50),
+        )
+        .await;
 
         assert_eq!(drain.confirmed, vec![("5".to_string(), 5)]);
         assert!(drain.unresolved.is_empty());
@@ -1498,6 +1566,47 @@ mod tests {
             drain.leftover[0].request_id.as_deref(),
             Some("req-cycle-place")
         );
+        assert!(!drain.channel_closed);
+    }
+
+    /// Regression for the 07-30 stop (run `baseline-pnl-20260730T153920Z`):
+    /// the venue answers one cancel with a gateway `accepted` frame and a
+    /// terminal `success` frame. Attempt 1's drain claims the first frame and
+    /// releases the ID; the terminal frame lands in a LATER attempt's drain,
+    /// where the ID is no longer pending. It must be dropped via the tombstone
+    /// set, never forwarded as leftover — replaying it would fail closed on
+    /// `Orphan` and stop the run.
+    #[tokio::test]
+    async fn ws_drain_drops_tombstoned_cleanup_frame_instead_of_leftovering_it() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let mut pending: HashMap<String, (String, i64)> =
+            [("req-attempt-2".to_string(), ("8".to_string(), 8))]
+                .into_iter()
+                .collect();
+        let mut tombstones = CleanupTombstones::default();
+        // Minted by attempt 1: its `accepted` half was already claimed there.
+        tombstones.remember("req-attempt-1".to_string());
+        tx.send(ws_response("req-attempt-1", 0, "success"))
+            .await
+            .unwrap();
+        tx.send(ws_response("req-attempt-2", 0, "success"))
+            .await
+            .unwrap();
+
+        let drain = drain_ws_cancel_responses(
+            &mut rx,
+            &mut pending,
+            &tombstones,
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert_eq!(drain.confirmed, vec![("8".to_string(), 8)]);
+        assert!(
+            drain.leftover.is_empty(),
+            "tombstoned frame must not replay"
+        );
+        assert_eq!(drain.tombstoned, 1);
         assert!(!drain.channel_closed);
     }
 
@@ -1512,8 +1621,13 @@ mod tests {
                 .collect();
         drop(tx);
 
-        let drain =
-            drain_ws_cancel_responses(&mut rx, &mut pending, Duration::from_millis(50)).await;
+        let drain = drain_ws_cancel_responses(
+            &mut rx,
+            &mut pending,
+            &CleanupTombstones::default(),
+            Duration::from_millis(50),
+        )
+        .await;
 
         assert!(drain.confirmed.is_empty());
         assert_eq!(drain.unresolved, vec![("9".to_string(), 9)]);

--- a/crates/standx-maker/src/account_projection.rs
+++ b/crates/standx-maker/src/account_projection.rs
@@ -736,6 +736,26 @@ impl MakerAccountProjection {
                 resolved_in,
                 lifecycle,
             }
+        } else if resolution == ProjectionRequestResolution::CancelResolved {
+            // The venue's ws-api answers one `order:cancel` with TWO frames: a
+            // gateway `accepted` followed by a terminal result (observed live on
+            // 2026-07-30, run `baseline-pnl-20260730T153920Z`: the cancel
+            // resolved, the order then turned out to have already filled, and
+            // the terminal frame arrived as a *rejection*). For a cancel the
+            // recorded resolution plus the independent venue-state channels
+            // (account stream, `/api/query_order`) already establish everything
+            // the maker needs — the second frame carries no new information.
+            // Judging it as a channel-integrity contradiction converted a
+            // routine cancel/fill race into a spurious fail-closed freeze, so a
+            // post-resolution cancel ack is idempotent regardless of its code.
+            // Place resolutions keep the strict check: an accepted-then-rejected
+            // place contradicts a possibly-live quote slot.
+            ResponseCorrelation::LateKnown {
+                operation,
+                resolution,
+                resolved_in,
+                lifecycle,
+            }
         } else {
             ResponseCorrelation::Contradictory {
                 operation,

--- a/crates/standx-maker/src/account_projection_tests.rs
+++ b/crates/standx-maker/src/account_projection_tests.rs
@@ -163,6 +163,46 @@ fn correlation_verdict_is_pinned_for_every_observation_ordering() {
     }
 }
 
+/// The venue's ws-api answers one `order:cancel` with two frames: a gateway
+/// `accepted` followed by a terminal result. When the cancel races a fill,
+/// the terminal frame is a *rejection* (observed live 2026-07-30, run
+/// `baseline-pnl-20260730T153920Z`: cancel accepted, order already filled,
+/// second frame rejected). That second frame carries no new information —
+/// the cancel is already resolved and the fill arrives over the account
+/// stream — so it must be idempotent, not a channel-integrity failure.
+#[test]
+fn post_resolution_cancel_ack_is_idempotent_even_when_rejected() {
+    let mut projection = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
+    projection.apply(
+        1,
+        AccountProjectionEvent::CancelSubmitted(ProjectionPendingCancel {
+            request_id: "cancel-1".to_owned(),
+            order_id: 7,
+            side: OrderSide::Sell,
+            level: 0,
+            price: 54.349,
+            cycle: 1,
+        }),
+    );
+    projection.apply(
+        1,
+        AccountProjectionEvent::CancelResolved {
+            request_id: "cancel-1".to_owned(),
+        },
+    );
+
+    // Terminal frame shaped as success: the pre-existing idempotent path.
+    let success = projection.classify_response(Some("cancel-1"), true);
+    assert_eq!(success.label(), "late_known");
+    assert!(!success.fails_closed());
+
+    // Terminal frame shaped as rejection (cancel lost the race to a fill):
+    // also idempotent. This is the case that froze the 07-30 run.
+    let rejected = projection.classify_response(Some("cancel-1"), false);
+    assert_eq!(rejected.label(), "late_known");
+    assert!(!rejected.fails_closed());
+}
+
 /// A reconnect that preserves pending acks must keep the *pending* ack
 /// matched, not demote it to a tombstone verdict — that is the whole point of
 /// preserving it across the generation bump.

--- a/docs/27-maker-baseline-pnl-collection-runbook.md
+++ b/docs/27-maker-baseline-pnl-collection-runbook.md
@@ -102,6 +102,25 @@ emergency cancel 操作人：release owner（BossX）
 授权人 / 时间：release owner（BossX），2026-07-28，会话内明确授权（"授权"）
 ```
 
+已填授权（2026-07-30，第二次）：
+
+```text
+授权：冻结基线 PnL 绝对读数采集（单臂长跑）
+symbol：HYPE-USD
+配置：examples/maker-guard-hype-candidate.toml（sha256 6314a374…，原样）
+代码：git sha 0420fe0a10ae01b3ec8addc1b6c631177ec7d373（含 cleanup 硬化 Phase 1+2）
+风险边界：单 symbol、一档、最小有效数量、max_position 沿用基线；
+          stop_loss=5.0 生效；账户硬熔断不开启
+窗口：2026-07-30T15:39Z 起，计划 72 小时（3 天），不换臂、不调参
+emergency cancel 操作人：release owner（BossX）
+授权人 / 时间：release owner（BossX），2026-07-30，会话内明确授权（"授权开始"）
+```
+
+**第二次 run 于 15:41:31Z 截断（存活 ~2 分钟）**：场馆对单个 `order:cancel`
+回两帧 ack 的新实证行为先后击穿 cancel 决议矛盾判定与 leftover replay 判定，
+两次 fail-closed 均为误报，停机时 FLAT 且挂单簿已清。根因与修复见
+[maker-baseline-pnl-2026-07-30-run2-truncated.md](evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md)。
+
 风险预算沿用 canary 口径（[18 号"风险预算"](18-maker-strategy-roadmap.md)）：已知最坏
 路径是趋势市库存满仓后 stop-loss 停机持仓，损失上界约
 `max_position × 不利变动幅度 + 退出成本`。本轮不扩规模，因此不触发安全轨二级的额外前置。

--- a/docs/evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md
+++ b/docs/evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md
@@ -1,0 +1,78 @@
+# 基线 PnL 采集第二次截断报告：两帧 ack 击穿两个 fail-closed 判定（2026-07-30）
+
+run：`baseline-pnl-20260730T153920Z`，2026-07-30T15:39:20Z 启动，
+**15:41:31Z fail-safe 停机（exit 75），存活约 2 分钟**。
+代码 `0420fe0`（cleanup 硬化 Phase 1+2 + 两次评审修复）。停机时状态安全：
+仓位 FLAT、挂单簿已清、告警全部送达（maker-dev 群 23:40/23:41 + OpenObserve
+critical 23:42）。
+
+这是**可用性事故，不是安全 breach**：两次 fail-closed 都是把场馆的正常行为
+误判为通道损坏。安全不变量全程成立。
+
+## 时间线（全部 UTC，证据 `var/standx/baseline-pnl-20260730T153920Z.ndjson`）
+
+| 时刻 | 事件 |
+|---|---|
+| 15:39:20 | 启动，cleanup 空簿通过，FLAT 开跑 |
+| 15:40:34 | **事件 1**：cycle 36 对卖单 `11949281438` 发 cancel（request `b9744756`，reason=mark_moved）。场馆回**两帧**：网关 `accepted`（→ cancel_resolved 落账），随后终态帧是 **rejection**（该单已成交：fill sell 0.1 @54.349，15:40:37 经 REST 回填确认）→ projection 判 `contradictory` → fail-closed freeze |
+| 15:40:35 | freeze cleanup 走 REST 单查路径（order-response freeze，WS 正在替换），两单确认 canceled |
+| 15:40:37 | order-response 重连成功（新 session `2e52e09a`），仓位 -0.1 正确归属 |
+| 15:41:27 | **事件 2**：position_reconciliation freeze（cycle_invalidation：account update 使活动 cycle 失效） |
+| 15:41:28 | cleanup attempt 1：WS 撤 `11949283729`，drain 只收到 `accepted`（非 success）→ 降级 REST 单查确认 canceled；同时发现迟到可见单 `11949300497` → residual，重试 |
+| 15:41:30 | attempt 2：WS 撤 `11949300497`，同样 `accepted` → REST 单查确认 canceled → complete |
+| 15:41:31 | **leftover replay 判 `orphan_current_run`（request `3f31b25c`）→ fail-closed → cleanup 判失败 → 停机**。`residual_position: flat` |
+
+## 根因
+
+**场馆 ws-api 对一个 `order:cancel` 会回两帧**：网关 `accepted` + 终态结果
+（正常撤销是 `success`；撤销与成交竞态时是 `rejection`）。这是本次 run 两分钟
+内两次目击的实证行为，与设计假设"一个 request_id 恰好一帧响应"直接冲突。
+
+- **事件 1（`b9744756`）**：常规 cycle 撤单与成交竞态 → accepted + rejected
+  两帧。projection 把第二帧判为 `Contradictory`（已记录的 cancel_resolved 与
+  rejection 矛盾）→ freeze。对 maker 来说撤单/成交竞态是日常事件，这个判定把
+  常态变成了 fail-closed。
+- **事件 2（`3f31b25c`）**：cleanup WS 撤单同样只收到 `accepted`（两个
+  `confirmed_by=query_order` 可证），其第二帧（终态 `success`）在后一个
+  attempt 的 drain 窗口到达——该 request_id 已从 pending 释放，于是进了
+  leftover。replay 路径（`replay_leftover_responses`，0420fe0）**不查
+  cleanup 墓碑**，projection 从未登记过 cleanup 自己 mint 的 request_id →
+  `Orphan` → fail-closed → 停机。`3f31b25c` 在本 run 日志中无任何其他出现，
+  与"attempt 1 撤单的第二帧"推断一致（不能 100% 排除是跨 session 陈旧帧；
+  cleanup 当时未记录自己 mint 的 request_id，本次修复已补此遥测）。
+
+旁证：07-28 首轮 run 跑了 35.9h、391 笔成交、数千次撤单，**零次**此类
+contradictory/orphan 事件；本次 90 秒内两次。两帧行为可能是场馆侧新近变化，
+也需要继续观察。
+
+## 修复（本分支）
+
+1. **Fix A（standx-maker）**：`classify_response` 对已决议（CancelResolved）
+   的 cancel 的第二帧一律判 `late_known`（幂等可丢），无论 accepted 与否。
+   依据：cancel 的决议已落账，订单真实状态由账户流 / `/api/query_order`
+   独立确立，第二帧不携带新信息。**place 决议保持严格**（accepted-then-
+   rejected 的 place 仍 `Contradictory` fail-closed）。
+2. **Fix B（standx-cli）**：cleanup drain 对墓碑覆盖的 request_id（本轮或
+   上一轮 cleanup mint 的）在捕获时直接丢弃（计数诊断），不再作为 leftover
+   交给 replay。同时消除"cleanup 自己的第二帧"与"跨 attempt 迟到帧"两类
+   orphan。
+3. **遥测**：`maker_cleanup` 事件 `orders[]` 新增 `ws_request_id`，cleanup
+   mint 的 request_id 与订单的对应关系从此可查证。
+
+两个修复的回归测试均经变异验证（摘除实现后测试确实变红）：
+`post_resolution_cancel_ack_is_idempotent_even_when_rejected`、
+`ws_drain_drops_tombstoned_cleanup_frame_instead_of_leftovering_it`。
+
+## 仍开放的问题
+
+- 若未来目击到**既非 cleanup mint、也非本 run 登记**的响应帧（真·跨 session
+  陈旧帧），当前仍会 fail-closed。这是保留的安全姿态；出现时用
+  `ws_request_id` 遥测对照确认来源后再议。
+- 事件 1 的 freeze 本身是"撤单与成交竞态"的日常化触发——Fix A 后该类不再
+  freeze。两帧行为若为场馆新变更，值得向场馆确认协议语义。
+
+## 处置记录
+
+- 按 [27 号手册](../27-maker-baseline-pnl-collection-runbook.md)：fail-safe
+  停机不自动重启，记录原因；重启需修复合入 + 新的授权文本。
+- 授权记录（27 号手册"已填授权"节）同步回填本次窗口与截断原因。

--- a/docs/evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md
+++ b/docs/evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md
@@ -65,11 +65,23 @@ contradictory/orphan 事件；本次 90 秒内两次。两帧行为可能是场�
 
 ## 仍开放的问题
 
+- **Fix A 的残余窗口（对抗复审 finding）**：Fix A 丢弃的终态 rejection 帧，
+  在已观测语义（"已成交/已撤销"，订单必为终态）下确实无信息；但若场馆存在
+  未观测的"撤销被拒但订单仍活"的 rejection 语义，maker 会在 CancelSubmitted
+  已把该档从账上释放的前提下继续报价，可能在同一档重复挂单（敞口最高 2×），
+  直到 30 秒 REST audit 的 `unexpected_rest_open_order_ids` 发现并以
+  position_reconciliation freeze 兜底。即安全边际从"立即 freeze"收窄为
+  "最长一个 audit 周期的重复敞口"。当前无证据表明该语义存在；一旦出现
+  该类 freeze，应用本遥测（`ws_request_id` + 撤单原因）对照确认。
 - 若未来目击到**既非 cleanup mint、也非本 run 登记**的响应帧（真·跨 session
   陈旧帧），当前仍会 fail-closed。这是保留的安全姿态；出现时用
   `ws_request_id` 遥测对照确认来源后再议。
 - 事件 1 的 freeze 本身是"撤单与成交竞态"的日常化触发——Fix A 后该类不再
   freeze。两帧行为若为场馆新变更，值得向场馆确认协议语义。
+- 两帧行为下 WS cleanup 的 `confirmed_by=ws_success` 路径实际上很少命中：
+  drain 在网关 `accepted` 帧即释放 request_id 并降级 REST 单查，终态
+  `success` 帧作为 tombstoned 帧丢弃。行为正确但 `ws_success` 将近乎不出现，
+  且每次 freeze cleanup 会对 WS 已撤成的单多发一次幂等的 REST `cancel_orders`。
 
 ## 处置记录
 


### PR DESCRIPTION
## 事故

第二次基线 PnL run（`baseline-pnl-20260730T153920Z`）启动 2 分钟即被两次误报 fail-closed 打死（exit 75，停机时 FLAT、挂单簿已清）。实证：**场馆 ws-api 对单个 `order:cancel` 回两帧**——网关 `accepted` + 终态结果（正常撤销为 `success`；撤单与成交竞态时为 `rejection`）。

1. `b9744756`（cycle 撤单）：accepted 落账 cancel_resolved → 第二帧 rejection（单已成交）→ `Contradictory` → spurious freeze。
2. `3f31b25c`（cleanup 自己 mint 的撤单第二帧）：在后续 attempt 的 drain 到达 → leftover → replay 不查墓碑 → `Orphan` → 停机。

完整分析：[docs/evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md](docs/evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md)

## 修复

- **Fix A（standx-maker）**：`classify_response` 对已 `CancelResolved` 的 cancel 第二帧一律 `late_known`（幂等可丢）。cancel 决议已落账，订单真实状态由账户流 / `/api/query_order` 独立确立。**place 决议保持严格 fail-closed 不变**。
- **Fix B（standx-cli）**：cleanup drain 对墓碑覆盖的 request_id 在捕获时丢弃（计数诊断），不再交给 replay。
- **遥测**：`maker_cleanup` 事件 `orders[]` 新增 `ws_request_id`。

## fail-closed 语义

place 侧与未知 request_id（orphan / unidentified / unverifiable / venue_contradiction）保持不变。仅两类降级为幂等：cancel 决议后的第二帧、cleanup 自 mint 帧。

## 验证

- 新增回归测试 ×2，均经**变异验证**（摘除实现后确实变红）
- 对抗复审（独立 reviewer）已跑：**无高危**；MEDIUM #1（rejected-but-still-live 的残余窗口，30s REST audit 兜底）已回填证据文档仍开放的问题
- `cargo test --workspace --offline` / clippy `-D warnings` / fmt 全绿

## 重启

按 27 号手册，重启采集需本 PR 合入 + 新授权文本。