### PR TITLE
docs(maker): markout 尾部分解证据 + 候选 4 上限钉死 + 候选 6（尾部避让）立项线索

### DIFF
--- a/docs/25-maker-short-term-roadmap-2026-07-27.md
+++ b/docs/25-maker-short-term-roadmap-2026-07-27.md
@@ -91,13 +91,44 @@ B/C/D 等硬化项）未做。候选 2（基线 PnL 采集）仍是推荐的下�
 移动斜率 ≈ 1 且线性延伸到 ±2bps 桶，成交时点逆向选择系统性存在（买 -3.2 /
 卖 +3.65bps），反事实上限 λ=0.5 → +0.27（回收亏损 25~50%）。设计与预注册判据见
 [28-maker-external-skew-design.md](28-maker-external-skew-design.md)。
-**不占 live 时间片、窗口内不部署**；裁决与 A/B 排在基线 PnL 窗口收尾之后。
+**不占 live 时间片、窗口内不部署**；裁决与 A/B 排在一次**有效**基线采集 run 收尾
+之后（原"2026-07-31T08:17Z"的日历式表述已失效：三次 run 全部被截断）。
 microprice（盘口量失衡）降为第二优先，阻塞在 depth 观测字段（量从未落日志）。
+
+**2026-07-31 细化（设计已可上裁决桌）**：补完了四处——guard 激活期间的复合语义、
+band 预算红线（`spread + nonlinear.cap + external.cap ≤ band`，8+12+8=28≤30，
+故 `cap_bps=8` 是上限）、证据溯源（离线证据来自 run1 `819f0f0`，信号侧可平移、
+水位侧不可，故 **run1 不得充当 baseline 臂**）、以及验收判据的统计功效口径。
+功效那条原判据（"每臂 ≥250 笔 fill" + "markout@30s 改善 ≥2bps"）缺功效论证，
+已补：**σ 于 2026-07-31 实测 = 8.60bps**（两个 baseline-pnl run 池化 n=633、~44h，
+script 口径），代入单侧 α=0.05/power=80% 得 Δ=2bps 需 **229 笔/臂**——
+**原样本量在名义口径下刚好够用**（n=250 时 MDE=1.91bps、功效 83%），施工前按波动上限
+推的 σ=15~25 被实测否掉。**真正的约束是序列相关**（成交成簇、有效样本小于名义样本），
+窗口长度按它定而非按 σ 定。判据同时定稿了 markout 口径（script，不含 capture；与
+runner 口径差一个 capture，实测已对上：-8.09+2.91=-5.18 ≈ 遥测 -5.14）。
+序列相关也已实测（block bootstrap，44 个小时块）：**只有 mo30s 真扎堆**
+（deff 1.8/2.0/3.1 @ 1h/2h/4h 块，且 4h 未封顶，故 3.1 只是下界），capture / mo1s /
+mo5s / drift15s 基本不扎堆。据此定稿窗口：**硬下限 700 笔/臂，授权按 ~1000 笔
+（≈70h）申请**，且**最终置信区间用 block bootstrap（4h 块）在实测数据上算，不用
+假定 deff 反推**——预注册的是方法不是 deff 取值，估错只会落进 inconclusive 分支。
+自举块 4h 与编排的 12h 臂块整齐嵌套。
+**"Stage A 机制段 / Stage B 经济段"两段式已撤销**：中间量 AS 的样本需求与 markout
+同量级，先跑不省时间。改为单窗口跑到底、两指标分析时一起算，AS 降为**诊断量**
+（决定 rejected 之后是关闭方向还是转 microprice），不设硬阈值、不得用于晋级。
+**剩一个未知量**：AS 的实测 σ（口径是 `external_divergence_bps` 的**成交时刻条件
+分布**，不是场内 drift，也不是早前反推的全 cycle 无条件 σ≈2.5）——不占 live 时间片。
 
 ### 候选 3：挂账清理与质量债
 
 - `maker-recovery-dedup` 分支封存（见现状盘点，已确认可无损删除）；
-- Divergence B + C 实现（默认关、replay 等价）——若走候选 1，这两项直接并入 5-b；
+- ~~Divergence B + C 实现（默认关、replay 等价）~~ **已于 2026-07-28 复核后出清**（见现状
+  盘点）：C（熔断豁免）关闭——共享恢复熔断早已从代码移除，没有可豁免的对象；B（恢复迟滞）
+  与 D（tick 阈值）降级为观测项，立项触发条件已预注册（单次 standby >10min / 窗口内累计
+  >1% 运行时间 / 证明发生在"阈值上方悬停"），唯一证据来源是
+  [27 号手册](27-maker-baseline-pnl-collection-runbook.md)的每日 `divergence_standby` /
+  `transport_standby` 记录。**本候选名下不再有 Divergence 代码项**；命中触发条件后按 18 号
+  文档 v0 流程重新立项，B 与 D 合并评估（同属阈值形状问题）。
+  复核记录见 [maker-divergence-degradation-review-2026-07-28.md](evidence/maker-divergence-degradation-review-2026-07-28.md)。
 - 质量债 #259（dedup 残余）/ #261（CLI 一致性）/ #277（请求生命周期关联）。
 
 ### 候选 5（Phase 1+2 已完成，2026-07-30）：cleanup 残余判定硬化

