### PR TITLE
release: prepare v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.4] - 2026-07-31
+
+### Fixed
+- Forward-release corrected `v1.3.4` source and binaries after `v1.3.3` was accidentally published from the `v1.3.2` source commit and its assets reported `standx 1.3.2`.
+
 ### Changed
 - Release preparation now uses `scripts/release.py` with `Cargo.toml` as the version source of truth, and stable releases run through a guarded manual workflow that verifies the requested tag against the source and built binary before publishing.
+
+## [1.3.3] - 2026-07-31
+
+### Known Issues
+- The published tag points to commit `6c89d58`, whose Cargo version is `1.3.2`, and the release binaries report `standx 1.3.2`. The public tag is retained for auditability; use `v1.3.4` or later.
 
 ## [1.3.2] - 2026-07-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,7 +1778,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "standx-cli"
-version = "1.3.2"
+version = "1.3.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/standx-cli/Cargo.toml
+++ b/crates/standx-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "standx-cli"
-version = "1.3.2"
+version = "1.3.4"
 description = "AI Agent trading toolkit for StandX - natural language to execution for any CLI-capable agent"
 keywords = ["openclaw", "trading", "crypto", "standx", "agent"]
 categories = ["command-line-utilities", "cryptography::cryptocurrencies"]


### PR DESCRIPTION
## Summary

- advance `standx-cli` and `Cargo.lock` from 1.3.2 to 1.3.4
- record the immutable `v1.3.3` release anomaly: its tag points to the 1.3.2 source commit and its published binaries report `standx 1.3.2`
- prepare `v1.3.4` release notes for a forward fix through the newly guarded Stable Release workflow

## Why 1.3.4

`v1.3.3` is already public and must not be deleted or retagged. Because `main` still reported 1.3.2, a normal patch bump would collide with the existing tag and the new workflow would correctly reject it. This PR reconciles that gap and reserves 1.3.4 as the first correctly guarded release.

This PR only prepares release metadata. It does not create a tag or publish a GitHub Release.

## Validation

- `HOME=/tmp/standx-test-home CARGO_HOME=/Users/junlin/.cargo RUSTUP_HOME=/Users/junlin/.rustup cargo test --workspace --locked --offline`
- `HOME=/tmp/standx-test-home CARGO_HOME=/Users/junlin/.cargo RUSTUP_HOME=/Users/junlin/.rustup cargo clippy --workspace --all-targets --locked --offline -- -D warnings`
- `cargo fmt --all -- --check`
- `sh -n install.sh && sh scripts/test_install.sh`
- `python3 -m unittest scripts/test_release.py`
- `python3 scripts/release.py verify --tag v1.3.4`
- `cargo build --release --locked --offline`
- `python3 scripts/release.py verify --tag v1.3.4 --binary target/release/standx`
- confirmed that neither the `v1.3.4` tag nor Release exists
