### PR TITLE
fix: keep standalone installs self-updatable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
+      - name: Test standalone installer
+        run: |
+          sh -n install.sh
+          sh scripts/test_install.sh
+
   # 多平台构建矩阵
   build-matrix:
     strategy:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,12 @@ curl -sSL https://raw.githubusercontent.com/wjllance/standx-cli/main/install.sh 
 Optional environment variables:
 
 - `STANDX_VERSION` — install a specific tag instead of the latest release (e.g. `STANDX_VERSION=v1.3.0`).
-- `INSTALL_DIR` — install somewhere other than `/usr/local/bin`.
+- `INSTALL_DIR` — install somewhere other than the default `$HOME/.local/bin`.
+
+The standalone installer never elevates privileges. Its user-owned default keeps
+`standx update` working without `sudo`. If `$HOME/.local/bin` is not already in
+your `PATH`, the installer prints the exact export command to add it. For a
+system-managed macOS installation, use Homebrew instead.
 
 #### Option 2: Homebrew (macOS)
 

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -31,22 +31,16 @@ Homebrew 装的用 `brew upgrade standx-cli`——`standx update` 会检测到�
 避免 formula 与实际二进制不一致。安装目录不可写时会直接报错并给出说明，**不会**自动
 提权。
 
-### 方式二：直接下载二进制
+### 方式二：独立安装脚本
 
 ```bash
-# 下载对应平台的二进制文件
-# macOS ARM64
-curl -L -o standx.tar.gz https://github.com/wjllance/standx-cli/releases/latest/download/standx-macos-aarch64.tar.gz
+# 默认安装到用户可写的 $HOME/.local/bin，不使用 sudo
+curl -sSL https://raw.githubusercontent.com/wjllance/standx-cli/main/install.sh | sh
 
-# Linux x86_64
-curl -L -o standx.tar.gz https://github.com/wjllance/standx-cli/releases/latest/download/standx-linux-x86_64.tar.gz
+# 如果安装器提示目录尚未加入 PATH
+export PATH="$HOME/.local/bin:$PATH"
 
-# 解压
-tar -xzf standx.tar.gz
-chmod +x standx
-sudo mv standx /usr/local/bin/
-
-# 验证
+# 验证；独立安装后可直接使用上面的 standx update 命令升级
 standx --version
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,6 @@ set -e
 
 REPO="wjllance/standx-cli"
 BINARY_NAME="standx"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 # Colors
 RED='\033[0;31m'
@@ -90,6 +89,17 @@ sha256_of() {
     fi
 }
 
+binary_version() {
+    binary_path=$1
+    output=$(env -i \
+        PATH="${PATH:-/usr/bin:/bin}" \
+        HOME="${HOME:-/}" \
+        LANG="${LANG:-C}" \
+        TMPDIR="${TMPDIR:-/tmp}" \
+        "$binary_path" --version 2>/dev/null) || return 1
+    printf '%s\n' "$output" | awk '{print $NF}'
+}
+
 # Main installation logic
 main() {
     say "${GREEN}=== StandX CLI Installer ===${NC}"
@@ -97,6 +107,39 @@ main() {
 
     command -v curl >/dev/null 2>&1 || die "curl is required but was not found"
     command -v tar >/dev/null 2>&1 || die "tar is required but was not found"
+    command -v env >/dev/null 2>&1 || die "env is required but was not found"
+
+    # A standalone install must remain writable by the user so `standx update`
+    # can atomically replace it later without elevating privileges.
+    if [ -z "${INSTALL_DIR:-}" ]; then
+        [ -n "${HOME:-}" ] || die "HOME is not set; choose an install directory with INSTALL_DIR"
+        INSTALL_DIR="${HOME}/.local/bin"
+    fi
+    if [ ! -d "$INSTALL_DIR" ]; then
+        if ! mkdir -p "$INSTALL_DIR"; then
+            die "Unable to create install directory $INSTALL_DIR.
+Choose a directory you own, for example:
+  INSTALL_DIR=\"\$HOME/.local/bin\""
+        fi
+    fi
+    if [ ! -w "$INSTALL_DIR" ]; then
+        die "Install directory $INSTALL_DIR is not writable.
+Choose a directory you own, for example:
+  INSTALL_DIR=\"\$HOME/.local/bin\"
+This installer deliberately does not elevate privileges. For a system-managed
+macOS install, use Homebrew instead."
+    fi
+
+    staging_dir=
+    tmp_dir=
+    cleanup() {
+        [ -z "${tmp_dir:-}" ] || rm -rf "$tmp_dir"
+        [ -z "${staging_dir:-}" ] || rm -rf "$staging_dir"
+    }
+    trap cleanup 0 HUP INT TERM
+    staging_dir=$(mktemp -d "${INSTALL_DIR}/.standx-install.XXXXXX") \
+        || die "Unable to create a staging directory in $INSTALL_DIR"
+    tmp_dir=$(mktemp -d) || die "Unable to create a temporary download directory"
 
     # Detect platform
     target=$(get_target)
@@ -111,7 +154,7 @@ main() {
         tag=$(get_latest_tag) || die "Unable to determine the latest version.
 GitHub may be rate-limiting or blocking this network. Retry later, or pin a
 version explicitly:
-  curl -sSL https://raw.githubusercontent.com/${REPO}/main/install.sh | STANDX_VERSION=v1.2.0 sh"
+  curl -sSL https://raw.githubusercontent.com/${REPO}/main/install.sh | STANDX_VERSION=vX.Y.Z sh"
         say "Latest version: ${YELLOW}$tag${NC}"
     fi
 
@@ -119,10 +162,6 @@ version explicitly:
     tarball_name="${BINARY_NAME}-${tag}-${target}.tar.gz"
     download_url="https://github.com/${REPO}/releases/download/${tag}/${tarball_name}"
     checksums_url="https://github.com/${REPO}/releases/download/${tag}/checksums.txt"
-
-    # Create temp directory
-    tmp_dir=$(mktemp -d)
-    trap 'rm -rf "$tmp_dir"' EXIT
 
     # Download tarball
     echo ""
@@ -136,71 +175,94 @@ https://github.com/${REPO}/releases/tag/${tag} for available downloads."
     # Download checksums.txt
     echo "Downloading checksums.txt..."
     if ! curl -fsSL -o "${tmp_dir}/checksums.txt" "$checksums_url"; then
-        warn "Warning: Unable to download checksums.txt, skipping verification"
-    else
-        echo "Verifying file integrity..."
-        expected=$(awk -v f="$tarball_name" \
-            '$2 == f || $2 == "*" f {print $1; exit}' "${tmp_dir}/checksums.txt")
-        if [ -z "$expected" ]; then
-            warn "Warning: ${tarball_name} is not listed in checksums.txt, skipping verification"
-        elif ! actual=$(sha256_of "${tmp_dir}/${tarball_name}"); then
-            warn "Warning: no sha256 tool (shasum/sha256sum) found, skipping verification"
-        elif [ "$actual" != "$expected" ]; then
-            die "SHA256 verification failed, file may be corrupted or tampered
-  expected: $expected
-  actual:   $actual"
-        else
-            say "${GREEN}✓ Verification passed${NC}"
-        fi
+        die "Unable to download checksums.txt; nothing was installed"
     fi
+    echo "Verifying file integrity..."
+    expected=$(awk -v f="$tarball_name" \
+        '$2 == f || $2 == "*" f {print $1; exit}' "${tmp_dir}/checksums.txt")
+    if [ -z "$expected" ]; then
+        die "${tarball_name} is not listed in checksums.txt; nothing was installed"
+    fi
+    case "$expected" in
+        *[!0-9a-fA-F]*)
+            die "Checksum entry for ${tarball_name} is not a SHA-256 digest; nothing was installed"
+            ;;
+    esac
+    if [ "${#expected}" -ne 64 ]; then
+        die "Checksum entry for ${tarball_name} is not a SHA-256 digest; nothing was installed"
+    fi
+    if ! actual=$(sha256_of "${tmp_dir}/${tarball_name}"); then
+        die "No SHA-256 tool (shasum or sha256sum) was found; nothing was installed"
+    fi
+    if [ "$actual" != "$expected" ]; then
+        die "SHA256 verification failed, file may be corrupted or tampered
+  expected: $expected
+  actual:   $actual
+Nothing was installed."
+    fi
+    say "${GREEN}✓ Verification passed${NC}"
 
-    # Extract
+    # Extract into the destination filesystem so the final rename is atomic.
     echo ""
     echo "Extracting..."
-    tar -xzf "${tmp_dir}/${tarball_name}" -C "$tmp_dir"
+    if ! tar -xzf "${tmp_dir}/${tarball_name}" -C "$staging_dir" standx; then
+        die "Unable to extract standx from ${tarball_name}; nothing was installed"
+    fi
 
     # Check extracted binary
-    binary_path="${tmp_dir}/${BINARY_NAME}"
-    if [ ! -f "$binary_path" ]; then
-        die "Binary file ${BINARY_NAME} not found after extraction"
+    binary_path="${staging_dir}/${BINARY_NAME}"
+    if [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; then
+        die "Release archive did not contain a regular ${BINARY_NAME} binary; nothing was installed"
+    fi
+    chmod +x "$binary_path" || die "Unable to mark the new binary executable; nothing was installed"
+
+    # Run the downloaded binary with a cleared environment before it replaces
+    # anything. Checksums protect integrity, not release provenance, so secrets
+    # such as STANDX_JWT and STANDX_PRIVATE_KEY must not be inherited here.
+    expected_version=${tag#v}
+    if ! reported_version=$(binary_version "$binary_path"); then
+        die "Downloaded binary could not run on this machine; nothing was installed"
+    fi
+    if [ "$reported_version" != "$expected_version" ]; then
+        die "Downloaded binary reports ${reported_version}, but the release is ${expected_version}; nothing was installed"
     fi
 
-    # Check install directory permissions
-    if [ ! -d "$INSTALL_DIR" ]; then
-        warn "Install directory $INSTALL_DIR does not exist, attempting to create..."
-        sudo mkdir -p "$INSTALL_DIR" || die "Unable to create install directory"
-    fi
-
-    # Install
+    # The staged binary and destination share a filesystem, so this replacement
+    # is atomic even when an older standx already exists.
+    install_path="${INSTALL_DIR}/${BINARY_NAME}"
     echo ""
-    echo "Installing to ${INSTALL_DIR}/${BINARY_NAME}..."
-    if [ -w "$INSTALL_DIR" ]; then
-        mv "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
-        chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
-    else
-        warn "Administrator privileges required to install to $INSTALL_DIR"
-        sudo mv "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}" \
-            || die "Unable to install to ${INSTALL_DIR} (sudo failed)"
-        sudo chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
-    fi
+    echo "Installing to ${install_path}..."
+    mv -f "$binary_path" "$install_path" \
+        || die "Unable to atomically install to ${install_path}; the previous binary was left unchanged"
 
-    # Verify installation
+    # Verify the exact installed path, not whichever older copy PATH resolves.
     echo ""
     echo "Verifying installation..."
-    if command -v "$BINARY_NAME" >/dev/null 2>&1; then
-        version=$($BINARY_NAME --version 2>/dev/null || echo "unknown")
-        say "${GREEN}✓ Installation successful!${NC}"
-        echo ""
-        say "Version: ${YELLOW}$version${NC}"
-        echo ""
-        echo "Get started with:"
-        say "  ${YELLOW}standx --help${NC}          Show help"
-        say "  ${YELLOW}standx --version${NC}       Show version"
-        say "  ${YELLOW}standx auth login${NC}      Authenticate"
-    else
-        warn "Warning: Installation complete, but $BINARY_NAME is not in PATH"
-        echo "Please ensure $INSTALL_DIR is in your PATH environment variable"
+    installed_version=$(binary_version "$install_path") \
+        || die "Installed binary at ${install_path} could not report its version"
+    if [ "$installed_version" != "$expected_version" ]; then
+        die "Installed binary at ${install_path} reports ${installed_version}, expected ${expected_version}"
     fi
+    say "${GREEN}✓ Installation successful!${NC}"
+    echo ""
+    say "Version: ${YELLOW}${BINARY_NAME} ${installed_version}${NC}"
+
+    resolved=$(command -v "$BINARY_NAME" 2>/dev/null || true)
+    if [ "$resolved" != "$install_path" ]; then
+        if [ -n "$resolved" ]; then
+            warn "Warning: PATH currently resolves ${BINARY_NAME} to ${resolved}, not ${install_path}"
+        else
+            warn "Warning: ${install_path} is not currently in PATH"
+        fi
+        echo "Add the install directory before other copies:"
+        echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    fi
+
+    echo ""
+    echo "Get started with:"
+    say "  ${YELLOW}standx --help${NC}          Show help"
+    say "  ${YELLOW}standx --version${NC}       Show version"
+    say "  ${YELLOW}standx auth login${NC}      Authenticate"
 }
 
 # Run main function

--- a/scripts/test_install.sh
+++ b/scripts/test_install.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
+INSTALLER_UNDER_TEST=${INSTALLER_UNDER_TEST:-"${REPO_ROOT}/install.sh"}
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' 0 HUP INT TERM
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+sha256_of() {
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        sha256sum "$1" | awk '{print $1}'
+    fi
+}
+
+clean_version() {
+    env -i PATH="/usr/bin:/bin" "$1" --version
+}
+
+case "$(uname -s):$(uname -m)" in
+    Darwin:arm64|Darwin:aarch64)
+        TARGET=aarch64-apple-darwin
+        ;;
+    Linux:x86_64|Linux:amd64)
+        TARGET=x86_64-unknown-linux-gnu
+        ;;
+    Linux:aarch64|Linux:arm64)
+        TARGET=aarch64-unknown-linux-gnu
+        ;;
+    *)
+        fail "unsupported test platform"
+        ;;
+esac
+
+TAG=v9.8.7
+ASSET="standx-${TAG}-${TARGET}.tar.gz"
+FAKE_BIN="${TEST_ROOT}/fake-bin"
+RELEASE_DIR="${TEST_ROOT}/release"
+PAYLOAD_DIR="${TEST_ROOT}/payload"
+mkdir -p "$FAKE_BIN" "$RELEASE_DIR" "$PAYLOAD_DIR"
+
+cat >"${FAKE_BIN}/curl" <<'EOF'
+#!/bin/sh
+output=
+url=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            output=$2
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            url=$1
+            shift
+            ;;
+    esac
+done
+
+[ -n "$output" ] && [ -n "$url" ] || exit 2
+asset=${url##*/}
+if [ "$asset" = "checksums.txt" ] && [ "${FAKE_CHECKSUM_FAILURE:-0}" = "1" ]; then
+    exit 22
+fi
+cp "${FAKE_RELEASE_DIR}/${asset}" "$output"
+EOF
+
+cat >"${FAKE_BIN}/sudo" <<'EOF'
+#!/bin/sh
+printf 'called\n' >"${FAKE_TEST_ROOT}/sudo-called"
+exit 99
+EOF
+
+cat >"${FAKE_BIN}/standx" <<'EOF'
+#!/bin/sh
+printf 'standx 0.1.0\n'
+EOF
+
+chmod +x "${FAKE_BIN}/curl" "${FAKE_BIN}/sudo" "${FAKE_BIN}/standx"
+
+build_release() {
+    version=$1
+    {
+        printf '%s\n' '#!/bin/sh'
+        printf '%s\n' 'if [ -n "${STANDX_JWT:-}" ] || [ -n "${STANDX_PRIVATE_KEY:-}" ]; then'
+        printf '%s\n' '    echo "secret environment leaked into version probe" >&2'
+        printf '%s\n' '    exit 42'
+        printf '%s\n' 'fi'
+        printf 'printf "standx %s\\n"\n' "$version"
+    } >"${PAYLOAD_DIR}/standx"
+    chmod +x "${PAYLOAD_DIR}/standx"
+    tar -czf "${RELEASE_DIR}/${ASSET}" -C "$PAYLOAD_DIR" standx
+    digest=$(sha256_of "${RELEASE_DIR}/${ASSET}")
+    printf '%s  %s\n' "$digest" "$ASSET" >"${RELEASE_DIR}/checksums.txt"
+}
+
+assert_no_staging_dirs() {
+    install_dir=$1
+    leftovers=$(find "$install_dir" -maxdepth 1 -name '.standx-install.*' -print)
+    [ -z "$leftovers" ] || fail "installer left staging directories behind: $leftovers"
+}
+
+build_release 9.8.7
+success_home="${TEST_ROOT}/success-home"
+success_output="${TEST_ROOT}/success-output"
+HOME="$success_home" \
+PATH="${FAKE_BIN}:$PATH" \
+STANDX_VERSION="$TAG" \
+STANDX_JWT=secret-jwt \
+STANDX_PRIVATE_KEY=secret-key \
+FAKE_RELEASE_DIR="$RELEASE_DIR" \
+FAKE_TEST_ROOT="$TEST_ROOT" \
+sh "$INSTALLER_UNDER_TEST" >"$success_output" 2>&1
+
+installed="${success_home}/.local/bin/standx"
+[ -x "$installed" ] || fail "default install did not create $installed"
+[ "$(clean_version "$installed")" = "standx 9.8.7" ] || fail "installed version is wrong"
+[ ! -e "${TEST_ROOT}/sudo-called" ] || fail "installer invoked sudo"
+grep -q "PATH currently resolves standx to ${FAKE_BIN}/standx" "$success_output" \
+    || fail "installer did not report the shadowing PATH entry"
+assert_no_staging_dirs "${success_home}/.local/bin"
+
+failure_home="${TEST_ROOT}/checksum-failure-home"
+mkdir -p "${failure_home}/.local/bin"
+cp "${FAKE_BIN}/standx" "${failure_home}/.local/bin/standx"
+if HOME="$failure_home" \
+    PATH="${FAKE_BIN}:$PATH" \
+    STANDX_VERSION="$TAG" \
+    FAKE_CHECKSUM_FAILURE=1 \
+    FAKE_RELEASE_DIR="$RELEASE_DIR" \
+    FAKE_TEST_ROOT="$TEST_ROOT" \
+    sh "$INSTALLER_UNDER_TEST" >"${TEST_ROOT}/checksum-failure-output" 2>&1
+then
+    fail "installer succeeded without checksums.txt"
+fi
+[ "$(clean_version "${failure_home}/.local/bin/standx")" = "standx 0.1.0" ] \
+    || fail "checksum failure replaced the existing binary"
+assert_no_staging_dirs "${failure_home}/.local/bin"
+
+build_release 9.8.6
+mismatch_home="${TEST_ROOT}/version-mismatch-home"
+mkdir -p "${mismatch_home}/.local/bin"
+cp "${FAKE_BIN}/standx" "${mismatch_home}/.local/bin/standx"
+if HOME="$mismatch_home" \
+    PATH="${FAKE_BIN}:$PATH" \
+    STANDX_VERSION="$TAG" \
+    FAKE_RELEASE_DIR="$RELEASE_DIR" \
+    FAKE_TEST_ROOT="$TEST_ROOT" \
+    sh "$INSTALLER_UNDER_TEST" >"${TEST_ROOT}/version-mismatch-output" 2>&1
+then
+    fail "installer accepted a binary whose version did not match the release"
+fi
+[ "$(clean_version "${mismatch_home}/.local/bin/standx")" = "standx 0.1.0" ] \
+    || fail "version mismatch replaced the existing binary"
+assert_no_staging_dirs "${mismatch_home}/.local/bin"
+
+printf 'install.sh tests passed\n'


### PR DESCRIPTION
## Summary
- default standalone installs to the user-owned `~/.local/bin` path and remove implicit privilege elevation
- fail closed on missing or malformed checksums, probe the downloaded version with a cleared environment, and replace atomically on the destination filesystem
- add hermetic installer coverage to CI and align the user-facing installation docs

## Validation
- `sh -n install.sh`
- `sh -n scripts/test_install.sh`
- `sh scripts/test_install.sh`
- `cargo fmt --all -- --check`
- `cargo test --workspace --locked --offline` (556 passed, 1 ignored)
- `cargo clippy --workspace --all-targets --locked --offline -- -D warnings`
- real macOS aarch64 v1.3.0 install and forced self-update in an isolated temporary HOME
- checksum fail-closed regression test verified by implementation mutation