--- a/docs/28-maker-external-skew-design.md
+++ b/docs/28-maker-external-skew-design.md
@@ -1,9 +1,15 @@
-# 外部领先价连续偏移（`[external_skew]`）立项设计（2026-07-29 草案）
+# 外部领先价连续偏移（`[external_skew]`）立项设计（2026-07-29 草案，2026-07-31 细化）
 
-状态：**草案，待 release owner 裁决**。live 时间片前置：基线 PnL 采集窗口
-（[27 号手册](27-maker-baseline-pnl-collection-runbook.md)，run
-`baseline-pnl-20260728T081712Z`）2026-07-31T08:17Z 收尾之后才可上 A/B。
-窗口内不碰冻结基线，本文档与离线分析不消耗 live 时间片。
+状态：**草案，待 release owner 裁决**。2026-07-31 细化了四处（机制与配置面不变）：
+guard 激活期间的复合语义、band 预算红线、验收判据的统计功效口径、证据溯源。
+
+live 时间片前置（**2026-07-31 更新**）：原文写的是"采集窗口 2026-07-31T08:17Z
+收尾之后"，该表述已失效——三次基线采集 run 全部被截断（run1 35.9h 读-写滞后误报、
+run2 2min / run3 51min 两帧 ack，见
+[截断报告](evidence/maker-baseline-pnl-2026-07-30-run2-truncated.md)），没有任何一次
+跑到授权窗口末端。**现行前置改为条件式**：一次**有效**基线采集 run 收尾（[27 号手册](27-maker-baseline-pnl-collection-runbook.md)
+的终止条件之一命中，不是按日历日期）。窗口内不碰冻结基线，本文档与离线分析不消耗
+live 时间片。
 
 上游口径：[18-maker-strategy-roadmap.md](18-maker-strategy-roadmap.md)；
 信号源机制沿用 [22 号设计](22-maker-stage3v1-guard-design.md)的
@@ -74,6 +80,27 @@ microprice（盘口量失衡）类候选保留为第二优先，等 depth 观测
   要求"重启须以新的独立证据立项"，guard accepted（07-27）与本节 (a)(b) 正是
   阶段 4 终止（07-20）之后到达的新独立证据。
 
+### 4. 证据溯源与代码基线（2026-07-31 补）
+
+上面 (a)~(d) 的全部离线数字来自**单一 run**：`baseline-pnl-20260728T081712Z`
+（代码 `819f0f0`，配置 `6314a374…`，35.9h / 527 fills，
+[读数报告](evidence/maker-baseline-pnl-2026-07-30.md)；(a)(b)(c) 用的是该 run
+19.4h / 289 fills 时点的中间切片，末态读数为 capture +5.19 / markout@30s -5.14bps，
+与 19h 时点同向同量级）。裁决时必须知道这条证据链跨了一次代码变更：
+
+- **A/B 将跑的二进制 ≠ run1 的 `819f0f0`**。07-30/31 之间合并了 cleanup 残余判定
+  硬化（[29 号文档](29-maker-cleanup-residual-verification.md) Phase 1+2）与两帧
+  ack 三处修复（`4464167` / `97d14e8` / `02f6cea`）。
+- **信号侧证据可以平移**：这些修复动的是撤单/下单 ack 落账与 cleanup 残余判定，
+  不碰报价中心、excess 计算、band/no-cross、refresh。excess→30s mark 移动的斜率
+  与成交时点的 excess 分布（(a)(b)）是市场性质与信号性质，不因订单生命周期记账
+  改变。
+- **水位侧证据不能平移**：uptime、fill 数、以及"两帧 ack 被误判为通道损坏"路径上
+  的 PnL，都可能因修复而变。**因此 run1 不得充当 A/B 的 baseline 臂**——baseline
+  必须与 candidate 跑同一个二进制、同一时期（见验收判据的编排要求）。
+- 冻结基线配置文件本身未变（`maker-guard-hype-candidate.toml`，sha256
+  `6314a374…`）；candidate 臂 = 该文件 + `[external_skew]` 四个键，其余不动。
+
 ## 机制设计（`[external_skew]`）
 
 报价梯子已有唯一中心锚点：`skew_center_with`（`standx-maker/src/lib.rs`，
@@ -94,9 +121,60 @@ shift_bps = clamp(λ × excess_bps, ±cap_bps)     |excess| < dead_zone 时为 0
   （≥10bps）单侧 stale 是质变（价位即将被打穿），保留现有压制语义作为尾部保险。
   **候选臂 = 冻结基线（nonlinear_skew + guard 双开）+ `[external_skew]`，
   其他一个字节不动。**
