### PR TITLE
fix(maker): place 侧两帧 ack 按异步拒单落账 + venue_observed 保全（07-31 run3 事故修复）

### DIFF
--- a/crates/standx-cli/src/commands/maker/runtime/events.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/events.rs
@@ -264,6 +264,45 @@ pub(super) fn apply_order_response(
 ) -> std::result::Result<maker::ResponseCorrelation, CancelRejection> {
     let request_id = response.request_id.as_deref();
     let correlation = projection.classify_response(request_id, response.accepted());
+    // The two-frame place ack: gateway `accepted` already resolved the first
+    // frame, and the terminal ALO rejection arrives as a second frame. With no
+    // account-stream observation the classification is Matched+AwaitingVenue:
+    // apply it as the ordinary async rejection, freeing the level.
+    if matches!(
+        correlation,
+        maker::ResponseCorrelation::Matched {
+            operation: maker::RequestOperation::Place,
+            lifecycle: maker::RequestLifecycle::AwaitingVenue,
+        }
+    ) {
+        let request_id = request_id.expect("a matched correlation carries a request ID");
+        let place = projection
+            .pending_places()
+            .into_iter()
+            .find(|place| place.request_id == request_id);
+        let generation = projection.generation();
+        projection.apply(
+            generation,
+            AccountProjectionEvent::PlaceRejected {
+                request_id: request_id.to_string(),
+            },
+        );
+        if let Some(place) = place {
+            output::log_maker_event(output::MakerLogEvent {
+                output_format,
+                symbol,
+                cycle,
+                action: "place_rejected_async",
+                side: place.side,
+                level: place.level,
+                price: place.price,
+                price_decimals,
+                detail: &response.message,
+                exit_kind: None,
+            });
+        }
+        return Ok(correlation);
+    }
     // Only a live pending request produces new projection state. Everything else
     // is either idempotent (a late duplicate) or refused by the caller's
     // fail-closed policy, and must not mutate the projection on the way out.

--- a/crates/standx-cli/src/commands/maker/runtime/tests/order_events.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/tests/order_events.rs
@@ -1,7 +1,5 @@
 use super::*;
-use standx_maker::{
-    ProjectionRequestResolution, RequestLifecycle, RequestOperation, ResponseCorrelation,
-};
+use standx_maker::{RequestLifecycle, RequestOperation, ResponseCorrelation};
 
 #[test]
 fn apply_order_response_keeps_accepted_placement() {
@@ -263,36 +261,62 @@ fn duplicate_cancel_ack_matches_completed_request_after_cleanup() {
 }
 
 #[test]
-fn contradictory_replay_for_completed_request_remains_fail_closed() {
+fn two_frame_place_rejection_without_venue_observation_is_async_rejection() {
     let mut projection = projection_with_pending(&["req-1"]);
     assert!(!correlate(&mut projection, Some("req-1"), 0).fails_closed());
 
-    // The tombstone records PlaceAccepted; a rejection for the same request
-    // cannot also be true. This is a contradiction, not an unknown ID, and the
-    // verdict now says so.
+    // The tombstone records PlaceAccepted and the account stream has NOT shown
+    // the order: under the venue's two-frame protocol (gateway `accepted`, then
+    // terminal `"alo order rejected"` — observed live 2026-07-31, run
+    // `baseline-pnl-20260730T163544Z`) this second frame is the ordinary async
+    // rejection, not a channel contradiction.
     let verdict = correlate(&mut projection, Some("req-1"), 400);
-    assert!(verdict.fails_closed());
-    assert_eq!(verdict.label(), "contradictory");
+    assert!(!verdict.fails_closed());
+    assert_eq!(verdict.label(), "matched");
     assert_eq!(
         verdict,
-        ResponseCorrelation::Contradictory {
+        ResponseCorrelation::Matched {
             operation: RequestOperation::Place,
-            resolution: ProjectionRequestResolution::PlaceAccepted,
-            resolved_in: 1,
-            // The accepted place is still awaiting its account-order
-            // observation, which is exactly when a stray rejection is most
-            // dangerous: the slot is open and the maker believes it is filled.
             lifecycle: RequestLifecycle::AwaitingVenue,
         }
     );
+    // The rejection is applied as the ordinary async rejection: the quote
+    // slot is freed and the request lifecycle is retired.
+    assert!(
+        projection.pending_places().is_empty(),
+        "the async rejection must free the level"
+    );
+    assert_eq!(projection.pending_request_count(), 0);
+}
+
+#[test]
+fn two_frame_place_rejection_after_venue_observation_remains_fail_closed() {
+    let mut projection = projection_with_pending(&["req-1"]);
+    assert!(!correlate(&mut projection, Some("req-1"), 0).fails_closed());
+    // The account stream shows the placed order live; the projection adopts it
+    // and retires the pending slot.
+    projection.apply(
+        1,
+        AccountProjectionEvent::OrderObserved(standx_maker::OrderObservation {
+            order_id: 42,
+            client_order_id: Some("sxmk-test-q00000001b0".to_string()),
+            side: OrderSide::Buy,
+            price: 100.0,
+            open_qty: 1.0,
+            terminal: false,
+        }),
+    );
+
+    // The terminal rejection now genuinely contradicts the venue-visible order.
+    let verdict = correlate(&mut projection, Some("req-1"), 400);
+    assert!(verdict.fails_closed());
+    assert_eq!(verdict.label(), "venue_contradiction");
     // The failure detail must let an operator reconstruct all of it.
     let detail = correlation_failure_detail(&verdict, Some("req-1"), projection.generation());
     for expected in [
-        "verdict=contradictory",
+        "verdict=venue_contradiction",
         "request_id=req-1",
         "operation=place",
-        "lifecycle=awaiting_venue",
-        "place_accepted",
     ] {
         assert!(
             detail.contains(expected),

--- a/crates/standx-maker/src/account_projection.rs
+++ b/crates/standx-maker/src/account_projection.rs
@@ -848,13 +848,20 @@ impl MakerAccountProjection {
                     })
                     .map(|entry| {
                         entry.ack_pending = false;
-                        entry.request.clone()
+                        (entry.request.clone(), entry.venue_observed)
                     });
                 let applied = request.is_some();
-                if let Some(request) = request {
+                if let Some((request, venue_observed)) = request {
+                    // The account stream may have adopted the order BEFORE this
+                    // ack (observe-first ordering). The entry settles and drops
+                    // below, so the tombstone must inherit `venue_observed` —
+                    // otherwise a later terminal rejection frame would be
+                    // misjudged as the ordinary async rejection of a place the
+                    // venue never had, while the adopted order sits in the book.
                     self.remember_completed_request(
                         request,
                         ProjectionRequestResolution::PlaceAccepted,
+                        venue_observed,
                     );
                 }
                 self.drop_settled();
@@ -879,6 +886,8 @@ impl MakerAccountProjection {
                     self.remember_completed_request(
                         request,
                         ProjectionRequestResolution::PlaceRejected,
+                        // The venue rejected the place: no exposure to record.
+                        false,
                     );
                 }
                 self.drop_settled();
@@ -925,6 +934,8 @@ impl MakerAccountProjection {
                 self.remember_completed_request(
                     entry.request,
                     ProjectionRequestResolution::CancelResolved,
+                    // The flag is only consulted for accepted places.
+                    false,
                 );
                 ProjectionOutcome {
                     applied: true,
@@ -1005,6 +1016,7 @@ impl MakerAccountProjection {
         &mut self,
         request: ProjectionPendingRequest,
         resolution: ProjectionRequestResolution,
+        venue_observed: bool,
     ) {
         if self
             .completed
@@ -1017,7 +1029,7 @@ impl MakerAccountProjection {
             request,
             resolution,
             generation: self.generation,
-            venue_observed: false,
+            venue_observed,
         });
         if self.completed.len() > MAX_COMPLETED_ORDER_REQUESTS {
             self.completed.pop_front();
@@ -1092,8 +1104,29 @@ impl MakerAccountProjection {
                     .is_some_and(|client_order_id| place.client_order_id == client_order_id),
                 ProjectionPendingRequest::Cancel(cancel) => cancel.order_id == observation.order_id,
             };
-            if matches {
-                entry.slot_open = false;
+            if !matches {
+                continue;
+            }
+            let slot_was_open = entry.slot_open;
+            entry.slot_open = false;
+            // A terminal observation is the account stream showing this order
+            // one last time — the venue provably HAD it. Record that on the
+            // entry and its tombstone so a terminal rejection frame arriving
+            // later is still judged a venue contradiction, not the ordinary
+            // async rejection of a place the venue never had. Only an open
+            // slot counts: cleanup closes slots precisely to declare that a
+            // later rejection no longer contradicts anything live.
+            if slot_was_open && entry.place().is_some() {
+                entry.venue_observed = true;
+                let request_id = entry.request_id().to_string();
+                if let Some(completed) = self
+                    .completed
+                    .iter_mut()
+                    .rev()
+                    .find(|completed| completed.request_id() == request_id)
+                {
+                    completed.venue_observed = true;
+                }
             }
         }
         self.drop_settled();

--- a/crates/standx-maker/src/account_projection.rs
+++ b/crates/standx-maker/src/account_projection.rs
@@ -396,6 +396,12 @@ struct CompletedRequest {
     /// acknowledgement arriving against it belongs to a superseded epoch and
     /// must be reported as such rather than as an unknown ID.
     generation: u64,
+    /// The account stream showed this request's order live at the venue.
+    /// Tracked on the tombstone (not only the pending entry, which settles and
+    /// drops on adoption) so a terminal *rejection* frame arriving after the
+    /// ack resolved is still recognised as a venue contradiction rather than
+    /// the ordinary async rejection of a place the venue never had.
+    venue_observed: bool,
 }
 
 impl CompletedRequest {
@@ -700,8 +706,8 @@ impl MakerAccountProjection {
         // quote slot — is the authority on what the outcome was. An entry whose
         // slot is open is reported as such, but a second acknowledgement is
         // still judged against the recorded resolution: a rejection arriving for
-        // an accepted place contradicts it whether or not the venue has
-        // confirmed the order yet.
+        // an accepted place contradicts it when the account stream has already
+        // shown the order live (see the PlaceAccepted handling below).
         let slot_still_open = self
             .pending
             .iter()
@@ -748,14 +754,36 @@ impl MakerAccountProjection {
             // Judging it as a channel-integrity contradiction converted a
             // routine cancel/fill race into a spurious fail-closed freeze, so a
             // post-resolution cancel ack is idempotent regardless of its code.
-            // Place resolutions keep the strict check: an accepted-then-rejected
-            // place contradicts a possibly-live quote slot.
+            // Place resolutions keep the strict check — with one exception,
+            // handled next.
             ResponseCorrelation::LateKnown {
                 operation,
                 resolution,
                 resolved_in,
                 lifecycle,
             }
+        } else if resolution == ProjectionRequestResolution::PlaceAccepted
+            && !completed.venue_observed
+        {
+            // Same two-frame protocol, place side (observed live on 2026-07-31,
+            // run `baseline-pnl-20260730T163544Z`): the venue's gateway answers
+            // `order:new` with `accepted`, then the terminal frame rejects the
+            // ALO order (`"alo order rejected"`, would-cross) — a routine race
+            // for a maker. Because the account stream has NOT shown this order,
+            // the rejection cannot contradict anything: the order never existed
+            // at the venue. It is the ordinary async rejection, delivered as a
+            // second frame; the caller applies it as `PlaceRejected`, which
+            // frees the level. Only reachable for places — a resolved cancel's
+            // second frame is handled above.
+            ResponseCorrelation::Matched {
+                operation,
+                lifecycle: RequestLifecycle::AwaitingVenue,
+            }
+        } else if resolution == ProjectionRequestResolution::PlaceAccepted {
+            // The account stream DID show this order live before the terminal
+            // rejection arrived: the two channels genuinely disagree about
+            // whether the order exists right now.
+            ResponseCorrelation::VenueContradiction { operation }
         } else {
             ResponseCorrelation::Contradictory {
                 operation,
@@ -989,6 +1017,7 @@ impl MakerAccountProjection {
             request,
             resolution,
             generation: self.generation,
+            venue_observed: false,
         });
         if self.completed.len() > MAX_COMPLETED_ORDER_REQUESTS {
             self.completed.pop_front();
@@ -1173,25 +1202,41 @@ impl MakerAccountProjection {
         let request_id = self.pending[index].request_id().to_string();
         self.pending[index].slot_open = false;
         self.pending[index].venue_observed = true;
+        // The entry itself settles and drops below; the tombstone is the
+        // durable record that the venue showed this request's order.
+        if let Some(completed) = self
+            .completed
+            .iter_mut()
+            .rev()
+            .find(|entry| entry.request_id() == request_id)
+        {
+            completed.venue_observed = true;
+        }
         self.drop_settled();
         Some((AdoptedSlot::from_place(&place), request_id))
     }
 
     fn completed_place_slot(
-        &self,
+        &mut self,
         observation: &OrderObservation,
     ) -> Option<(AdoptedSlot, String)> {
         let client_order_id = observation.client_order_id.as_deref()?;
-        self.completed.iter().rev().find_map(|entry| {
-            entry
+        self.completed.iter_mut().rev().find_map(|entry| {
+            let matches = entry
                 .accepted_place()
-                .filter(|place| place.client_order_id == client_order_id)
-                .map(|place| {
-                    (
-                        AdoptedSlot::from_place(place),
-                        entry.request_id().to_string(),
-                    )
-                })
+                .is_some_and(|place| place.client_order_id == client_order_id);
+            if !matches {
+                return None;
+            }
+            // This observation proves the venue has the tombstoned request's
+            // order live; record it on the tombstone so a later terminal
+            // rejection frame is judged a contradiction.
+            entry.venue_observed = true;
+            let place = entry.accepted_place().expect("matched above").clone();
+            Some((
+                AdoptedSlot::from_place(&place),
+                entry.request_id().to_string(),
+            ))
         })
     }
 

--- a/crates/standx-maker/src/account_projection_tests.rs
+++ b/crates/standx-maker/src/account_projection_tests.rs
@@ -119,10 +119,22 @@ fn correlation_verdict_is_pinned_for_every_observation_ordering() {
             "late_known",
         ),
         (
-            "rejection contradicting an accepted place, slot still open",
+            // The venue's two-frame place ack (observed live 2026-07-31): the
+            // terminal ALO rejection arrives as a second frame; the account
+            // stream never showed the order, so it is the ordinary async
+            // rejection, applied as PlaceRejected by the caller.
+            "two-frame place ack: accepted then ALO rejection, venue never showed it",
             vec![Step::Submit, accepted],
             false,
-            "contradictory",
+            "matched",
+        ),
+        (
+            // Same second frame, but the account stream already showed the
+            // order live — the two channels genuinely disagree.
+            "two-frame place ack: terminal rejection after the venue showed it live",
+            vec![Step::Submit, accepted, resting],
+            false,
+            "venue_contradiction",
         ),
         (
             "acceptance contradicting a rejected place",

--- a/crates/standx-maker/src/account_projection_tests.rs
+++ b/crates/standx-maker/src/account_projection_tests.rs
@@ -261,6 +261,90 @@ fn rejection_after_the_venue_showed_the_order_live_is_a_contradiction() {
     assert_eq!(verdict.label(), "venue_contradiction");
 }
 
+/// Observe-first ordering of the same contradiction (adversarial-review
+/// finding, 07-31): the account stream adopts the order BEFORE the command
+/// ack arrives. The pending entry carries `venue_observed`, but it settles
+/// and drops when the accepted ack resolves — the tombstone created at that
+/// point must inherit the flag. Otherwise a later terminal rejection frame is
+/// misjudged as the ordinary async rejection of a place the venue never had,
+/// while the maker still carries the adopted order in its book.
+#[test]
+fn rejection_after_observe_first_adoption_is_still_a_contradiction() {
+    let mut projection = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
+    projection.apply(1, AccountProjectionEvent::PlaceSubmitted(pending("req-1")));
+    let adopted = projection.apply(1, AccountProjectionEvent::OrderObserved(order(0.2, false)));
+    assert_eq!(adopted.effective_request_id.as_deref(), Some("req-1"));
+    // The ack resolves AFTER the adoption; the pending entry settles here.
+    projection.apply(
+        1,
+        AccountProjectionEvent::PlaceAccepted {
+            request_id: "req-1".to_owned(),
+        },
+    );
+    assert_eq!(
+        projection.resting_quotes().len(),
+        1,
+        "adopted order is still in the book"
+    );
+
+    let verdict = projection.classify_response(Some("req-1"), false);
+    assert!(
+        verdict.fails_closed(),
+        "the venue showed this order live; rejecting it must fail closed, got {verdict:?}"
+    );
+    assert_eq!(verdict.label(), "venue_contradiction");
+}
+
+/// A terminal observation is the account stream proving the venue HAD the
+/// order — it filled (or closed) and is gone. A terminal rejection frame
+/// arriving after that still contradicts the recorded history, so the
+/// tombstone must carry `venue_observed` even though nothing live remains.
+#[test]
+fn rejection_after_a_terminal_observation_is_a_contradiction() {
+    let mut projection = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
+    projection.apply(1, AccountProjectionEvent::PlaceSubmitted(pending("req-1")));
+    projection.apply(
+        1,
+        AccountProjectionEvent::PlaceAccepted {
+            request_id: "req-1".to_owned(),
+        },
+    );
+    // The order fills; the terminal observation closes the slot.
+    let filled = projection.apply(1, AccountProjectionEvent::OrderObserved(order(0.0, true)));
+    assert_eq!(filled.effective_request_id.as_deref(), Some("req-1"));
+
+    let verdict = projection.classify_response(Some("req-1"), false);
+    assert!(
+        verdict.fails_closed(),
+        "the venue provably had this order; rejecting it must fail closed, got {verdict:?}"
+    );
+    assert_eq!(verdict.label(), "venue_contradiction");
+}
+
+/// Terminal observation BEFORE the ack: the entry settles only when the ack
+/// resolves, so the flag set by the terminal observation must survive the
+/// trip through `PlaceAccepted` into the tombstone.
+#[test]
+fn rejection_after_terminal_observation_before_the_ack_is_a_contradiction() {
+    let mut projection = MakerAccountProjection::new(1, PREFIX, 0.0, 0.005, 0.00005);
+    projection.apply(1, AccountProjectionEvent::PlaceSubmitted(pending("req-1")));
+    let filled = projection.apply(1, AccountProjectionEvent::OrderObserved(order(0.0, true)));
+    assert_eq!(filled.effective_request_id.as_deref(), Some("req-1"));
+    projection.apply(
+        1,
+        AccountProjectionEvent::PlaceAccepted {
+            request_id: "req-1".to_owned(),
+        },
+    );
+
+    let verdict = projection.classify_response(Some("req-1"), false);
+    assert!(
+        verdict.fails_closed(),
+        "the venue provably had this order; rejecting it must fail closed, got {verdict:?}"
+    );
+    assert_eq!(verdict.label(), "venue_contradiction");
+}
+
 /// A missing `request_id` is a protocol violation with its own verdict. It
 /// must never share the "unknown ID" path, and it must never be ignored.
 #[test]

--- a/docs/evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md
+++ b/docs/evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md
@@ -1,4 +1,8 @@
-# 基线 PnL 采集第二次截断报告：两帧 ack 击穿两个 fail-closed 判定（2026-07-30）
+# 基线 PnL 采集截断报告：两帧 ack 击穿 fail-closed 判定（2026-07-30/31）
+
+> 本文档原记录第二次 run（run2，15:41 截断）。第三次 run（run3，
+> `baseline-pnl-20260730T163544Z`）于 2026-07-31T01:26:53Z 再次被同一协议
+> 行为的 **place 侧变体**击杀，附在后半部分。
 
 run：`baseline-pnl-20260730T153920Z`，2026-07-30T15:39:20Z 启动，
 **15:41:31Z fail-safe 停机（exit 75），存活约 2 分钟**。
@@ -88,3 +92,59 @@ contradictory/orphan 事件；本次 90 秒内两次。两帧行为可能是场�
 - 按 [27 号手册](../27-maker-baseline-pnl-collection-runbook.md)：fail-safe
   停机不自动重启，记录原因；重启需修复合入 + 新的授权文本。
 - 授权记录（27 号手册"已填授权"节）同步回填本次窗口与截断原因。
+
+---
+
+# run3 截断（2026-07-31T01:26:53Z）：place 侧两帧经 leftover replay 击杀
+
+run：`baseline-pnl-20260730T163544Z`，存活约 51 分钟（99 笔成交后才出事，
+期间 cycle 459 时已目击 2 次 place 侧 `contradictory` freeze 并自恢复）。
+
+## 事故链
+
+1. 01:26:52 一笔 buy fill 0.1（仓位 -0.2 → -0.1），账户事件使 cycle 失效 →
+   position_reconciliation freeze；
+2. freeze cleanup 正常完成（挂单簿清空）；
+3. cleanup drain 捕获 leftover：买单 place（request `6756a3ca`）的第二帧
+   终态 `"alo order rejected"`——该 place 的网关 `accepted` 已落账
+   （slot 等场馆确认中），终态帧 ALO 拒单（would-cross）在 freeze 窗口到达；
+4. replay 经 `classify_response` 判 `Contradictory`（place + awaiting_venue）
+   → cleanup 判失败 → exit 75；
+5. 停机时 **-0.10 HYPE 空头 handoff**（venue 确认 short -0.10，无挂单），
+   由 owner 手动处置。
+
+市场背景：HYPE 当小时 54.6 → 56.1（+2.8%），波动放大 would-cross 竞态，
+ALO 拒单的两帧形态从"罕见"变成"每小时数次"。
+
+## 根因（place 侧）
+
+与 cancel 侧同一协议行为：`order:new` 同样是网关 `accepted` + 终态帧
+两帧。ALO 挂单被 would-cross 拒掉时，终态帧是 rejection——对 maker 这是
+日常竞态，但 `classify_response` 把"已 PlaceAccepted 且 slot 未关闭"的
+rejection 一律判 `Contradictory` fail-closed。两帧里真正需要区分的只有：
+**账户流是否已展示过这张单**——展示过才是真的双通道矛盾（VenueContradiction）。
+
+## 修复（Fix C，本分支）
+
+- `classify_response`：`PlaceAccepted` 墓碑 + 终态 rejection，**账户流未
+  展示** → `Matched{AwaitingVenue}`，由 apply 路径按普通异步拒单落账
+  `PlaceRejected`（释放档位，记 `place_rejected_async` 日志）；**已展示**
+  → `VenueContradiction`（fail-closed 不变）。
+- "账户流是否展示过"记录在 **completed 墓碑新增的 `venue_observed`** 上：
+  收养（`match_pending_slot` / `completed_place_slot`）时置位。pending 条目
+  承担不了这个信号——收养即关闭 slot、条目 settle 并被丢弃。
+- cancel 侧（Fix A）、cleanup 墓碑侧（Fix B）、place 严格侧
+  （`PlaceRejected` 墓碑 + acceptance 仍 `Contradictory`）行为不变。
+
+测试：`two_frame_place_rejection_without_venue_observation_is_async_rejection`
+（含 slot 释放断言）与 `two_frame_place_rejection_after_venue_observation_
+remains_fail_closed`，外加 maker-core 钉住表两个新用例；两处变异验证
+（摘除 classify 分支 / 摘除 apply 臂）均确认测试变红。旧用例
+`contradictory_replay_for_completed_request_remains_fail_closed` 按新语义
+改写——它钉的正是被场馆协议证伪的旧假设。
+
+## run3 的残余窗口（同 Fix A 复审结论）
+
+若场馆存在"ALO 拒单但订单实际挂上"的未观测语义，Fix C 会在账户流未展示的
+前提下释放档位，最长一个 30 秒 REST audit 周期后由
+`unexpected_rest_open_order_ids` freeze 兜底。当前无证据表明该语义存在。

--- a/scripts/baseline_pnl_report.py
+++ b/scripts/baseline_pnl_report.py
@@ -89,7 +89,7 @@ def fmt(v, digits=6):
 def build_report(stats, run_id: str, process_alive: bool, alerts) -> str:
     cycles = stats["cycles"]
     if not cycles:
-        return f"[standx] {run_id}: 日志中还没有 cycle_summary"
+        return f"**[standx]** {run_id}: 日志中还没有 cycle_summary"
     latest = cycles[-1]
     perf = latest.get("performance") or {}
 
@@ -113,18 +113,19 @@ def build_report(stats, run_id: str, process_alive: bool, alerts) -> str:
     )
 
     crit = len(stats["criticals"])
-    alive = "alive" if process_alive else "**DEAD**"
+    alive = "🟢 alive" if process_alive else "🔴 **DEAD**"
 
-    alert_lines = [f"🚨 ALERT: {a}" for a in alerts] if alerts else []
+    alert_lines = [f"🚨 **ALERT**: {a}" for a in alerts] if alerts else []
 
     lines = [
-        f"[standx] 基线 PnL 采集运行报告",
+        f"**[standx] 基线 PnL 采集运行报告**",
         *alert_lines,
-        f"run: {run_id}",
-        f"进程: {alive} | 最新 cycle: {latest.get('ts')} (#{latest.get('cycle')})",
-        f"仓位: {fmt(latest.get('position'))} | 会话 PnL: {fmt(latest.get('pnl'))}",
+        "---",
+        f"**run**: `{run_id}`",
+        f"**进程**: {alive} | **最新 cycle**: {latest.get('ts')} (#{latest.get('cycle')})",
+        f"**仓位**: {fmt(latest.get('position'))} | **会话 PnL**: {fmt(latest.get('pnl'))}",
         (
-            f"净额归因: gross {fmt(perf.get('gross_spread_quote'))}"
+            f"**净额归因**: gross {fmt(perf.get('gross_spread_quote'))}"
             f" | fee {fmt(perf.get('fee_quote'))}"
             f" | rebate {fmt(perf.get('rebate_quote'))}"
             f" | funding {fmt(perf.get('funding_quote'))}"
@@ -132,33 +133,33 @@ def build_report(stats, run_id: str, process_alive: bool, alerts) -> str:
             f", unattributed={perf.get('funding_unattributed')})"
         ),
         (
-            f"net_pnl_complete={perf.get('net_pnl_complete')}"
-            f" | costs_unavailable={perf.get('execution_costs_unavailable')}"
+            f"**net_pnl_complete**: {perf.get('net_pnl_complete')}"
+            f" | **costs_unavailable**: {perf.get('execution_costs_unavailable')}"
         ),
         (
-            f"markout bps: 1s {fmt(perf.get('markout_1s_bps'), 2)}"
+            f"**markout bps**: 1s {fmt(perf.get('markout_1s_bps'), 2)}"
             f" / 5s {fmt(perf.get('markout_5s_bps'), 2)}"
             f" / 30s {fmt(perf.get('markout_30s_bps'), 2)}"
         ),
         (
-            f"uptime: {fmt(perf.get('time_weighted_uptime_pct'), 1)}%"
-            f" | fills_total: {stats['fills_total']}"
-            f" | 撤单: {cancel_str}"
+            f"**uptime**: {fmt(perf.get('time_weighted_uptime_pct'), 1)}%"
+            f" | **fills_total**: {stats['fills_total']}"
+            f" | **撤单**: {cancel_str}"
         ),
         (
-            f"guard 激活: {guard_on}/{n} cycles ({100.0 * guard_on / n:.1f}%)"
-            f" | halt: {halted}/{n} ({100.0 * halted / n:.1f}%)"
-            f" | 主动退出: {stats['exits_submitted']} (suppressed {stats['exit_suppressed']})"
+            f"**guard 激活**: {guard_on}/{n} cycles ({100.0 * guard_on / n:.1f}%)"
+            f" | **halt**: {halted}/{n} ({100.0 * halted / n:.1f}%)"
+            f" | **主动退出**: {stats['exits_submitted']} (suppressed {stats['exit_suppressed']})"
         ),
         (
-            f"standby: {len(stats['standby'])} 次, 单次 max {standby_max:.0f}s"
+            f"**standby**: {len(stats['standby'])} 次, 单次 max {standby_max:.0f}s"
             f", 累计 {standby_total:.0f}s"
         ),
-        f"critical 事件: {crit}" + (" ⚠️" if crit else ""),
+        f"**critical 事件**: {crit}" + (" ⚠️" if crit else ""),
     ]
     if crit:
         last = stats["criticals"][-1]
-        lines.append(f"最近 critical: {last.get('ts')} {str(last.get('message'))[:120]}")
+        lines.append(f"**最近 critical**: {last.get('ts')} {str(last.get('message'))[:120]}")
     return "\n".join(lines)
 
 
@@ -211,7 +212,7 @@ def send_lark(text: str, open_id: str) -> int:
             open_id,
             "--as",
             "bot",
-            "--text",
+            "--markdown",
             text,
         ],
         capture_output=True,


### PR DESCRIPTION
## 背景

实证（run `baseline-pnl-20260730T163544Z`，01:26:53Z exit 75，残余 -0.1 HYPE 空头 handoff）：`order:new` 与 `order:cancel` 同样是「网关 accepted + 终态帧」两帧协议；ALO 挂单被 would-cross 拒掉时终态帧是 rejection。place 已 `PlaceAccepted` 且 slot 未关闭时的 rejection 此前一律判 `Contradictory` fail-closed，经 leftover replay 把日常竞态变成停机。

## 变更

**b483c70 — 两帧协议 place 侧落账**
- `classify_response`：`PlaceAccepted` 墓碑 + 终态 rejection，按账户流是否展示过该单分流——未展示 → `Matched{AwaitingVenue}`（普通异步拒单）；已展示 → `VenueContradiction`（fail-closed 不变）。
- `venue_observed` 记录进 completed 墓碑（收养时置位），pending 条目收养后即 settle 丢弃，承担不了这个信号。
- `apply_order_response`：`Matched+AwaitingVenue` 按 `PlaceRejected` 落账，释放档位并记 `place_rejected_async` 日志。
- fail-closed 语义不变：venue_observed 的 place 矛盾、PlaceRejected 墓碑矛盾、cancel/未知 ID 全部保持。

**e316fa5 — 对抗复审 Finding 1/2 修复（均为 b483c70 引入、未上 main）**
- Finding 1 (HIGH)：observe-first 排序下 `PlaceAccepted` 建墓碑硬编码 `venue_observed: false`，entry settle 后真相丢失，已收编进 book 的订单被后续 rejection 误判为普通异步拒单。修复：墓碑继承 entry 标志。
- Finding 2 (MEDIUM)：终态观测（成交）不置位，同样漏判。修复：终态观测关闭开着的 place slot 时同步置 entry 与墓碑标志；仅 `slot_was_open` 才置位，不击穿 cleanup 故意清标志的契约。

**cc64dfd — 脚本杂项**：基线 PnL Lark 报告改 markdown 排版（与本修复无关，独立 commit）。

## 验证

- 两帧协议：两个 CLI 端到端用例 + maker-core 钉住表；旧 contradictory 钉住用例按被场馆协议证伪后的新语义改写。
- 对抗复审修复：三个新钉住测试先全红（失败形态与预测一致），变异验证 ×2（分别摘除两条修复路径，对应测试精确变红）。
- `cargo test --workspace --offline` 全绿，`clippy --workspace --all-targets -- -D warnings` 干净，`cargo fmt --check` 干净。
- 证据文档已回填 run3 事故链与残余窗口（b483c70）。