+
+### guard 激活期间的复合语义（2026-07-31 定稿）
+
+原草案只说了"中段 / 尾部分工"，没回答 guard 实际激活时 skew 怎么办。guard 有
+`enter=10 / exit=5` 的迟滞，所以存在一段 `excess ∈ [5, 10)` 且 guard **仍然激活**
+的区间，这一区间必须有明确语义。**定稿：`external_skew` 无条件作用于 center，
+与 guard 状态完全解耦。**
+
+- 两者作用在**不同的杠杆**上，不存在重复计数：guard 决定"危险侧这一轮还挂不挂"
+  （[lib.rs:764](../crates/standx-maker/src/lib.rs:764) 的 `guard.active &&
+  endangered == Some(side)` → `continue`，整侧不挂 + resting 走
+  `SideSuppressed` 撤单），skew 决定"挂着的那些单的锚点在哪"。guard 激活时危险侧
+  根本没有报价，center 偏移对它无意义；**存活侧的偏移方向恰好是保护性的**——
+  excess>0 时危险侧 = Sell 被摘掉，剩下 Buy，center 上推使买价更靠近即将上行的
+  mark，正是"在上行前买到"的方向。
+- **拒绝的备选：guard 激活期间令 shift=0**。会在 `enter_bps` 处造成不连续跳变
+  （shift 从 cap 突降到 0），且把存活侧的保护性偏移一起关掉；还会让纯函数依赖
+  guard 状态机，破坏无状态性与 replay 可测性。
+- **代价（记录，不设门槛）**：guard 激活占比实测 1.58%（run1）/ 0.52–1.92%
+  （guard 轮 6 臂），这段时间内 skew 顶在 `cap_bps` 附近的单侧报价会略微加大
+  库存偏斜倾向。已被 `cap_bps` + 库存 guardrail 覆盖，不单独设判据。
+
+### band 预算红线（2026-07-31 新增）
+
+`external_skew` 与库存 skew 在同一 center 上**同号叠加**（最坏情况），而 band
+资格区间锚定的是**真实 mark**（[lib.rs:745](../crates/standx-maker/src/lib.rs:745)
+注释明确："Band eligibility is defined around the TRUE mark, not the skewed
+center"）。故远侧报价到 mark 的距离在最坏情况下是三项之和，必须留在 band 内：
+
+```
+spread_bps + (levels − 1) × level_step_bps + nonlinear.cap_bps + external_skew.cap_bps ≤ band_bps
+```
+
+冻结基线代入：`8 + 0 + 12 + 8 = 28 ≤ 30`（`levels=1`，故 level_step 项为 0），
+**留 2bps 余量，`cap_bps = 8` 是能取的上限**。这条红线与
+[22 号文档](22-maker-stage3v1-guard-design.md)的 `spread + cap ≤ band`（8+12=20）
+同源，只是多消耗了 8bps 预算。
+
+越线的后果不是报错，是**静默劣化**，两条都值得知道：
+
+1. **band 夹取（饱和）**：越出 band 的价格被 `clamp(price_lo, price_hi)` 夹到
+   band 边沿（[lib.rs:805](../crates/standx-maker/src/lib.rs:805)），不是丢弃该侧
+   ——报价照挂，但远侧钉在边沿，梯子变成非预期的不对称形状，且此后 center 再动
+   对该侧价格不再有任何影响（机制在这一侧失效而无任何告警）。
+2. **撤单 churn**：refresh 判据比的是 **center 漂移**而非价格差
+   （[lib.rs:965](../crates/standx-maker/src/lib.rs:965)
+   `bps_diff(center, r.ref_center) > refresh_bps`）。价格已被夹住时，center 继续
+   移动仍会触发 `MarkMovedBeyondRefresh` → 撤单重挂到**同一个价格**，纯 churn。
+
 - **band / no-cross / refresh 照旧**，以新 center 为锚。`refresh_bps=4` 天然
-  限流：λ=0.5 时 excess 2~6bps 产生 1~3bps 偏移，不触发重挂，平静期不增加
-  撤单 churn；死区进一步防止漂移累积造成的抖动。
+  限流：λ=0.5 时 excess 2~6bps 产生 1~3bps 偏移，单独不触发重挂，平静期不增加
+  撤单 churn；死区进一步防止漂移累积造成的抖动。**但注意偏移是叠加在库存驱动的
+  center 漂移之上的**，二者合成后越过 4bps 的频率高于任一单独作用，所以撤单率
+  guardrail 是本轮最可能被触发的那一条（见验收判据）。
 - **配置面**（`[external_skew]`，默认关，缺省即 replay 等价）：
   - `enabled`（默认 false）
   - `lambda`（偏移系数，预注册单臂 0.5）
@@ -107,8 +185,10 @@ shift_bps = clamp(λ × excess_bps, ±cap_bps)     |excess| < dead_zone 时为 0
 
 - **反事实估计的选择效应盲区**：上限口径假设全部 fill 平移后仍成交。真实世界
   里中心偏移留下最毒的 fill（价格打穿新旧两档）、丢掉边际好 fill——符号与
-  量级日志不可算，**只能 A/B 实测**。预注册判据必须建在 live markout 上，
-  不得用离线反事实数作为晋级证据。
+  量级日志不可算，**只能 A/B 实测**。**晋级判据必须建在 live markout 上**，
+  不得用离线反事实数作为晋级证据。（2026-07-31 澄清：AS 是 live 实测量而非离线
+  反事实数，但它已降为**诊断量、不得用于晋级**，与本条同向——本条挡的正是"用便宜的
+  中间指标替代经济指标去晋级"。）
 - **basis 漂移**：静态 basis（HYPE 观测 ~-14bps 场馆溢价）若缓慢漂移，300s
   EWMA 跟踪期内的残差会变成持续性偏移 → 单向推报价 → 库存偏斜。`cap_bps` +
   `dead_zone_bps` 是第一道防线；A/B 期间把库存均值/方差列为 guardrail。
@@ -122,6 +202,16 @@ shift_bps = clamp(λ × excess_bps, ±cap_bps)     |excess| < dead_zone 时为 0
 - `cycle_summary` 新增 `external_skew_shift_bps`（本轮实际应用的偏移，含 0）。
 - `external_skew` 事件（shift 越过 dead_zone 或方向翻转时记录，风格同
   `external_guard` 事件）。
+- **fill 事件新增 `excess_bps_at_fill`（2026-07-31 新增，AS 诊断量的直接输入）**：
+  成交被观测到的时刻在用的那个 excess 样本。立项依据 (b) 的买 -3.2 / 卖 +3.65 是
+  按时间把 fill join 到 `cycle_summary` 算出来的——估 σ 可以这么干，但
+  **AS 要进判定报告，不该建在一次时间 join 上**（成交可能落在两个 cycle
+  之间，join 的归属规则会变成读数的隐藏自由度）。
+  - **两臂都必须落这个字段**，与 `external_skew.enabled` 无关——否则 baseline 臂
+    没有 AS 读数，无从对比。字段可用性只依赖 guard 链路的 excess 样本
+    （冻结基线里 guard 是开的，两臂都有）。样本缺失/过期时写 null，不写 0
+    （0 是"无偏离"这个真实取值，与"没测到"必须可区分）。
+  - 纯遥测新增，不进决策路径，replay 的 action 序列不受影响。
 - 现有 `external_divergence_bps` / `external_basis_bps` / guard 事件不动。
 
 ## 实现边界
@@ -129,9 +219,16 @@ shift_bps = clamp(λ × excess_bps, ±cap_bps)     |excess| < dead_zone 时为 0
 - `standx-maker`：纯函数 `external_skew_shift_bps(excess_bps, cfg) -> f64`
   （clamp + 死区，无状态、无 I/O、无时钟），以及 center 复合点；replay 等价
   （默认关）。测试：死区/clamp/符号方向/fail-open（无样本 → 0）、与库存 skew
-  复合的确定性。
+  复合的确定性、**guard 激活期间 shift 照常施加**（复合语义定稿的回归锁）、
+  **band 边沿行为**（构造越线配置，断言远侧被夹到 band 而非丢弃，锁住"静默劣化"
+  这一事实本身）。
 - `standx-cli`：配置解析（`[external_skew]` → domain）、把 guard 链路已算好的
   excess 喂给 planner、遥测字段与事件。不新增订阅、不改 feed。
+  **配置校验**：`enabled=true` 时校验 band 预算红线
+  （`spread_bps + (levels−1) × level_step_bps + nonlinear.cap_bps +
+  external_skew.cap_bps ≤ band_bps`）与 `cap_bps < external_guard.enter_bps`，
+  越线拒绝启动而不是静默夹取。校验放 CLI 侧（band/levels 都是 CLI 配置面的东西，
+  core 纯函数不该知道梯子形状）。
 - 不改动：guard 判定语义、basis half-life、refresh/band/no-cross、输出契约
   （只增不改）。
 
@@ -139,20 +236,191 @@ shift_bps = clamp(λ × excess_bps, ±cap_bps)     |excess| < dead_zone 时为 0
 
 两臂：baseline = 冻结基线（`maker-guard-hype-candidate.toml` 原样）；
 candidate = baseline + `[external_skew] enabled, lambda=0.5, cap_bps=8,
-dead_zone_bps=1`。跑法沿用 guard 轮的编排器与时长口径（每臂 ≥36h 或
-≥250 笔 fill，以先到后补为准，启动时写入授权文本）。
+dead_zone_bps=1`。两臂**必须跑同一个二进制**（见证据溯源：run1 不能充当 baseline）。
 
-- **primary**：逐笔签名 markout@30s，candidate 相对 baseline 改善 ≥ 2bps
-  （约相对 1/3），且 5s markout 不恶化超过 1bps。
-- **guardrail**（任一命中即 rejected，不论 primary）：
-  - passive capture 掉幅 > 1bps；
-  - 撤单率（cancel/quote-hour）上涨 > 50%；
-  - 时间加权库存均值 |position| 或 p95 显著上偏（basis 漂移征兆）；
-  - uptime 下降 > 2pp。
+> **2026-07-31 修订说明**：原草案写"每臂 ≥36h 或 ≥250 笔 fill" + "markout@30s 改善
+> ≥2bps"，但没有给出功效论证——σ 当时未测，判据是从 guard 轮抄来的时长口径。σ 已于
+> 2026-07-31 实测（见下节），结论是**原样本量在名义口径下刚好够用**，真正的约束来自
+> 序列相关而非 σ。本节按实测口径重写，机制与配置面一个字节没改。
+
+### 统计功效（σ 已实测，2026-07-31）
+
+primary 是**逐笔**签名 markout@30s 的两臂均值差。所需样本（单侧检验，假设是方向性的：
+candidate 更好；α=0.05、power=80%）：
+
+```
+n_per_arm = 2 σ² (z₀.₉₅ + z₀.₈)² / Δ²  =  12.37 σ² / Δ²
+MDE(n)    = σ √(12.37 / n)
+SE_diff   = σ √(2 / n)
+```
+
+**实测（2026-07-31）**：两个 baseline-pnl run 池化，n=633 笔被动成交、约 44h
+（≈14.4 fills/h）。口径为下文"script 口径"（从成交时的 mark 起算，不含 capture）：
+
+| 量 | mean | median | σ | sem |
+|---|---|---|---|---|
+| capture | +2.91 | +2.57 | 4.25 | 0.17 |
+| markout@1s | -2.63 | -0.00 | 4.17 | 0.17 |
+| markout@5s | -5.79 | -5.44 | 5.03 | 0.20 |
+| **markout@30s** | **-8.09** | -7.27 | **8.60** | 0.34 |
+
+代入 σ=8.60、Δ=2bps：
+
+| 口径 | Δ=2bps 所需 n/臂 | 折算时长/臂 |
+|---|---|---|
+| 单侧（预注册口径） | **229** | 16h |
+| 双侧（参考） | 291 | 20h |
+
+n=250/臂 时：SE_diff = 0.77bps，单侧 MDE = **1.91bps**，对真实效应 2bps 的功效
+≈ 83%。**即原判据的 250 笔在名义口径下刚好够分辨 2bps**——σ 的实测值远低于施工前
+的先验估计（先验按波动上限推 15~25，实测 8.6），此前"样本量差 6~8 倍"的判断按
+实测数据不成立。
+
+**σ 不是瓶颈，下面两条才是**（这也是窗口长度真正的定法）：
+
+1. **序列相关（binding）**：成交在时间上成簇，同一簇共享同一段行情，**有效样本
+   小于名义样本**，上表的 sem 是下界。按簇内相关 ρ 的方差膨胀因子
+   `VIF = 1 + (m−1)ρ`（m ≈ 14，即每小时的成交数）：
+
+   | ρ | VIF | Δ=2bps 实际所需 n/臂 | 折算时长/臂 |
+   |---|---|---|---|
+   | 0.05 | 1.65 | 378 | 26h |
+   | 0.10 | 2.30 | 527 | 37h |
+   | 0.20 | 3.60 | 824 | 57h |
+   | 0.30 | 4.90 | 1121 | 78h |
+
+   **已实测（2026-07-31，block bootstrap，44 个小时块）**：只有 mo30s 真的扎堆，
+   其余指标名义笔数≈有效笔数。
+
+   | 指标 | 名义 sem | deff（1h / 2h / 4h 块） | neff（名义 633） |
+   |---|---|---|---|
+   | capture | 0.17 | 1.2 / 1.1 / 1.3 | ~530 |
+   | markout@1s | 0.17 | 0.7 / 1.0 / 0.7 | ~660（不扎堆） |
+   | markout@5s | 0.20 | 1.2 / 1.2 / 1.2 | ~520 |
+   | **markout@30s** | 0.34 | **1.8 / 2.0 / 3.1** | 348 / 315 / **202** |
+
+   **deff 只是下界**：块长拉到 4h 时 deff 还在涨（1.8→2.0→3.1），说明同一段行情的
+   影响超过 4h，现有数据看不到它封顶在哪；且 4h 块只有 11 个，3.1 这个点估计的
+   误差棒很粗。**这是量级判断，不是精确值**——mo30 的部分扎堆还是机械性的（相邻
+   成交的 30s 前瞻窗口本身重叠），这部分不会因编排改善而消失。
+2. **regime 依赖**：这 44h 是单一行情段，σ 本身跨段会漂。故窗口按"≥n 笔 fill/臂"
+   计而不按小时计（candidate 的 center 偏移本身也会改变成交率），且两臂必须分块
+   交替以共享同一 regime 序列（见编排节）。
+
+**预注册样本量（2026-07-31 定稿）**：不押注 deff 这个数，押方法。
+
+| 名义笔数/臂 | deff=3 | deff=4 | deff=5 |
+|---|---|---|---|
+| 700（≈48h） | neff 233 ✓ | 175 ✗ | 140 ✗ |
+| **1000（≈70h）** | 333 ✓ | 250 ✓ | 200 △ |
+
+- **硬下限：每臂 ≥700 笔 fill。** 低于此不判定，直接算 inconclusive。
+- **授权按 ~1000 笔/臂（≈70h）申请**，deff 到 4 仍然够用。
+- **最终置信区间用 block bootstrap 在 A/B 实测数据上算，不用假定的 deff 反推。**
+  预注册的是**方法**而非 deff 的取值：deff 估错只会让区间变宽、落进已有的
+  inconclusive 分支（按原参数延长窗口，不改 λ、不加臂），不会伤到判定的有效性。
+- **自举块长 = 4h**（deff=3.1 的测量尺度）。自举块不得跨越换臂边界；编排的 12h
+  臂块与 4h 自举块整齐嵌套（每臂块 3 个自举块），70h/臂 约 17 个块。
+
+### markout 口径（预注册，2026-07-31 定稿）
+
+仓库里有两个 markout 定义，差一个 capture，此前设计文档混用了两者，实测数据把它
+们对上了：
+
+| 口径 | 起算点 | 含 capture | 实测 mo30 |
+|---|---|---|---|
+| **script**（[`maker_markout_ab.py`](../scripts/maker_markout_ab.py) 的 mo30，**预注册采用**） | 成交时的 mark | 否 | **-8.09** |
+| runner（`performance.markout_*` 遥测字段，仅记录） | 成交价 | 是 | -5.18 |
+
+一致性校验：`-8.09 (script) + 2.91 (capture) = -5.18`，与 run1 报告的遥测读数
+-5.14 吻合——两个口径确实只差一个 capture，没有第三种误差。
+
+**采用 script 口径**：它把"成交时机好不好"与"价差挣多少"分开，而本机制治的恰恰是
+前者；capture 已经单独是 guardrail，混在一个数里会让 primary 与 guardrail 相互污染。
+判定脚本与功效计算共用这一个口径。（注意：立项依据 1 的 -5.8 与读数报告的 -5.14 是
+runner 口径，立项依据 (d) 的 -10.6 是 script 口径下的**分桶条件**读数，都不是本节的
+池化 -8.09，引用时别混。）
+
+### primary 判据与 AS 诊断量
+
+> **2026-07-31 两次修订，结构已变**：原草案的"Stage A 机制段 / Stage B 经济段"
+> 两段式**撤销**。撤销理由是它唯一的卖点（"用便宜的中间指标先筛一遍"）经实测不成立：
+> 中间量 AS 的样本需求与 markout 同量级，先跑它不省时间，分段就只剩管理成本。
+> **改为单一窗口跑到底、两个指标在分析时一起算。**
+
+**primary**：逐笔签名 markout@30s（script 口径）改善 ≥ 2bps，判定看**单侧 95%
+置信下界 > 0 且点估计 ≥ 2bps**，区间用 **block bootstrap（4h 块）** 而非 iid 公式；
+且 5s markout 不恶化超过 1bps（σ=5.03、deff≈1.2，分辨力充裕）。
+
+**AS（逆选暴露）= 诊断量，不是判据**。定义：全部 passive fill 上"签名 excess"的
+均值，符号约定为**正 = 外部价预告的移动方向对我们不利**（买单成交时 excess 为负
+即不利，故买单取相反数、卖单取原值）。基线 ≈ **+3.4bps**（立项依据 (b) 的买 -3.2 /
+卖 +3.65 池化）。
+
+它的作用是**给 null 结果解释**——markout 没改善有两种完全不同的成因，后续动作相反
+（见判定表）：AS 也没动 = 机制压根没生效，关闭方向；AS 明显改善 = 机制生效但经济量
+没跟上（残余毒性占主导），转 microprice 并把本轮读数作为其立项证据。这个理由与成本
+无关，因此不受 σ 修正影响。
+
+- **不设 AS 的硬阈值**：定阈值需要 AS 的实测 σ，而该值尚未测出（见下）。它现在的
+  角色是解释而非判定，定性区分足够。
+- **AS 不得用于晋级**，任何情况下都不能替代 primary。这一点必须写进授权文本。
+- 保留一个**中途弃疗检查**（跑到一半时看一眼，两个指标都毫无动静则 owner 可提前停）：
+  纯省时间的选项，不是判定环节，不预设阈值，不对 primary 做效能声明，因此不需要对
+  α 做多重比较校正。
+
+**AS 的 σ 仍未实测（唯一剩余未知量）**。注意两个容易搞错的地方：
+
+- **AS 的 excess 是外部量，不是场内漂移。** 它来自 `[external_guard]` 链路的
+  `external_divergence_bps`（HL midPx − StandX mark，已扣 300s EWMA 静态基差），
+  **不是**成交前的场内 mark 漂移（drift）。用 drift 类指标当判据会把本轮变成已终止的
+  阶段 4 的翻版——立项依据 3 的边界正是"信息来自另一个场馆"。
+- 文档早前写的 σ_excess ≈ 2.5 是从立项依据 (a) 的**全 cycle 无条件分布**分桶反推的
+  （均值 +0.03），而 AS 要的是**成交时刻的条件分布**（均值 +3.4）。两者不是同一个
+  总体，那个 2.5 无论如何都要重测。
+
+测法（数据已具备，不占 live 时间片，不必等 `excess_bps_at_fill` 落地）：把 fill 按
+时间 join 到最近的 `cycle_summary`、取该轮 `external_divergence_bps`、按上述符号约定
+定号，估 σ 与 deff。**口径校验**：池化均值应落在 +3.4 附近，对不上说明 join 或符号
+搞错了。预注册判据仍要求字段化（见遥测节）——**时间 join 只用于估 σ，不得回填成
+预注册数**。
+
+### guardrail（任一命中即 rejected，不论 primary）
+
+- passive capture 掉幅 > 1bps（σ=4.25 实测，n=600 时 SE_diff=0.25bps，分辨力充裕）；
+- **撤单率（cancel/quote-hour）上涨 > 50%**——本轮最可能触发的一条，机理见
+  band 预算红线节（偏移叠加在库存 center 漂移之上，合成后更频繁越过
+  `refresh_bps=4`）；
+- 时间加权库存均值 |position| 或 p95 显著上偏（basis 漂移征兆）；
+- uptime 下降 > 2pp。
+
+### 编排：分块交替，不是两段长跑
+
+guard 轮的 PnL 读数就是因为"两臂窗口活跃度不同，混淆无法分离"而作废的
+（[25 号现状盘点](25-maker-short-term-roadmap-2026-07-27.md)）。本轮两臂按
+**≥12h 的块交替**，块边界覆盖不同 UTC 时段，使两臂的 regime 暴露大致平衡。
+
+- 代价：每次换臂要重启进程，而重启要过 cleanup / 残余判定这一关——run1/run2/run3
+  三次截断有两次死在这里。[29 号文档](29-maker-cleanup-residual-verification.md)
+  Phase 1+2 与两帧 ack 三处修复已合并，per-restart 风险已降低，**但这是本编排的
+  已知主要风险，不是零**。块长取 12h（而非 4h）就是为了把重启次数压到 ~10 次量级。
+- 交替不改善 primary 的功效（逐笔方差是主项，块设计治的是偏差不是方差），
+  所以样本量仍按上表算，不因交替打折。
+
+### 判定与后续
+
+判定按 primary（markout@30s）走，AS 只决定 rejected 之后往哪走：
+
+| 结果 | 处置 |
+|---|---|
+| primary 达标 + guardrail 全过 | **accepted**，并入新冻结基线（AS 读数记入报告作佐证，不参与判定） |
+| 样本 < 700 笔/臂，或 block bootstrap 区间跨 0 | **inconclusive**：按原参数把窗口延到 n 笔，**不改 λ、不加臂**（改参数就等于重新立项） |
+| 样本已达 n + primary 未达标 + **AS 也没动** | **rejected**，本立项关闭。结论是"外部价偏移挪不动成交时点"，机制本身没按模型工作 |
+| 样本已达 n + primary 未达标 + **AS 明显改善** | **rejected**，但这是有信息的否决：机制生效而经济量没跟上 = 立项依据 (d) 的残余毒性占主导 → 按 18 号 v0 流程转 microprice（阻塞在 depth 观测字段），并把本轮 AS/markout 联合读数作为该候选的立项证据 |
+| guardrail 命中 | **rejected**，不论 primary |
+
 - **PnL 依旧不作晋级条件**（沿用 skew/guard 两轮口径），但逐日记入报告。
-- 判定：accepted → 并入新冻结基线；rejected → 回滚配置，证据归档。
-- **不做多 λ 赛马**：单臂 λ=0.5（反事实估计中点）；accepted 后如需调优另行
-  立项。
+- **不做多 λ 赛马**：单臂 λ=0.5（反事实估计中点）；accepted 后如需调优另行立项。
 
 ## 明确不做
 


### PR DESCRIPTION
## 这个 PR 是什么

两个 baseline-pnl run 的 **markout 尾部分解**（纯离线只读），以及据此对候选 4 / 候选排序的修订。**纯文档，无代码。**

> **已 rebase 到 `origin/main`（2026-08-02）。** 原先本 PR 还包含 07-31 的设计细化（功效口径 / band 红线 / 复合语义 / 证据溯源），但那部分已经通过 `afc46d3` 进入 main，rebase 时被识别为 patch 等价并丢弃。**现在本 PR 只剩 08-01 这一轮证据工作**，diff 为三个文件 `+232 / −6`。

`[external_skew]` 的实现代码不在本 PR，走单独的 PR。

## 数据来源

两个独立 run，同配置（`maker-guard-hype-candidate.toml`，sha256 `6314a374…`），不同代码 sha：上轮 `baseline-pnl-20260728T081712Z`（527 笔被动成交 / 35.9h）、本轮 run4（36h 时点切片，513~522 笔，`run_id` 待回填）。

全部 markout 为 **script 口径**（从成交时的 mark 起算，不含 capture），与 28 号预注册口径一致。

## 五个发现

**1. markout 曲线在 30s 饱和，没有长尾**

| 视界 | 本轮 | 上轮 |
|---|---|---|
| 30s | -7.8 | -7.9 |
| 60s | -8.4 | -8.2 |
| 300s | -8.1 | -8.7 |
| 900s | -8.0 | -8.2 |

负占比从 30s 的 83% 降到 900s 的 58%（多数成交 30s 后仍在修复）。此前"伤害可能延伸到 1~5 分钟、因而 30s 视界低估"的假设**被否** —— 伤害确实落在外部领先价的有效窗口内。

**2. 净额对账：30s markout 已解释全部净亏**

`+2.8 − 7.8 − 1 ≈ −6bps/笔 × 513 × ~5.5 ≈ −1.66` = 会话净亏。不存在"找不到原因的另一半" —— 此前那个判断是 markout 口径混用造成的重复计数（把含 capture 的 runner markout 当毛伤害，又另计一遍毛利）。

**3. 亏损尾部主导，不是均匀渗透**

| 分组 | mo300 均值 | 占 markout 亏损质量 |
|---|---|---|
| 最差 10%（n≈103 两轮合计） | **-53 ~ -58 bps** | **60~72%** |
| 其余 90% | -2.5 ~ -4.0 bps | 28~40% |

有毒成交特征：单龄中位 **9~26 秒**（刚挂上就被打穿）、成交前 drift 略大。

**4. 外部 excess 对尾部无判别力**

有毒 10% 与其余 90% 的 `|div|` 几乎同分布（均值 4.04 vs 3.83、p90 6.96 vs 7.24，上轮同结论），`enter_bps=10` 在这 103 笔里**零激活**。尾部是场内成因（扫单 / 本所逆选）。

**5. 立项依据 (b) 三样本复现**

买 -3.2 / -3.25 / -3.35，卖 +3.65 / +3.31 / +3.53，全部落在 **±0.35bps** 内。靶子真实且稳定，从单次读数升级为可复现证据。

## 对候选 4 的处置：保持待裁决，不降级不关闭，但上限钉死

| 口径 | 量级 | 占当前净亏 |
|---|---|---|
| 现实（λ=0.5，(c) 反事实） | +0.27 / 35h | **~16%** |
| 理想（其余 90% 的 markout 全消除） | +0.6 ~ 1.1 / 35h | 36~66% |
| 尾部那 60~72% | **本机制碰不到** | — |

**即使 A/B 达标，策略仍然不赚钱。** 原文"回收 25~50%"易被读成"回收一半就快到平衡了"，已标注。这不构成否决理由（16% 是真钱、机制成本极低），但裁决不能按"这一个就能救活"来批。

性质定位：`[external_skew]` 是**改善价格**的机制，不是**避开成交**的机制 —— 与候选 6 不互斥、不重叠。

## 新增候选 6（尾部避让）：目前最大的靶子

60~72% 的亏损集中在最差 10%，成因是场内的。**设计文档暂不开写**，因为形态取决于一个待验证的成因假设：

> 是否"我们自己撞上去" —— refresh（漂移 > `refresh_bps=4`）触发撤单重挂，新单落进仍在移动的市场后立刻被扫。

- **成立** → 对策是重挂纪律（延迟补挂 / 临时加宽），可能是配置量级，**不需要 140h A/B**；
- **不成立** → 新单保护 / 打穿即撤类新机制，走 18 号 v0 流程。

验证只需现有 place / cancel / fill 时间线，不占 live 时间片，**尚未做**。

**排序建议**：A/B 按当前亏损速率（-0.046 DUSD/h）跑 140h 约烧 6.5 DUSD ≈ 权益 3.5%，**超过单次 `stop_loss=5.0` 预算**。不宜把 live 时间片先花在 16% 的杠杆上，而 72% 的杠杆还差一次免费的离线查询就能有设计。

## Reviewer 注意

- **run4 的 `run_id` 待回填**，证据文档里已标注占位。该 run 未收尾，以上为 36h 时点切片，收尾后应复核数字是否漂移。
- **两个百分比口径不同，别读成打架**：尾部占 **markout 亏损质量**的 60~72%；"全砍其余 90%"能拿回**净亏**的 36~66% —— 差别在于那些成交的 capture 收入仍然保留。文档内已注明。
- **一条作废记录**：分析中一度得出"有毒成交无外部预警 → 候选 4 应关闭"，因带符号 divergence 多乘了一个 side 符号而作废，证据文档内已记录。发现 4（尾部无判别力）建立在 `|div|` 同分布与 guard 零激活上，与符号无关，不受影响。
- **两条已知限制**：亚秒级外部领先会被 cycle 级（~2.4s）口径漏掉（但那种幅度也不在 λ×excess / cap 8bps 的作用范围）；盘口量从未落日志，故"薄档位"一类前置特征无法检验。
- **"亏损放缓"未裁决**：本轮前 20h 亏 1.5、后 17h 仅亏 0.16，但库存重估随价格方向变动，很可能是横盘 regime 而非策略改善。判别法（分段算逐笔 markout）已写入文档，尚未做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
