### PR TITLE
feat(maker): 实现 [external_skew] 连续外部领先价中心偏移（默认关、toggle-off 字节等价）

### DIFF
--- a/crates/standx-cli/src/commands/maker/config.rs
+++ b/crates/standx-cli/src/commands/maker/config.rs
@@ -91,6 +91,29 @@ impl NonlinearSkewFileConfig {
     }
 }
 
+/// Continuous external-price center offset (`[external_skew]`). This mechanism
+/// is TOML-only so frozen A/B arm files remain the single source of truth.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ExternalSkewFileConfig {
+    pub enabled: Option<bool>,
+    pub lambda: Option<f64>,
+    pub cap_bps: Option<f64>,
+    pub dead_zone_bps: Option<f64>,
+}
+
+impl ExternalSkewFileConfig {
+    pub(super) fn into_domain(self) -> standx_maker::ExternalSkewConfig {
+        let defaults = standx_maker::ExternalSkewConfig::default();
+        standx_maker::ExternalSkewConfig {
+            enabled: self.enabled.unwrap_or(defaults.enabled),
+            lambda: self.lambda.unwrap_or(defaults.lambda),
+            cap_bps: self.cap_bps.unwrap_or(defaults.cap_bps),
+            dead_zone_bps: self.dead_zone_bps.unwrap_or(defaults.dead_zone_bps),
+        }
+    }
+}
+
 /// External-price defensive guard (`[external_guard]`). Field defaults match
 /// [`standx_maker::GuardConfig`] so partial files stay valid.
 #[derive(Debug, Clone, Deserialize)]
@@ -144,6 +167,7 @@ pub(super) struct MakerFileConfig {
     pub adaptive_spread: Option<AdaptiveSpreadFileConfig>,
     pub size_skew: Option<SizeSkewFileConfig>,
     pub nonlinear_skew: Option<NonlinearSkewFileConfig>,
+    pub external_skew: Option<ExternalSkewFileConfig>,
     pub external_guard: Option<ExternalGuardFileConfig>,
     pub stop_loss: Option<f64>,
     pub alert_loss: Option<f64>,
@@ -273,6 +297,10 @@ pub(super) fn merge(
         .nonlinear_skew
         .map(|config| config.into_domain())
         .unwrap_or_default();
+    let external_skew = file
+        .external_skew
+        .map(|config| config.into_domain())
+        .unwrap_or_default();
     let external_guard_basis_half_life_secs = file
         .external_guard
         .as_ref()
@@ -309,6 +337,7 @@ pub(super) fn merge(
         adaptive_spread,
         size_skew,
         nonlinear_skew,
+        external_skew,
         external_guard,
         external_guard_basis_half_life_secs,
         stop_loss: choose(stop_loss, file.stop_loss, 0.0),
@@ -377,6 +406,7 @@ pub(super) struct MakerRunArgs {
     pub(super) adaptive_spread: standx_maker::AdaptiveSpreadConfig,
     pub(super) size_skew: standx_maker::SizeSkewConfig,
     pub(super) nonlinear_skew: standx_maker::NonlinearSkewConfig,
+    pub(super) external_skew: standx_maker::ExternalSkewConfig,
     pub(super) external_guard: standx_maker::GuardConfig,
     pub(super) external_guard_basis_half_life_secs: u64,
     pub(super) stop_loss: f64,
@@ -400,6 +430,72 @@ pub(super) struct MakerRunArgs {
     pub(super) account_stream_reconnect_backoff: u64,
     pub(super) controlled_disconnect_after: Option<u64>,
     pub(super) verbose: bool,
+}
+
+/// Validate the CLI-owned composition constraints for `[external_skew]`.
+/// Maker core remains a pure signal/center calculation and never learns about
+/// TOML sections or ladder geometry.
+pub(super) fn validate_external_skew(
+    external: standx_maker::ExternalSkewConfig,
+    base: &standx_maker::MakerConfig,
+    adaptive_spread: &standx_maker::AdaptiveSpreadConfig,
+    nonlinear: standx_maker::NonlinearSkewConfig,
+    guard: standx_maker::GuardConfig,
+) -> Result<()> {
+    if !external.lambda.is_finite()
+        || !external.cap_bps.is_finite()
+        || !external.dead_zone_bps.is_finite()
+    {
+        return Err(anyhow::anyhow!("external skew values must be finite"));
+    }
+    if external.lambda < 0.0 {
+        return Err(anyhow::anyhow!("external skew lambda must be >= 0"));
+    }
+    if external.cap_bps <= 0.0 {
+        return Err(anyhow::anyhow!("external skew cap_bps must be > 0"));
+    }
+    if external.dead_zone_bps < 0.0 {
+        return Err(anyhow::anyhow!("external skew dead_zone_bps must be >= 0"));
+    }
+    if !external.enabled {
+        return Ok(());
+    }
+    if !guard.enabled {
+        return Err(anyhow::anyhow!(
+            "enabled external skew requires an enabled [external_guard]"
+        ));
+    }
+    if external.cap_bps >= guard.enter_bps {
+        return Err(anyhow::anyhow!(
+            "external skew cap_bps must be < external_guard enter_bps"
+        ));
+    }
+
+    let ladder_bps = f64::from(base.levels.saturating_sub(1)) * base.level_step_bps;
+    // `skew_center_with` falls back to the legacy linear curve when nonlinear
+    // skew is off, and that curve saturates at `base.skew_bps`.
+    let inventory_cap_bps = if nonlinear.enabled {
+        nonlinear.cap_bps
+    } else {
+        base.skew_bps
+    };
+    let spread_cap_bps = if adaptive_spread.enabled {
+        adaptive_spread
+            .tiers
+            .iter()
+            .map(|tier| tier.spread_bps)
+            .fold(base.spread_bps, f64::max)
+    } else {
+        base.spread_bps
+    };
+    let budget_bps = spread_cap_bps + ladder_bps + inventory_cap_bps + external.cap_bps;
+    if budget_bps > base.band_bps {
+        return Err(anyhow::anyhow!(
+            "external skew violates band red line: spread_bps + ladder + inventory cap + cap_bps = {budget_bps} must be <= band_bps {}",
+            base.band_bps
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -664,6 +760,223 @@ add_side_factor = 0.5
         assert!(!guard.enabled);
         assert_eq!(guard.enter_bps, 8.0);
         assert_eq!(guard.exit_bps, 3.0);
+    }
+
+    #[test]
+    fn parses_external_skew_full_partial_and_rejects_unknown_fields() {
+        let config: MakerFileConfig = toml::from_str(
+            "[external_skew]\nenabled = true\nlambda = 0.5\ncap_bps = 8.0\ndead_zone_bps = 1.0\n",
+        )
+        .unwrap();
+        let skew = config.external_skew.unwrap().into_domain();
+        assert!(skew.enabled);
+        assert_eq!(skew.lambda, 0.5);
+        assert_eq!(skew.cap_bps, 8.0);
+        assert_eq!(skew.dead_zone_bps, 1.0);
+
+        let partial: MakerFileConfig = toml::from_str("[external_skew]\nlambda = 0.25\n").unwrap();
+        let skew = partial.external_skew.unwrap().into_domain();
+        assert!(!skew.enabled);
+        assert_eq!(skew.lambda, 0.25);
+        assert_eq!(skew.cap_bps, 8.0);
+        assert_eq!(skew.dead_zone_bps, 1.0);
+
+        assert!(toml::from_str::<MakerFileConfig>(
+            "[external_skew]\nenabled = true\nunknown = 1\n"
+        )
+        .is_err());
+    }
+
+    fn external_skew_validation_base() -> standx_maker::MakerConfig {
+        standx_maker::MakerConfig {
+            spread_bps: 8.0,
+            band_bps: 30.0,
+            level_step_bps: 2.0,
+            refresh_bps: 4.0,
+            levels: 1,
+            size: 0.1,
+            max_position: 1.0,
+            skew_bps: 8.0,
+            price_decimals: 3,
+            qty_decimals: 2,
+            min_order_qty: 0.1,
+        }
+    }
+
+    #[test]
+    fn external_skew_validation_enforces_guard_and_band_red_lines() {
+        let external = standx_maker::ExternalSkewConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let nonlinear = standx_maker::NonlinearSkewConfig {
+            enabled: true,
+            boost: 3.0,
+            cap_bps: 12.0,
+        };
+        let guard = standx_maker::GuardConfig {
+            enabled: true,
+            enter_bps: 10.0,
+            exit_bps: 5.0,
+            max_age_ms: 5000,
+        };
+        assert!(validate_external_skew(
+            external,
+            &external_skew_validation_base(),
+            &Default::default(),
+            nonlinear,
+            guard,
+        )
+        .is_ok());
+
+        let mut too_many_levels = external_skew_validation_base();
+        too_many_levels.levels = 3;
+        let error = validate_external_skew(
+            external,
+            &too_many_levels,
+            &Default::default(),
+            nonlinear,
+            guard,
+        )
+        .expect_err("outer ladder levels must consume band budget");
+        assert!(error.to_string().contains("band red line"), "{error}");
+
+        let wide_guard = standx_maker::GuardConfig {
+            enter_bps: 20.0,
+            ..guard
+        };
+        let exact_edge = standx_maker::ExternalSkewConfig {
+            cap_bps: 10.0,
+            ..external
+        };
+        assert!(validate_external_skew(
+            exact_edge,
+            &external_skew_validation_base(),
+            &Default::default(),
+            nonlinear,
+            wide_guard,
+        )
+        .is_ok());
+        let over_edge = standx_maker::ExternalSkewConfig {
+            cap_bps: 10.5,
+            ..external
+        };
+        assert!(validate_external_skew(
+            over_edge,
+            &external_skew_validation_base(),
+            &Default::default(),
+            nonlinear,
+            wide_guard,
+        )
+        .is_err());
+
+        let guard_disabled = standx_maker::GuardConfig {
+            enabled: false,
+            ..guard
+        };
+        assert!(validate_external_skew(
+            external,
+            &external_skew_validation_base(),
+            &Default::default(),
+            nonlinear,
+            guard_disabled,
+        )
+        .is_err());
+
+        let adaptive_spread = standx_maker::AdaptiveSpreadConfig {
+            enabled: true,
+            min_spread_bps: 8.0,
+            max_spread_bps: 18.0,
+            tiers: vec![standx_maker::SpreadTier {
+                enter_vol_bps: None,
+                exit_vol_bps: None,
+                spread_bps: 18.0,
+                refresh_bps: 4.0,
+            }],
+        };
+        assert!(validate_external_skew(
+            external,
+            &external_skew_validation_base(),
+            &adaptive_spread,
+            nonlinear,
+            guard,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn external_skew_validation_rejects_invalid_scalars_even_when_disabled() {
+        let base = external_skew_validation_base();
+        for external in [
+            standx_maker::ExternalSkewConfig {
+                lambda: f64::NAN,
+                ..Default::default()
+            },
+            standx_maker::ExternalSkewConfig {
+                lambda: -0.5,
+                ..Default::default()
+            },
+            standx_maker::ExternalSkewConfig {
+                cap_bps: 0.0,
+                ..Default::default()
+            },
+            standx_maker::ExternalSkewConfig {
+                dead_zone_bps: -1.0,
+                ..Default::default()
+            },
+        ] {
+            assert!(validate_external_skew(
+                external,
+                &base,
+                &Default::default(),
+                Default::default(),
+                Default::default(),
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn external_skew_band_budget_uses_legacy_cap_when_nonlinear_is_off() {
+        let external = standx_maker::ExternalSkewConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let nonlinear = standx_maker::NonlinearSkewConfig::default();
+        let guard = standx_maker::GuardConfig {
+            enabled: true,
+            enter_bps: 10.0,
+            exit_bps: 5.0,
+            max_age_ms: 5000,
+        };
+        let mut base = external_skew_validation_base();
+        base.skew_bps = 16.0;
+        assert!(
+            validate_external_skew(external, &base, &Default::default(), nonlinear, guard,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn external_skew_candidate_is_frozen_baseline_plus_one_section() {
+        let baseline = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/maker-guard-hype-candidate.toml"
+        ));
+        let candidate = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/maker-external-skew-hype-candidate.toml"
+        ));
+        let suffix = concat!(
+            "\n# Candidate arm (docs/28): continuous external-price center offset.\n",
+            "# Band red line: spread(8) + nonlinear.cap(12) + external.cap(8) = 28 <= band(30).\n",
+            "[external_skew]\n",
+            "enabled = true\n",
+            "lambda = 0.5\n",
+            "cap_bps = 8.0\n",
+            "dead_zone_bps = 1.0\n",
+        );
+        assert_eq!(candidate.strip_suffix(suffix), Some(baseline));
     }
 
     /// The frozen production baseline (docs/25: skew + guard both on) must keep

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -5,12 +5,12 @@ use super::model::{
     optional_decimal, position_for_symbol, rest_order_observation, unhealthy_stream, Decimal,
 };
 use super::output::{
-    emit_cycle_skip, emit_guard_transition, emit_maker_cycle, log_maker_event, CycleOutput,
-    ExitStatus, MakerLogEvent,
+    emit_cycle_skip, emit_external_skew_transition, emit_guard_transition, emit_maker_cycle,
+    log_maker_event, CycleOutput, ExitStatus, MakerLogEvent,
 };
 use super::pipeline::{
     fetch_account_audit, CycleRequest, CycleResult, CycleState, OrderRequestKind,
-    BALANCE_FLOOR_MAX_AGE, FUNDING_HISTORY_LIMIT,
+    TimedExternalDivergence, BALANCE_FLOOR_MAX_AGE, FUNDING_HISTORY_LIMIT,
 };
 use super::recovery::PositionReconciliationError;
 use anyhow::Result;
@@ -28,6 +28,37 @@ use standx_sdk::order_response::{OrderCommandSender, OrderResponseHealth};
 use std::time::Instant;
 
 const ORDER_LATENCY_TIMEOUT_MS: u64 = 15_000;
+
+fn external_skew_transitioned(previous: f64, current: f64) -> bool {
+    let previous_active = previous != 0.0;
+    let current_active = current != 0.0;
+    previous_active != current_active
+        || (previous_active
+            && current_active
+            && previous.is_sign_positive() != current.is_sign_positive())
+}
+
+fn legacy_inventory_skew_shift_bps(mark: f64, plan: &maker::CyclePlan) -> f64 {
+    if mark > 0.0 {
+        (mark - plan.inventory_ref_center) / mark * 1e4
+    } else {
+        0.0
+    }
+}
+
+fn external_excess_at_plan(
+    observation: Option<TimedExternalDivergence>,
+    decision: &maker::GuardDecision,
+    max_age_ms: u64,
+    now: Instant,
+) -> (Option<maker::ExternalDivergence>, Option<f64>) {
+    let fresh_observation = observation
+        .map(|sample| sample.at(now))
+        .filter(|sample| sample.age_ms <= max_age_ms && sample.divergence_bps.is_finite());
+    let excess_bps =
+        fresh_observation.and_then(|_| decision.divergence_bps.filter(|value| value.is_finite()));
+    (fresh_observation, excess_bps)
+}
 
 struct LatencyRegistration<'a> {
     started: Option<Instant>,
@@ -264,6 +295,9 @@ pub(super) async fn maker_cycle(
         spread_controller,
         size_skew_controller,
         nonlinear_skew,
+        external_skew,
+        external_skew_previous_shift_bps,
+        external_excess_telemetry,
         guard_controller,
         external_divergence,
         external_basis_bps,
@@ -608,8 +642,28 @@ pub(super) async fn maker_cycle(
 
     // 3. Build the pure quote/exit plan from the synchronized state.
     let size_skew_decision = size_skew_controller.observe(position, cfg);
+    let guard_observed_at = Instant::now();
+    let guard_max_age_ms = guard_controller.config().max_age_ms;
+    // Preserve the established guard action path exactly: it consumes the age
+    // normalized before maker_cycle just as it did before external skew. The
+    // new shift/fill fields additionally account for I/O elapsed since that
+    // normalization, so a newly introduced center offset never uses a sample
+    // that is stale at planning time.
+    let guard_input = external_divergence.map(|sample| sample.value);
     let previous_guard_side = guard_controller.endangered();
-    let guard_decision = guard_controller.observe(external_divergence);
+    let guard_decision = guard_controller.observe(guard_input);
+    let (fresh_external_divergence, external_excess_bps) = external_excess_at_plan(
+        external_divergence,
+        &guard_decision,
+        guard_max_age_ms,
+        guard_observed_at,
+    );
+    external_excess_telemetry.observe(
+        external_excess_bps,
+        fresh_external_divergence,
+        guard_max_age_ms,
+        guard_observed_at,
+    );
     if guard_decision.endangered != previous_guard_side {
         emit_guard_transition(output_format, symbol, cycle, &guard_decision);
     }
@@ -639,12 +693,26 @@ pub(super) async fn maker_cycle(
             inventory_exit_qty,
             size_skew: size_skew_decision,
             nonlinear_skew,
+            external_skew,
+            external_excess_bps,
             guard: guard_decision,
             wind_down,
             qty_tolerance,
         },
         halted,
     );
+    let external_skew_shift_bps = plan.external_skew_shift_bps;
+    let inventory_skew_shift_bps = legacy_inventory_skew_shift_bps(mark, &plan);
+    if external_skew_transitioned(*external_skew_previous_shift_bps, external_skew_shift_bps) {
+        emit_external_skew_transition(
+            output_format,
+            symbol,
+            cycle,
+            external_skew_shift_bps,
+            external_excess_bps,
+        );
+    }
+    *external_skew_previous_shift_bps = external_skew_shift_bps;
     let raw_inventory_exit = plan.requested_inventory_exit;
     if exit_fill_observed {
         *inventory_exit_pending = false;
@@ -1043,17 +1111,15 @@ pub(super) async fn maker_cycle(
         account: account_balance.as_ref(),
         actions: &actions,
         fills: &fills,
+        excess_bps_at_fill: external_excess_bps,
         stats,
         halt_vol_bps: halted.then(|| breaker.vol_bps()),
         spread_decision: &spread_decision,
         size_skew_decision: &size_skew_decision,
         guard_decision: &guard_decision,
         external_basis_bps,
-        skew_shift_bps: if mark > 0.0 {
-            (mark - ref_center) / mark * 1e4
-        } else {
-            0.0
-        },
+        external_skew_shift_bps,
+        skew_shift_bps: inventory_skew_shift_bps,
         exit_status,
         cfg,
         performance: performance_summary.as_ref(),
@@ -1085,6 +1151,108 @@ fn eligible_quote_qty(resting: &[RestingQuote], mark: f64, band_bps: f64) -> (f6
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn external_skew_transition_detects_dead_zone_crossings_and_sign_flips() {
+        assert!(!external_skew_transitioned(0.0, 0.0));
+        assert!(external_skew_transitioned(0.0, 1.0));
+        assert!(external_skew_transitioned(1.0, 0.0));
+        assert!(!external_skew_transitioned(1.0, 2.0));
+        assert!(external_skew_transitioned(1.0, -1.0));
+    }
+
+    #[test]
+    fn legacy_skew_telemetry_excludes_external_center_offset() {
+        let plan = maker::CyclePlan {
+            requested_inventory_exit: None,
+            inventory_exit: None,
+            exit_suppression: None,
+            actions: Vec::new(),
+            inventory_ref_center: 100.0,
+            ref_center: 100.04,
+            external_skew_shift_bps: 4.0,
+        };
+
+        assert_eq!(legacy_inventory_skew_shift_bps(100.0, &plan), 0.0);
+        assert_ne!(plan.ref_center, plan.inventory_ref_center);
+    }
+
+    #[test]
+    fn fill_excess_telemetry_expires_to_none_at_guard_freshness_boundary() {
+        let now = Instant::now();
+        let mut telemetry = super::super::pipeline::ExternalExcessTelemetry::default();
+        let decision = maker::GuardDecision {
+            enabled: true,
+            active: false,
+            endangered: None,
+            divergence_bps: Some(0.0),
+        };
+        telemetry.observe(
+            decision.divergence_bps,
+            Some(maker::ExternalDivergence {
+                divergence_bps: 0.0,
+                age_ms: 5000,
+            }),
+            5000,
+            now,
+        );
+        assert_eq!(telemetry.current(now), Some(0.0));
+        assert_eq!(
+            telemetry.current(now + std::time::Duration::from_millis(1)),
+            None
+        );
+
+        telemetry.observe(None, None, 5000, now);
+        assert_eq!(telemetry.current(now), None);
+    }
+
+    #[test]
+    fn io_delay_is_included_before_external_freshness_decision() {
+        let normalized_at = Instant::now();
+        let observed_at = normalized_at + std::time::Duration::from_millis(200);
+        let timed = super::super::pipeline::TimedExternalDivergence {
+            value: maker::ExternalDivergence {
+                divergence_bps: 8.0,
+                age_ms: 4_900,
+            },
+            normalized_at,
+        };
+        let aged = timed.at(observed_at);
+        assert_eq!(aged.age_ms, 5_100);
+
+        let mut guard = maker::GuardController::new(maker::GuardConfig {
+            enabled: true,
+            enter_bps: 6.0,
+            exit_bps: 3.0,
+            max_age_ms: 5_000,
+        })
+        .unwrap();
+        // The pre-existing guard sees exactly the pre-I/O typed input, so the
+        // default-off arm retains its established side-suppression action.
+        let decision = guard.observe(Some(timed.value));
+        assert!(decision.active);
+        assert_eq!(decision.endangered, Some(OrderSide::Sell));
+        let (fresh, excess_bps) =
+            external_excess_at_plan(Some(timed), &decision, 5_000, observed_at);
+        assert_eq!(fresh, None);
+        assert_eq!(excess_bps, None);
+        assert_eq!(
+            maker::external_skew_shift_bps(
+                maker::ExternalSkewConfig {
+                    enabled: true,
+                    ..Default::default()
+                },
+                excess_bps,
+            ),
+            0.0
+        );
+
+        let mut telemetry = super::super::pipeline::ExternalExcessTelemetry::default();
+        // Defensively reject the already-stale sample even if a caller passes
+        // it alongside a numeric value.
+        telemetry.observe(decision.divergence_bps, Some(aged), 5_000, observed_at);
+        assert_eq!(telemetry.current(observed_at), None);
+    }
 
     fn trade(side: Option<&str>, price: &str, qty: &str) -> Trade {
         Trade {

--- a/crates/standx-cli/src/commands/maker/mod.rs
+++ b/crates/standx-cli/src/commands/maker/mod.rs
@@ -52,14 +52,15 @@ use notify::{
     RiskSeverity, TokenExpiryLevel,
 };
 use pipeline::{
-    CycleRequest, CycleState, LiveAccountPollState, OrderRequestDeadlines, TimedOutOrderRequest,
+    CycleRequest, CycleState, ExternalExcessTelemetry, LiveAccountPollState, OrderRequestDeadlines,
+    TimedExternalDivergence, TimedOutOrderRequest,
 };
 use recovery::{
     cancel_maker_orders_with_retry, ctrl_c_latched, probe_position_convergence,
     reconnect_account_stream, reconnect_order_response, AccountStreamReconnect, CleanupTombstones,
-    ConvergenceProbe, PositionReconciliationCause, PositionReconciliationError, ReconcileRequest,
-    ReconnectCleanupFailed, ReconnectInterrupted, ReconnectRequest, TransportReconnectExhausted,
-    WsCleanupContext,
+    ConvergenceProbe, FillEmissionContext, PositionReconciliationCause,
+    PositionReconciliationError, ReconcileRequest, ReconnectCleanupFailed, ReconnectInterrupted,
+    ReconnectRequest, TransportReconnectExhausted, WsCleanupContext,
 };
 
 // ============================================================================

--- a/crates/standx-cli/src/commands/maker/output.rs
+++ b/crates/standx-cli/src/commands/maker/output.rs
@@ -242,6 +242,8 @@ pub(super) struct CycleOutput<'a> {
     pub(super) account: Option<&'a Balance>,
     pub(super) actions: &'a [Action],
     pub(super) fills: &'a [MakerFill],
+    /// Guard-normalized excess sample in use when these fills were observed.
+    pub(super) excess_bps_at_fill: Option<f64>,
     pub(super) stats: &'a MakerStats,
     pub(super) halt_vol_bps: Option<f64>,
     pub(super) spread_decision: &'a maker::SpreadDecision,
@@ -249,8 +251,10 @@ pub(super) struct CycleOutput<'a> {
     pub(super) guard_decision: &'a maker::GuardDecision,
     /// Divergence-basis EMA the guard's excess is measured against.
     pub(super) external_basis_bps: Option<f64>,
-    /// Realized quote-center shift in bps (mark vs plan ref_center); covers
-    /// linear and nonlinear skew alike. Telemetry only.
+    /// Continuous external-price component of the quote-center shift.
+    pub(super) external_skew_shift_bps: f64,
+    /// Legacy inventory-only quote-center shift in bps; covers linear and
+    /// nonlinear skew but deliberately excludes the additive external field.
     pub(super) skew_shift_bps: f64,
     /// Stage 5-b: typed exit policy outcome for this cycle.
     pub(super) exit_status: ExitStatus,
@@ -275,12 +279,14 @@ pub(super) fn emit_maker_cycle(output: CycleOutput<'_>) {
         account,
         actions,
         fills,
+        excess_bps_at_fill,
         stats,
         halt_vol_bps,
         spread_decision,
         size_skew_decision,
         guard_decision,
         external_basis_bps,
+        external_skew_shift_bps,
         skew_shift_bps,
         exit_status,
         cfg,
@@ -313,6 +319,7 @@ pub(super) fn emit_maker_cycle(output: CycleOutput<'_>) {
                         "price": format_decimals(fill.price, cfg.price_decimals),
                         "qty": format_decimals(fill.qty, cfg.qty_decimals),
                         "mark_at_fill": fill.mark_at_fill,
+                        "excess_bps_at_fill": fill_excess_bps_json(excess_bps_at_fill),
                         "event_time_ms": fill.event_time_ms,
                         "trade_id": fill.trade_id,
                         "order_id": fill.order_id,
@@ -399,6 +406,7 @@ pub(super) fn emit_maker_cycle(output: CycleOutput<'_>) {
                         ),
                         guard_decision,
                         external_basis_bps,
+                        external_skew_shift_bps,
                         skew_shift_bps,
                     ),
                     exit_status,
@@ -598,6 +606,7 @@ fn with_guard_fields(
     mut summary: serde_json::Value,
     decision: &maker::GuardDecision,
     external_basis_bps: Option<f64>,
+    external_skew_shift_bps: f64,
     skew_shift_bps: f64,
 ) -> serde_json::Value {
     let object = summary
@@ -622,6 +631,10 @@ fn with_guard_fields(
     object.insert(
         "external_basis_bps".to_string(),
         serde_json::json!(external_basis_bps.map(|d| (d * 100.0).round() / 100.0)),
+    );
+    object.insert(
+        "external_skew_shift_bps".to_string(),
+        serde_json::json!((external_skew_shift_bps * 100.0).round() / 100.0),
     );
     object.insert(
         "skew_shift_bps".to_string(),
@@ -791,6 +804,37 @@ pub(super) fn emit_guard_transition(
     }
 }
 
+/// Emit when the continuous shift enters/leaves its dead zone or changes sign.
+/// This event is additive and never feeds a decision path.
+pub(super) fn emit_external_skew_transition(
+    output_format: OutputFormat,
+    symbol: &str,
+    cycle: u64,
+    shift_bps: f64,
+    excess_bps: Option<f64>,
+) {
+    match output_format {
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::json!({
+                "ts": ts_now(),
+                "cycle": cycle,
+                "symbol": symbol,
+                "action": "external_skew",
+                "active": shift_bps != 0.0,
+                "shift_bps": shift_bps,
+                "excess_bps": excess_bps,
+            })
+        ),
+        OutputFormat::Quiet => {}
+        _ if shift_bps == 0.0 => eprintln!("    ↔️ external skew: returned to dead zone"),
+        _ => eprintln!(
+            "    ↔️ external skew: shift {shift_bps:+.2}bps (excess {:+.2}bps)",
+            excess_bps.unwrap_or(f64::NAN),
+        ),
+    }
+}
+
 pub(super) struct MakerLogEvent<'a> {
     pub(super) output_format: OutputFormat,
     pub(super) symbol: &'a str,
@@ -858,6 +902,7 @@ pub(super) fn emit_live_fill(
     symbol: &str,
     cycle: u64,
     output_format: OutputFormat,
+    excess_bps_at_fill: Option<f64>,
 ) {
     match output_format {
         OutputFormat::Json => println!(
@@ -875,6 +920,7 @@ pub(super) fn emit_live_fill(
                 "price": fill.price,
                 "qty": fill.qty,
                 "mark_at_fill": fill.mark_at_fill,
+                "excess_bps_at_fill": fill_excess_bps_json(excess_bps_at_fill),
                 "event_time_ms": fill.event_time_ms,
                 "role": match fill.role {
                     maker::FillRole::PassiveMaker => "passive_maker",
@@ -892,6 +938,10 @@ pub(super) fn emit_live_fill(
             fill.order_id.unwrap_or_default()
         ),
     }
+}
+
+fn fill_excess_bps_json(excess_bps_at_fill: Option<f64>) -> serde_json::Value {
+    excess_bps_at_fill.map_or(serde_json::Value::Null, serde_json::Value::from)
 }
 
 pub(super) fn emit_reconciliation_state(
@@ -1369,6 +1419,12 @@ mod tests {
     }
 
     #[test]
+    fn fill_excess_distinguishes_missing_sample_from_zero_divergence() {
+        assert!(fill_excess_bps_json(None).is_null());
+        assert_eq!(fill_excess_bps_json(Some(0.0)), serde_json::json!(0.0));
+    }
+
+    #[test]
     fn phase_one_performance_json_exposes_cashflow_capture_and_inventory_time() {
         let mut ledger = maker::PerformanceLedger::new(0.0, 100.0).unwrap();
         ledger.observe_market(0, 100.0).unwrap();
@@ -1515,6 +1571,7 @@ mod tests {
             serde_json::json!({"action": "cycle_summary", "vol_bps": null}),
             &decision,
             Some(-14.2),
+            3.25,
             4.804,
         );
 
@@ -1525,6 +1582,7 @@ mod tests {
         assert_eq!(json["guard_side"], "sell");
         assert_eq!(json["external_divergence_bps"], 7.82);
         assert_eq!(json["external_basis_bps"], -14.2);
+        assert_eq!(json["external_skew_shift_bps"], 3.25);
         assert_eq!(json["skew_shift_bps"], 4.8);
 
         // Inactive guard serializes nulls, never drops the keys.
@@ -1533,12 +1591,14 @@ mod tests {
             &maker::GuardDecision::INACTIVE,
             None,
             0.0,
+            0.0,
         );
         assert_eq!(idle["guard_enabled"], false);
         assert_eq!(idle["guard_active"], false);
         assert!(idle["guard_side"].is_null());
         assert!(idle["external_divergence_bps"].is_null());
         assert!(idle["external_basis_bps"].is_null());
+        assert_eq!(idle["external_skew_shift_bps"], 0.0);
         assert_eq!(idle["skew_shift_bps"], 0.0);
     }
 

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -177,10 +177,13 @@ pub(super) struct CycleState<'a> {
     pub(super) size_skew_controller: &'a mut SizeSkewController,
     /// Stage 3 v1 nonlinear price-skew strength (disabled ≡ legacy linear).
     pub(super) nonlinear_skew: standx_maker::NonlinearSkewConfig,
+    pub(super) external_skew: standx_maker::ExternalSkewConfig,
+    pub(super) external_skew_previous_shift_bps: &'a mut f64,
+    pub(super) external_excess_telemetry: &'a mut ExternalExcessTelemetry,
     pub(super) guard_controller: &'a mut standx_maker::GuardController,
     /// Caller-normalized external leader observation for this cycle; `None`
     /// when the guard is disabled or the feed has no usable sample.
-    pub(super) external_divergence: Option<standx_maker::ExternalDivergence>,
+    pub(super) external_divergence: Option<TimedExternalDivergence>,
     /// Current divergence-basis EMA (telemetry only).
     pub(super) external_basis_bps: Option<f64>,
     pub(super) order_request_deadlines: Option<&'a mut OrderRequestDeadlines>,
@@ -191,6 +194,68 @@ pub(super) struct CycleState<'a> {
     /// safety decisions.
     pub(super) order_latency: Option<&'a mut OrderLatencyTracker>,
     pub(super) latency_started: Option<Instant>,
+}
+
+/// An external observation plus the instant at which its feed age was
+/// normalized. Account/audit I/O may delay planning, so the elapsed time must
+/// be folded back into `age_ms` immediately before the guard consumes it.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct TimedExternalDivergence {
+    pub(super) value: standx_maker::ExternalDivergence,
+    pub(super) normalized_at: Instant,
+}
+
+impl TimedExternalDivergence {
+    pub(super) fn at(self, now: Instant) -> standx_maker::ExternalDivergence {
+        let elapsed_ms = u64::try_from(
+            now.saturating_duration_since(self.normalized_at)
+                .as_millis(),
+        )
+        .unwrap_or(u64::MAX);
+        standx_maker::ExternalDivergence {
+            divergence_bps: self.value.divergence_bps,
+            age_ms: self.value.age_ms.saturating_add(elapsed_ms),
+        }
+    }
+}
+
+/// Last guard-normalized excess sample available to fill telemetry. The expiry
+/// preserves the guard's `max_age_ms` fail-open semantics between cycles without
+/// adding a feed read or a second signal calculation.
+#[derive(Debug, Default)]
+pub(super) struct ExternalExcessTelemetry {
+    value_bps: Option<f64>,
+    valid_until: Option<Instant>,
+}
+
+impl ExternalExcessTelemetry {
+    pub(super) fn observe(
+        &mut self,
+        value_bps: Option<f64>,
+        input: Option<standx_maker::ExternalDivergence>,
+        max_age_ms: u64,
+        now: Instant,
+    ) {
+        let Some((value_bps, input)) = value_bps.filter(|value| value.is_finite()).zip(
+            input.filter(|sample| sample.age_ms <= max_age_ms && sample.divergence_bps.is_finite()),
+        ) else {
+            self.value_bps = None;
+            self.valid_until = None;
+            return;
+        };
+        let remaining_ms = max_age_ms - input.age_ms;
+        self.value_bps = Some(value_bps);
+        self.valid_until = Some(now + Duration::from_millis(remaining_ms));
+    }
+
+    pub(super) fn current(&self, now: Instant) -> Option<f64> {
+        match (self.value_bps, self.valid_until) {
+            (Some(value), Some(valid_until)) if now <= valid_until && value.is_finite() => {
+                Some(value)
+            }
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/standx-cli/src/commands/maker/recovery.rs
+++ b/crates/standx-cli/src/commands/maker/recovery.rs
@@ -334,6 +334,13 @@ pub(super) enum ConvergenceProbe {
     SnapshotFailed(anyhow::Error),
 }
 
+#[derive(Clone, Copy)]
+pub(super) struct FillEmissionContext {
+    pub(super) cycle: u64,
+    pub(super) output_format: OutputFormat,
+    pub(super) excess_bps_at_fill: Option<f64>,
+}
+
 /// One iteration of the bounded position-convergence window shared by the
 /// account-stream and position-reconciliation recovery paths: REST-reconcile
 /// the ledger, emit every newly explained fill, count fills into `fills_sink`,
@@ -346,8 +353,7 @@ pub(super) async fn probe_position_convergence(
     ledger: &mut MakerLedger,
     stats: &mut MakerStats,
     fills_sink: &mut u64,
-    cycle: u64,
-    output_format: OutputFormat,
+    emission: FillEmissionContext,
 ) -> ConvergenceProbe {
     let symbol = request.symbol;
     let qty_tolerance = request.qty_tolerance;
@@ -355,7 +361,13 @@ pub(super) async fn probe_position_convergence(
         Ok((observed, fills)) => {
             *fills_sink += fills.len() as u64;
             for fill in &fills {
-                emit_live_fill(fill, symbol, cycle, output_format);
+                emit_live_fill(
+                    fill,
+                    symbol,
+                    emission.cycle,
+                    emission.output_format,
+                    emission.excess_bps_at_fill,
+                );
             }
             if (observed - ledger.expected_position).abs() <= qty_tolerance {
                 ConvergenceProbe::Converged { observed }
@@ -2059,8 +2071,11 @@ mod tests {
             &mut ledger,
             &mut stats,
             &mut fills_sink,
-            7,
-            OutputFormat::Quiet,
+            FillEmissionContext {
+                cycle: 7,
+                output_format: OutputFormat::Quiet,
+                excess_bps_at_fill: None,
+            },
         )
         .await;
 
@@ -2095,8 +2110,11 @@ mod tests {
             &mut ledger,
             &mut stats,
             &mut fills_sink,
-            7,
-            OutputFormat::Quiet,
+            FillEmissionContext {
+                cycle: 7,
+                output_format: OutputFormat::Quiet,
+                excess_bps_at_fill: None,
+            },
         )
         .await;
 
@@ -2140,8 +2158,11 @@ mod tests {
             &mut ledger,
             &mut stats,
             &mut fills_sink,
-            7,
-            OutputFormat::Quiet,
+            FillEmissionContext {
+                cycle: 7,
+                output_format: OutputFormat::Quiet,
+                excess_bps_at_fill: None,
+            },
         )
         .await;
 

--- a/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
@@ -216,12 +216,17 @@ impl MakerRuntime {
                 let cycle_external_divergence = match self.loop_state.external_feed.as_ref() {
                     Some(feed) => {
                         let state = *feed.read().await;
+                        let external_normalized_at = std::time::Instant::now();
                         super::super::external_feed::divergence_input(
                             state,
                             mark,
-                            std::time::Instant::now(),
+                            external_normalized_at,
                             &mut self.loop_state.external_basis,
                         )
+                        .map(|value| TimedExternalDivergence {
+                            value,
+                            normalized_at: external_normalized_at,
+                        })
                     }
                     None => None,
                 };
@@ -271,6 +276,11 @@ impl MakerRuntime {
                         spread_controller: &mut self.loop_state.spread_controller,
                         size_skew_controller: &mut self.loop_state.size_skew_controller,
                         nonlinear_skew: self.loop_state.nonlinear_skew,
+                        external_skew: self.loop_state.external_skew,
+                        external_skew_previous_shift_bps: &mut self
+                            .loop_state
+                            .external_skew_previous_shift_bps,
+                        external_excess_telemetry: &mut self.loop_state.external_excess_telemetry,
                         guard_controller: &mut self.loop_state.guard_controller,
                         external_divergence: cycle_external_divergence,
                         external_basis_bps: cycle_external_basis_bps,
@@ -461,6 +471,10 @@ impl MakerRuntime {
                             mark: self.market.last_mark.unwrap_or(baseline_mark),
                             cycle,
                             output_format,
+                            excess_bps_at_fill: self
+                                .loop_state
+                                .external_excess_telemetry
+                                .current(std::time::Instant::now()),
                         },
                     ) {
                         Ok(outcome) => {
@@ -899,6 +913,10 @@ impl MakerRuntime {
                                         mark: self.market.last_mark.unwrap_or(baseline_mark),
                                         cycle,
                                         output_format,
+                                        excess_bps_at_fill: self
+                                            .loop_state
+                                            .external_excess_telemetry
+                                            .current(std::time::Instant::now()),
                                     },
                                 ) {
                                     Ok(outcome) => {
@@ -963,8 +981,14 @@ impl MakerRuntime {
                                 &mut self.loop_state.ledger,
                                 &mut self.loop_state.stats,
                                 &mut self.loop_state.counters.total_fills,
-                                cycle,
-                                output_format,
+                                FillEmissionContext {
+                                    cycle,
+                                    output_format,
+                                    excess_bps_at_fill: self
+                                        .loop_state
+                                        .external_excess_telemetry
+                                        .current(std::time::Instant::now()),
+                                },
                             )
                             .await
                             {
@@ -1280,6 +1304,10 @@ impl MakerRuntime {
                                     mark: self.market.last_mark.unwrap_or(baseline_mark),
                                     cycle: self.loop_state.counters.cycle,
                                     output_format,
+                                    excess_bps_at_fill: self
+                                        .loop_state
+                                        .external_excess_telemetry
+                                        .current(std::time::Instant::now()),
                                 },
                             ) {
                                 Ok(outcome) => {

--- a/crates/standx-cli/src/commands/maker/runtime/events.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/events.rs
@@ -376,6 +376,7 @@ pub(super) struct AccountEventContext<'a> {
     pub(super) mark: f64,
     pub(super) cycle: u64,
     pub(super) output_format: OutputFormat,
+    pub(super) excess_bps_at_fill: Option<f64>,
 }
 
 pub(super) struct AccountEventState<'a> {
@@ -611,7 +612,13 @@ pub(super) fn apply_account_event(
                         },
                     );
                 }
-                emit_live_fill(fill, context.symbol, context.cycle, context.output_format);
+                emit_live_fill(
+                    fill,
+                    context.symbol,
+                    context.cycle,
+                    context.output_format,
+                    context.excess_bps_at_fill,
+                );
             }
             Ok(AccountEventOutcome {
                 fills: fills.len() as u64,
@@ -670,7 +677,13 @@ pub(super) fn apply_account_event(
                         },
                     );
                 }
-                emit_live_fill(fill, context.symbol, context.cycle, context.output_format);
+                emit_live_fill(
+                    fill,
+                    context.symbol,
+                    context.cycle,
+                    context.output_format,
+                    context.excess_bps_at_fill,
+                );
             }
             Ok(AccountEventOutcome {
                 fills: fills.len() as u64,

--- a/crates/standx-cli/src/commands/maker/runtime/recovery_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/recovery_flow.rs
@@ -980,6 +980,10 @@ impl MakerRuntime {
                             mark: self.market.last_mark.unwrap_or(baseline_mark),
                             cycle,
                             output_format,
+                            excess_bps_at_fill: self
+                                .loop_state
+                                .external_excess_telemetry
+                                .current(std::time::Instant::now()),
                         },
                     ) {
                         Ok(outcome) => outcome,
@@ -1052,6 +1056,10 @@ impl MakerRuntime {
                                     mark: self.market.last_mark.unwrap_or(baseline_mark),
                                     cycle,
                                     output_format,
+                                    excess_bps_at_fill: self
+                                        .loop_state
+                                        .external_excess_telemetry
+                                        .current(std::time::Instant::now()),
                                 },
                             ) {
                                 Ok(outcome) => {
@@ -1082,8 +1090,14 @@ impl MakerRuntime {
                                 &mut self.loop_state.ledger,
                                 &mut self.loop_state.stats,
                                 &mut reconnect_fills,
-                                cycle,
-                                output_format,
+                                FillEmissionContext {
+                                    cycle,
+                                    output_format,
+                                    excess_bps_at_fill: self
+                                        .loop_state
+                                        .external_excess_telemetry
+                                        .current(std::time::Instant::now()),
+                                },
                             )
                             .await
                             {
@@ -1450,7 +1464,15 @@ impl MakerRuntime {
 
                         self.loop_state.counters.total_fills += reconnected.fills.len() as u64;
                         for fill in &reconnected.fills {
-                            emit_live_fill(fill, symbol, cycle, output_format);
+                            emit_live_fill(
+                                fill,
+                                symbol,
+                                cycle,
+                                output_format,
+                                self.loop_state
+                                    .external_excess_telemetry
+                                    .current(std::time::Instant::now()),
+                            );
                             if let Some(order_id) = fill.order_id {
                                 let at_ms =
                                     u64::try_from(session.latency_started.elapsed().as_millis())
@@ -1579,6 +1601,10 @@ impl MakerRuntime {
                     mark: self.market.last_mark.unwrap_or(baseline_mark),
                     cycle,
                     output_format,
+                    excess_bps_at_fill: self
+                        .loop_state
+                        .external_excess_telemetry
+                        .current(std::time::Instant::now()),
                 },
             ) {
                 Ok(outcome) => {

--- a/crates/standx-cli/src/commands/maker/runtime/state.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/state.rs
@@ -45,6 +45,9 @@ pub(super) struct RuntimeLoopState {
     pub(super) spread_controller: maker::SpreadController,
     pub(super) size_skew_controller: maker::SizeSkewController,
     pub(super) nonlinear_skew: maker::NonlinearSkewConfig,
+    pub(super) external_skew: maker::ExternalSkewConfig,
+    pub(super) external_skew_previous_shift_bps: f64,
+    pub(super) external_excess_telemetry: ExternalExcessTelemetry,
     pub(super) guard_controller: maker::GuardController,
     /// Latest leader (Hyperliquid) sample for the external guard; `None` when
     /// the guard is disabled and no feed task runs.
@@ -168,6 +171,14 @@ impl MakerRuntime {
         // bad file never rides along silently (band red line included).
         let nonlinear_skew = args.nonlinear_skew;
         nonlinear_skew.validate(&cfg)?;
+        let external_skew = args.external_skew;
+        super::super::config::validate_external_skew(
+            external_skew,
+            &cfg,
+            &args.adaptive_spread,
+            nonlinear_skew,
+            args.external_guard,
+        )?;
         let guard_basis_half_life_secs = args.external_guard_basis_half_life_secs;
         let guard_controller = maker::GuardController::new(args.external_guard)?;
         let (external_feed, external_updates, external_feed_handle) = if args.external_guard.enabled
@@ -271,6 +282,9 @@ impl MakerRuntime {
                 spread_controller,
                 size_skew_controller,
                 nonlinear_skew,
+                external_skew,
+                external_skew_previous_shift_bps: 0.0,
+                external_excess_telemetry: ExternalExcessTelemetry::default(),
                 guard_controller,
                 external_feed,
                 external_updates,

--- a/crates/standx-cli/src/commands/maker/runtime/tests/account_events.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/tests/account_events.rs
@@ -19,6 +19,7 @@ fn drain_positions(events: Vec<AccountEvent>) -> AccountEventOutcome {
         mark: 100.0,
         cycle: 1,
         output_format: OutputFormat::Quiet,
+        excess_bps_at_fill: None,
     };
     apply_account_events(&mut rx, &mut state, &context).expect("benign events drain cleanly")
 }
@@ -83,6 +84,7 @@ fn balance_event_updates_raw_projection_without_touching_fill_accounting() {
         mark: 100.0,
         cycle: 1,
         output_format: OutputFormat::Quiet,
+        excess_bps_at_fill: None,
     };
     let outcome = {
         let mut state = AccountEventState {
@@ -129,6 +131,7 @@ fn uncorrelated_current_run_order_requires_reconciliation_without_stream_failure
         mark: 100.0,
         cycle: 2,
         output_format: OutputFormat::Quiet,
+        excess_bps_at_fill: None,
     };
     let update = OrderUpdate {
         seq: 1,
@@ -219,6 +222,7 @@ fn stable_trade_reports_current_run_inventory_exit_once() {
         mark: 100.0,
         cycle: 1,
         output_format: OutputFormat::Quiet,
+        excess_bps_at_fill: None,
     };
     let update = OrderUpdate {
         seq: 1,

--- a/crates/standx-maker/src/external_skew.rs
+++ b/crates/standx-maker/src/external_skew.rs
@@ -1,0 +1,110 @@
+//! Continuous external-price center offset (`[external_skew]`).
+//!
+//! The caller passes the excess divergence already normalized by the external
+//! guard chain. This module deliberately has no feed, clock, or guard-state
+//! dependency: a missing or unusable sample simply produces no shift.
+
+/// Operator configuration for the continuous external-price offset.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ExternalSkewConfig {
+    pub enabled: bool,
+    /// Offset coefficient applied before clamping (`shift = lambda * excess`).
+    pub lambda: f64,
+    /// Symmetric hard ceiling for the center offset, in basis points.
+    pub cap_bps: f64,
+    /// Excess magnitudes strictly below this threshold produce no offset.
+    pub dead_zone_bps: f64,
+}
+
+impl Default for ExternalSkewConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            lambda: 0.5,
+            cap_bps: 8.0,
+            dead_zone_bps: 1.0,
+        }
+    }
+}
+
+/// Return the signed quote-center offset for this cycle, in basis points.
+///
+/// Failure is open: disabled configuration and missing or non-finite samples
+/// all return zero, so the external signal can never become a stop-quoting
+/// source. Freshness is normalized by the existing guard chain before this
+/// pure function is called.
+pub fn external_skew_shift_bps(cfg: ExternalSkewConfig, excess_bps: Option<f64>) -> f64 {
+    if !cfg.enabled {
+        return 0.0;
+    }
+    let Some(excess_bps) = excess_bps.filter(|value| value.is_finite()) else {
+        return 0.0;
+    };
+    if excess_bps.abs() < cfg.dead_zone_bps {
+        return 0.0;
+    }
+    (cfg.lambda * excess_bps).clamp(-cfg.cap_bps, cfg.cap_bps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_cfg() -> ExternalSkewConfig {
+        ExternalSkewConfig {
+            enabled: true,
+            ..ExternalSkewConfig::default()
+        }
+    }
+
+    #[test]
+    fn defaults_to_disabled() {
+        let cfg = ExternalSkewConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(
+            external_skew_shift_bps(cfg, Some(40.0)).to_bits(),
+            0.0_f64.to_bits()
+        );
+    }
+
+    #[test]
+    fn absent_or_non_finite_sample_fails_open() {
+        let cfg = enabled_cfg();
+        assert_eq!(external_skew_shift_bps(cfg, None), 0.0);
+        assert_eq!(external_skew_shift_bps(cfg, Some(f64::NAN)), 0.0);
+        assert_eq!(external_skew_shift_bps(cfg, Some(f64::INFINITY)), 0.0);
+        assert_eq!(external_skew_shift_bps(cfg, Some(f64::NEG_INFINITY)), 0.0);
+    }
+
+    #[test]
+    fn dead_zone_is_strict_and_boundary_engages() {
+        let cfg = enabled_cfg();
+        assert_eq!(external_skew_shift_bps(cfg, Some(0.999)), 0.0);
+        assert_eq!(external_skew_shift_bps(cfg, Some(-0.999)), 0.0);
+        assert_eq!(external_skew_shift_bps(cfg, Some(1.0)), 0.5);
+        assert_eq!(external_skew_shift_bps(cfg, Some(-1.0)), -0.5);
+    }
+
+    #[test]
+    fn shift_is_proportional_and_signed_like_excess() {
+        let cfg = enabled_cfg();
+        assert_eq!(external_skew_shift_bps(cfg, Some(4.0)), 2.0);
+        assert_eq!(external_skew_shift_bps(cfg, Some(-4.0)), -2.0);
+    }
+
+    #[test]
+    fn shift_clamps_symmetrically() {
+        let cfg = enabled_cfg();
+        assert_eq!(external_skew_shift_bps(cfg, Some(100.0)), 8.0);
+        assert_eq!(external_skew_shift_bps(cfg, Some(-100.0)), -8.0);
+    }
+
+    #[test]
+    fn zero_lambda_is_a_no_op() {
+        let cfg = ExternalSkewConfig {
+            lambda: 0.0,
+            ..enabled_cfg()
+        };
+        assert_eq!(external_skew_shift_bps(cfg, Some(6.0)), 0.0);
+    }
+}

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -22,6 +22,7 @@ mod stats;
 
 pub mod account_projection;
 pub mod external_guard;
+pub mod external_skew;
 pub mod inventory;
 pub mod latency;
 pub mod ledger;
@@ -44,6 +45,7 @@ pub use alerts::{account_floor_breach, AccountFloorBreach, Alert, AlertMonitor};
 pub use external_guard::{
     ExternalDivergence, GuardConfig, GuardController, GuardDecision, GuardError,
 };
+pub use external_skew::{external_skew_shift_bps, ExternalSkewConfig};
 pub use inventory::{
     NonlinearSkewConfig, SizeSkewConfig, SizeSkewController, SizeSkewDecision, SizeSkewError,
 };
@@ -431,6 +433,27 @@ pub(crate) fn skew_center_with(
     mark * (1.0 - shift_bps * inv_ratio.signum() / 1e4)
 }
 
+/// The single quote-center composition point used by planning, price
+/// generation, and refresh reconciliation.
+///
+/// Keep the zero-shift branch on the exact legacy path. Besides documenting the
+/// default-off contract, this prevents even a mathematically neutral extra
+/// floating-point operation from entering old action sequences.
+pub(crate) fn quote_center(
+    cfg: &MakerConfig,
+    nonlinear: NonlinearSkewConfig,
+    external_shift_bps: f64,
+    mark: f64,
+    position: f64,
+) -> f64 {
+    let inventory_center = skew_center_with(cfg, nonlinear, mark, position);
+    if external_shift_bps == 0.0 {
+        inventory_center
+    } else {
+        inventory_center * (1.0 + external_shift_bps / 1e4)
+    }
+}
+
 /// Whether a quote at `price` on `side` crosses the current touch: a buy at or
 /// above the best ask (`price >= best_ask`), or a sell at or below the best bid
 /// (`price <= best_bid`). Returns false when the relevant book side is absent.
@@ -590,6 +613,11 @@ pub struct CycleInput<'a> {
     pub size_skew: SizeSkewDecision,
     /// Stage 3 v1 nonlinear price-skew strength; disabled ≡ legacy linear skew.
     pub nonlinear_skew: NonlinearSkewConfig,
+    /// Continuous external-price center offset configuration; default disabled.
+    pub external_skew: ExternalSkewConfig,
+    /// Fresh, finite excess from the external-guard signal chain. `None` fails
+    /// open to an exact zero shift.
+    pub external_excess_bps: Option<f64>,
     /// External-price guard outcome for this cycle; inactive ≡ no suppression.
     pub guard: GuardDecision,
     /// Supervisor-requested wind-down (e.g. an A/B arm past its scheduled
@@ -615,8 +643,13 @@ pub struct CyclePlan {
     pub exit_suppression: Option<SuppressedExit>,
     /// Cancels, places, and holds in executor-safe order.
     pub actions: Vec<Action>,
+    /// Inventory-only anchor retained for the legacy `skew_shift_bps`
+    /// telemetry contract.
+    pub inventory_ref_center: f64,
     /// Anchor used for any newly submitted quote.
     pub ref_center: f64,
+    /// External component actually applied to the shared quote center this cycle.
+    pub external_skew_shift_bps: f64,
 }
 
 /// Build a deterministic quote/exit plan after the caller has synchronized
@@ -632,6 +665,8 @@ pub struct CyclePlan {
 /// residual position above `input.qty_tolerance` yields a reduce-only exit
 /// plan regardless of the configured exit thresholds.
 pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> CyclePlan {
+    let external_shift_bps =
+        external_skew_shift_bps(input.external_skew, input.external_excess_bps);
     let market_active = input.market_data_mode == MarketDataMode::Active;
     // What the configured exit policy asks for, before any market-state or
     // volatility gate. Kept separate purely so suppression is observable: the
@@ -685,6 +720,7 @@ pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> Cyc
             input.position,
             input.size_skew,
             input.nonlinear_skew,
+            external_shift_bps,
             input.guard,
         );
         cap_desired_exposure(cfg, input.position, &raw, input.pending_slots)
@@ -704,8 +740,23 @@ pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> Cyc
             input.resting,
             input.cycle,
             input.nonlinear_skew,
+            external_shift_bps,
         ),
-        ref_center: skew_center_with(cfg, input.nonlinear_skew, input.market.mark, input.position),
+        inventory_ref_center: quote_center(
+            cfg,
+            input.nonlinear_skew,
+            0.0,
+            input.market.mark,
+            input.position,
+        ),
+        ref_center: quote_center(
+            cfg,
+            input.nonlinear_skew,
+            external_shift_bps,
+            input.market.mark,
+            input.position,
+        ),
+        external_skew_shift_bps: external_shift_bps,
     }
 }
 
@@ -725,6 +776,7 @@ pub(crate) fn compute_desired_quotes(
     position: f64,
     size_skew: SizeSkewDecision,
     nonlinear_skew: NonlinearSkewConfig,
+    external_shift_bps: f64,
     guard: GuardDecision,
 ) -> Vec<DesiredQuote> {
     let mut out = Vec::new();
@@ -746,9 +798,11 @@ pub(crate) fn compute_desired_quotes(
     let band_lo = mark * (1.0 - cfg.band_bps / 1e4);
     let band_hi = mark * (1.0 + cfg.band_bps / 1e4);
 
-    // Ladder is centered on the inventory-skewed price; the band/no-cross
-    // guards below still reference the true mark and touch.
-    let center = skew_center_with(cfg, nonlinear_skew, mark, position);
+    // Ladder is centered on the shared quote center (inventory skew, then the
+    // external offset); the band/no-cross guards below still reference the true
+    // mark and touch, so an oversized offset gets clamped to the band edge
+    // rather than moving the band with it.
+    let center = quote_center(cfg, nonlinear_skew, external_shift_bps, mark, position);
 
     let suppress_buy = position >= cfg.max_position;
     let suppress_sell = position <= -cfg.max_position;
@@ -934,12 +988,16 @@ pub(crate) fn reconcile(
     resting: &[RestingQuote],
     cycle: u64,
     nonlinear_skew: NonlinearSkewConfig,
+    external_shift_bps: f64,
 ) -> Vec<Action> {
     // Band/no-cross reference the true mark and touch; the anti-flicker anchor
-    // uses the inventory-skewed center.
+    // uses the shared quote center (inventory skew plus the external offset),
+    // the same one `compute_desired_quotes` priced this cycle's ladder from —
+    // comparing against a different anchor would requote every cycle the
+    // offset moved.
     let band_lo = mark * (1.0 - cfg.band_bps / 1e4);
     let band_hi = mark * (1.0 + cfg.band_bps / 1e4);
-    let center = skew_center_with(cfg, nonlinear_skew, mark, position);
+    let center = quote_center(cfg, nonlinear_skew, external_shift_bps, mark, position);
 
     let desired_has = |side: OrderSide, level: u32| -> bool {
         desired.iter().any(|d| d.side == side && d.level == level)

--- a/crates/standx-maker/src/lib_tests.rs
+++ b/crates/standx-maker/src/lib_tests.rs
@@ -32,6 +32,7 @@ fn desired(
         position,
         SizeSkewDecision::INACTIVE,
         NonlinearSkewConfig::default(),
+        0.0,
         GuardDecision::INACTIVE,
     )
 }
@@ -92,6 +93,7 @@ fn requotes_on_touch_move_without_creating_crossed_quote() {
         &[],
         0,
         Default::default(),
+        0.0,
     );
     assert!(actions
         .iter()
@@ -126,6 +128,7 @@ fn requotes_on_touch_move_without_creating_crossed_quote() {
         &resting,
         1,
         Default::default(),
+        0.0,
     );
     assert!(actions.iter().any(|action| matches!(
         action,
@@ -273,6 +276,7 @@ fn reconcile_hold_within_refresh() {
         &rest,
         7,
         Default::default(),
+        0.0,
     );
     assert!(
         actions.iter().all(|a| matches!(a, Action::Hold { .. })),
@@ -301,6 +305,7 @@ fn reconcile_requote_beyond_refresh() {
         &rest,
         1,
         Default::default(),
+        0.0,
     );
     // Expect: cancel(buy, mark_moved), then places for buy+sell.
     assert!(matches!(
@@ -337,6 +342,7 @@ fn reconcile_cancel_outside_band_precedence() {
         &rest,
         1,
         Default::default(),
+        0.0,
     );
     assert!(
         matches!(
@@ -368,6 +374,7 @@ fn reconcile_cancel_would_cross() {
         &rest,
         1,
         Default::default(),
+        0.0,
     );
     assert!(
         matches!(
@@ -416,6 +423,7 @@ fn reconcile_stale_level() {
         &rest,
         1,
         Default::default(),
+        0.0,
     );
     let stale: Vec<_> = actions
         .iter()
@@ -740,6 +748,7 @@ fn reconcile_skew_requote() {
         &rest,
         1,
         Default::default(),
+        0.0,
     );
     assert!(actions.iter().any(|a| matches!(
         a,
@@ -763,6 +772,7 @@ fn reconcile_skew_requote() {
         &rest2,
         1,
         Default::default(),
+        0.0,
     );
     assert!(actions2.iter().any(|a| matches!(a, Action::Hold { .. })));
     assert!(!actions2.iter().any(|a| matches!(a, Action::Cancel { .. })));
@@ -873,6 +883,8 @@ fn cycle_plan_pulls_quotes_for_exit_and_suppresses_exit_during_vol_halt() {
         inventory_exit_qty: 0.01,
         size_skew: Default::default(),
         nonlinear_skew: Default::default(),
+        external_skew: Default::default(),
+        external_excess_bps: None,
         guard: Default::default(),
         wind_down: false,
         qty_tolerance: 0.0005,
@@ -938,6 +950,8 @@ fn vol_halt_suppresses_wind_down_exit_with_typed_reason() {
         inventory_exit_qty: 0.0,
         size_skew: Default::default(),
         nonlinear_skew: Default::default(),
+        external_skew: Default::default(),
+        external_excess_bps: None,
         guard: Default::default(),
         wind_down: true,
         qty_tolerance: 0.0005,
@@ -992,6 +1006,8 @@ fn inactive_market_data_suppresses_exit_and_outranks_halt() {
         inventory_exit_qty: 0.01,
         size_skew: Default::default(),
         nonlinear_skew: Default::default(),
+        external_skew: Default::default(),
+        external_excess_bps: None,
         guard: Default::default(),
         wind_down,
         qty_tolerance: 0.0005,
@@ -1093,6 +1109,8 @@ fn cycle_plan_reserves_delayed_places_and_caps_directional_exposure() {
             inventory_exit_qty: 0.0,
             size_skew: Default::default(),
             nonlinear_skew: Default::default(),
+            external_skew: Default::default(),
+            external_excess_bps: None,
             guard: Default::default(),
             wind_down: false,
             qty_tolerance: 0.0005,
@@ -1136,6 +1154,8 @@ fn paused_market_data_cancels_without_placing_or_exiting() {
             inventory_exit_qty: 0.01,
             size_skew: Default::default(),
             nonlinear_skew: Default::default(),
+            external_skew: Default::default(),
+            external_excess_bps: None,
             guard: Default::default(),
             wind_down: false,
             qty_tolerance: 0.0005,
@@ -1198,6 +1218,8 @@ fn inactive_size_skew_is_exactly_plan_equivalent_across_state_grid() {
                     inventory_exit_qty: 0.0,
                     size_skew: SizeSkewDecision::default(),
                     nonlinear_skew: Default::default(),
+                    external_skew: Default::default(),
+                    external_excess_bps: None,
                     guard: Default::default(),
                     wind_down: false,
                     qty_tolerance: 0.0005,
@@ -1264,6 +1286,8 @@ fn disabled_nonlinear_and_inactive_guard_are_plan_equivalent_across_state_grid()
                 inventory_exit_qty: 0.0,
                 size_skew: SizeSkewDecision::default(),
                 nonlinear_skew: Default::default(),
+                external_skew: Default::default(),
+                external_excess_bps: None,
                 guard: Default::default(),
                 wind_down: false,
                 qty_tolerance: 0.0005,
@@ -1355,6 +1379,8 @@ fn guard_suppresses_endangered_side_and_cancels_its_resting_quotes() {
             inventory_exit_qty: 0.0,
             size_skew: Default::default(),
             nonlinear_skew: Default::default(),
+            external_skew: Default::default(),
+            external_excess_bps: None,
             guard: GuardDecision {
                 enabled: true,
                 active: true,
@@ -1424,6 +1450,8 @@ fn combined_high_inventory_and_guard_keeps_all_invariants() {
             inventory_exit_qty: 0.0,
             size_skew: Default::default(),
             nonlinear_skew: nl,
+            external_skew: Default::default(),
+            external_excess_bps: None,
             guard: GuardDecision {
                 enabled: true,
                 active: true,
@@ -1473,6 +1501,8 @@ fn combined_high_inventory_and_guard_keeps_all_invariants() {
             inventory_exit_qty: 0.0,
             size_skew: Default::default(),
             nonlinear_skew: nl,
+            external_skew: Default::default(),
+            external_excess_bps: None,
             guard: GuardDecision {
                 enabled: true,
                 active: false,
@@ -1488,6 +1518,239 @@ fn combined_high_inventory_and_guard_keeps_all_invariants() {
         .actions
         .iter()
         .any(|action| matches!(action, Action::Place(q) if q.side == OrderSide::Buy)));
+}
+
+fn enabled_external_skew() -> ExternalSkewConfig {
+    ExternalSkewConfig {
+        enabled: true,
+        lambda: 0.5,
+        cap_bps: 8.0,
+        dead_zone_bps: 1.0,
+    }
+}
+
+#[test]
+fn external_skew_composes_after_inventory_skew_deterministically() {
+    let mut c = cfg();
+    c.skew_bps = 8.0;
+    c.max_position = 1.0;
+    let nonlinear = NonlinearSkewConfig {
+        enabled: true,
+        boost: 3.0,
+        cap_bps: 12.0,
+    };
+    let inventory_center = skew_center_with(&c, nonlinear, 100.0, 0.25);
+    let composed = quote_center(&c, nonlinear, 3.5, 100.0, 0.25);
+    assert_eq!(composed, inventory_center * (1.0 + 3.5 / 1e4));
+}
+
+#[test]
+fn external_skew_disabled_is_exactly_plan_equivalent() {
+    let mut c = cfg();
+    c.skew_bps = 8.0;
+    let input = CycleInput {
+        cycle: 11,
+        market: MarketSnapshot {
+            mark: 100.0,
+            best_bid: Some(99.8),
+            best_ask: Some(100.2),
+        },
+        position: 0.02,
+        resting: &[],
+        pending_slots: &[],
+        market_data_mode: MarketDataMode::Active,
+        active_exit_enabled: false,
+        inventory_exit_pct: 0.0,
+        inventory_exit_qty: 0.0,
+        size_skew: Default::default(),
+        nonlinear_skew: Default::default(),
+        external_skew: Default::default(),
+        external_excess_bps: None,
+        guard: Default::default(),
+        wind_down: false,
+        qty_tolerance: 0.0005,
+    };
+    let baseline = plan_cycle(&c, input, false);
+    let explicitly_disabled = plan_cycle(
+        &c,
+        CycleInput {
+            external_skew: ExternalSkewConfig {
+                enabled: false,
+                lambda: 7.0,
+                cap_bps: 99.0,
+                dead_zone_bps: 0.0,
+            },
+            external_excess_bps: Some(40.0),
+            ..input
+        },
+        false,
+    );
+
+    assert_eq!(explicitly_disabled.actions, baseline.actions);
+    assert_eq!(
+        explicitly_disabled.ref_center.to_bits(),
+        baseline.ref_center.to_bits()
+    );
+    assert_eq!(
+        explicitly_disabled.external_skew_shift_bps.to_bits(),
+        0.0_f64.to_bits()
+    );
+}
+
+#[test]
+fn external_skew_still_shifts_surviving_side_while_guard_is_active() {
+    let c = cfg();
+    let guard = GuardDecision {
+        enabled: true,
+        active: true,
+        endangered: Some(OrderSide::Sell),
+        divergence_bps: Some(7.0),
+    };
+    let make_input = |external_skew, external_excess_bps| CycleInput {
+        cycle: 12,
+        market: MarketSnapshot {
+            mark: 100.0,
+            best_bid: Some(99.8),
+            best_ask: Some(100.2),
+        },
+        position: 0.0,
+        resting: &[],
+        pending_slots: &[],
+        market_data_mode: MarketDataMode::Active,
+        active_exit_enabled: false,
+        inventory_exit_pct: 0.0,
+        inventory_exit_qty: 0.0,
+        size_skew: Default::default(),
+        nonlinear_skew: Default::default(),
+        external_skew,
+        external_excess_bps,
+        guard,
+        wind_down: false,
+        qty_tolerance: 0.0005,
+    };
+    let baseline = plan_cycle(&c, make_input(Default::default(), Some(7.0)), false);
+    let shifted = plan_cycle(&c, make_input(enabled_external_skew(), Some(7.0)), false);
+    let buy_price = |plan: &CyclePlan| {
+        plan.actions
+            .iter()
+            .find_map(|action| match action {
+                Action::Place(quote) if quote.side == OrderSide::Buy => Some(quote.price),
+                _ => None,
+            })
+            .expect("guard-surviving buy quote")
+    };
+
+    assert!(buy_price(&shifted) > buy_price(&baseline));
+    assert!(shifted
+        .actions
+        .iter()
+        .all(|action| !matches!(action, Action::Place(q) if q.side == OrderSide::Sell)));
+    assert_eq!(shifted.external_skew_shift_bps, 3.5);
+}
+
+#[test]
+fn shared_external_quote_center_prevents_false_refresh() {
+    let c = cfg();
+    let market = MarketSnapshot {
+        mark: 100.0,
+        best_bid: Some(99.8),
+        best_ask: Some(100.2),
+    };
+    let first = plan_cycle(
+        &c,
+        CycleInput {
+            cycle: 20,
+            market,
+            position: 0.0,
+            resting: &[],
+            pending_slots: &[],
+            market_data_mode: MarketDataMode::Active,
+            active_exit_enabled: false,
+            inventory_exit_pct: 0.0,
+            inventory_exit_qty: 0.0,
+            size_skew: Default::default(),
+            nonlinear_skew: Default::default(),
+            external_skew: enabled_external_skew(),
+            external_excess_bps: Some(8.0),
+            guard: Default::default(),
+            wind_down: false,
+            qty_tolerance: 0.0005,
+        },
+        false,
+    );
+    assert_eq!(first.external_skew_shift_bps, 4.0);
+    assert_eq!(
+        first.ref_center.to_bits(),
+        quote_center(&c, Default::default(), 4.0, 100.0, 0.0).to_bits()
+    );
+    let resting = first
+        .actions
+        .iter()
+        .filter_map(|action| match action {
+            Action::Place(quote) => Some(RestingQuote {
+                order_id: Some(format!("{:?}-{}", quote.side, quote.level)),
+                side: quote.side,
+                level: quote.level,
+                price: quote.price,
+                qty: quote.qty,
+                ref_center: first.ref_center,
+                placed_at_cycle: 20,
+            }),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let second = plan_cycle(
+        &c,
+        CycleInput {
+            cycle: 21,
+            market,
+            position: 0.0,
+            resting: &resting,
+            pending_slots: &[],
+            market_data_mode: MarketDataMode::Active,
+            active_exit_enabled: false,
+            inventory_exit_pct: 0.0,
+            inventory_exit_qty: 0.0,
+            size_skew: Default::default(),
+            nonlinear_skew: Default::default(),
+            external_skew: enabled_external_skew(),
+            external_excess_bps: Some(8.0),
+            guard: Default::default(),
+            wind_down: false,
+            qty_tolerance: 0.0005,
+        },
+        false,
+    );
+    assert!(second
+        .actions
+        .iter()
+        .all(|action| matches!(action, Action::Hold { .. })));
+    assert!(!second.actions.iter().any(|action| matches!(
+        action,
+        Action::Cancel {
+            reason: CancelReason::MarkMovedBeyondRefresh,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn external_skew_over_band_is_clamped_not_dropped_if_validation_is_bypassed() {
+    let mut c = cfg();
+    c.band_bps = 20.0;
+    let quotes = compute_desired_quotes(
+        &c,
+        100.0,
+        Some(99.5),
+        Some(100.5),
+        0.0,
+        Default::default(),
+        Default::default(),
+        30.0,
+        Default::default(),
+    );
+    let sell = find(&quotes, OrderSide::Sell, 0);
+    assert_eq!(sell.price, 100.20);
 }
 
 // 28. Alert monitor: disabled emits nothing.
@@ -1618,6 +1881,8 @@ fn wind_down_flattens_residual_and_stops_quoting() {
         inventory_exit_qty: 0.0,
         size_skew: Default::default(),
         nonlinear_skew: Default::default(),
+        external_skew: Default::default(),
+        external_excess_bps: None,
         guard: Default::default(),
         wind_down: true,
         qty_tolerance: 0.0005,
@@ -1672,6 +1937,8 @@ fn wind_down_flat_still_suppresses_quotes() {
             inventory_exit_qty: 0.0,
             size_skew: Default::default(),
             nonlinear_skew: Default::default(),
+            external_skew: Default::default(),
+            external_excess_bps: None,
             guard: Default::default(),
             wind_down: true,
             qty_tolerance: 0.0005,
@@ -1705,6 +1972,8 @@ fn wind_down_overrides_threshold_and_honors_tolerance() {
         inventory_exit_qty: 0.01,
         size_skew: Default::default(),
         nonlinear_skew: Default::default(),
+        external_skew: Default::default(),
+        external_excess_bps: None,
         guard: Default::default(),
         wind_down: true,
         qty_tolerance: 0.0005,

--- a/crates/standx-maker/src/replay.rs
+++ b/crates/standx-maker/src/replay.rs
@@ -173,6 +173,8 @@ pub fn run_replay(
                             inventory_exit_qty: settings.inventory_exit_qty,
                             size_skew: size_skew_decision,
                             nonlinear_skew: Default::default(),
+                            external_skew: Default::default(),
+                            external_excess_bps: None,
                             guard: Default::default(),
                             wind_down: false,
                             qty_tolerance: 0.0005,

--- a/crates/standx-maker/src/volatility.rs
+++ b/crates/standx-maker/src/volatility.rs
@@ -527,6 +527,8 @@ mod tests {
                 inventory_exit_qty: 0.0,
                 size_skew: Default::default(),
                 nonlinear_skew: Default::default(),
+                external_skew: Default::default(),
+                external_excess_bps: None,
                 guard: Default::default(),
                 wind_down: false,
                 qty_tolerance: 0.0005,

--- a/examples/maker-external-skew-hype-candidate.toml
+++ b/examples/maker-external-skew-hype-candidate.toml
@@ -1,0 +1,89 @@
+# Stage 3 v1 combined-candidate live A/B arm, HYPE-USD. No credentials, webhook URL, or --live flag.
+# Venue metadata (2026-07-17 symbol-info): price_tick_decimals=3
+# qty_tick_decimals=2 min_order_qty=0.1 max_leverage=20.
+# Sizing tier approved by operator: ~$59 max notional at HYPE≈$59 (10x skew
+# room, stop_loss ≈2.7% of ~$184 equity). Vol thresholds intentionally kept
+# identical to the XAG arms so the adaptive-spread comparison stays structural.
+spread_bps = 8.0
+band_bps = 30.0
+size = 0.1
+levels = 1
+level_step_bps = 2.0
+refresh_bps = 4.0
+interval = 3
+
+max_position = 1.0
+skew_bps = 8.0
+inventory_exit_pct = 0.0
+inventory_exit_qty = 0.0
+max_divergence_bps = 15.0
+vol_pause_bps = 40.0
+vol_window_secs = 60
+
+stop_loss = 5.0
+alert_loss = 2.5
+alert_inventory_pct = 70.0
+alert_position_change_pct = 20.0
+alert_uptime = 60.0
+alert_equity_below = 94.0
+alert_margin_below = 30.0
+
+no_ws = false
+order_response_reconnect_attempts = 3
+order_response_reconnect_backoff = 2
+account_stream_reconnect_attempts = 3
+account_stream_reconnect_backoff = 2
+
+[adaptive_spread]
+enabled = false
+min_spread_bps = 8.0
+max_spread_bps = 18.0
+
+[[adaptive_spread.tiers]]
+spread_bps = 8.0
+refresh_bps = 4.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 10.0
+exit_vol_bps = 7.0
+spread_bps = 12.0
+refresh_bps = 5.0
+
+[[adaptive_spread.tiers]]
+enter_vol_bps = 20.0
+exit_vol_bps = 15.0
+spread_bps = 18.0
+refresh_bps = 6.0
+
+# size=0.1 is the venue minimum; factor 0.5 floors to 0.05, below the 0.1
+# minimum, so the active v0 controller degenerates to binary add-side suppression.
+[size_skew]
+enabled = false
+activate_pct = 30.0
+release_pct = 20.0
+add_side_factor = 0.5
+
+# Stage 3 v1 combined candidate (docs/22): nonlinear price skew — steeper but
+# never stops quoting; cap red line spread(8)+cap(12)=20 <= band(30).
+[nonlinear_skew]
+enabled = true
+boost = 3.0
+cap_bps = 12.0
+
+# External-price defensive guard: suppress the endangered side while the
+# leader (Hyperliquid midPx) has moved and StandX mark has not yet followed.
+# Fail-open: missing/stale feed deactivates the guard, quoting continues.
+[external_guard]
+enabled = true
+enter_bps = 10.0
+exit_bps = 5.0
+max_age_ms = 5000
+basis_half_life_secs = 300
+
+# Candidate arm (docs/28): continuous external-price center offset.
+# Band red line: spread(8) + nonlinear.cap(12) + external.cap(8) = 28 <= band(30).
+[external_skew]
+enabled = true
+lambda = 0.5
+cap_bps = 8.0
+dead_zone_bps = 1.0


### PR DESCRIPTION
按 [docs/28-maker-external-skew-design.md](docs/28-maker-external-skew-design.md) 施工（设计已随 #365 合入 main）。

**默认关闭、无 live 动作、输出契约只增不改。** `enabled = false` 或缺 section 时逐 action 与旧行为字节等价。

> **裁决状态**：机制本身仍是 `待 release owner 裁决`。本 PR 只交代码，**不启用、不申请 live 时间片**。按 28 号文档 2026-08-01 复核，即使 A/B 达标也只回收净亏 ~16%（亏损大头 60~72% 在最差 10% 的成交上，外部信号对其无判别力，属候选 6 的范围）。

## 机制

```
center    = skew_center_with(cfg, nonlinear, mark, position) × (1 + shift/1e4)
shift_bps = clamp(λ × excess_bps, ±cap_bps)     |excess| < dead_zone 时为 0
```

excess 完全复用 `[external_guard]` 链路（同一 HL midPx feed、同一 300s EWMA basis 扣除、同一 `max_age_ms` 新鲜度判定）——不新增订阅、不新增第二份信号配置。失败方向 **OPEN**：样本缺失/过期/非有限 → shift = 0，报价照常。外部信号永远不会成为新的停报价来源。

## core

- 新增 [external_skew.rs](crates/standx-maker/src/external_skew.rs)：纯函数 `external_skew_shift_bps`（死区 + 对称 clamp，无状态、无 I/O、无时钟）。
- 新增 `quote_center()` 作为**唯一**中心复合点。原先**三处各自算 center**（`plan_cycle` 的 `ref_center`、`compute_desired_quotes`、`reconcile`）全部改为调用它。
- `quote_center` 对 `shift == 0.0` 显式短路回旧路径，不依赖「乘 1.0 在 IEEE754 下精确」这个推理。

**为什么三处必须同锚**：refresh 判据比的是 **center 漂移**而非价格差。锚点不一致会让刚下的单在同一轮被判 `MarkMovedBeyondRefresh` 而撤单重挂 —— 这种 bug 三处分开测都能过、合起来才错，所以专门加了回归测试（见下）。

## 输出契约：既有 `skew_shift_bps` 语义未变

`cycle_summary.skew_shift_bps` 是由 mark 与 `ref_center` 之差算出的。`ref_center` 现在含外部偏移，**若直接沿用会静默改变这个既有字段的含义**。故 `CyclePlan` 保留 `inventory_ref_center`（库存口径）专供该字段，外部分量走新字段 `external_skew_shift_bps`。测试断言老字段仍为 0 而两个 anchor 不相等。

## CLI

`[external_skew]` 为 TOML-only（无 CLI flag —— 冻结 A/B 配置是唯一真相源），`deny_unknown_fields`，四键均可省。

`validate_external_skew()` 在启动时校验四条红线，**非法值即使 `enabled=false` 也拒绝**（坏文件不许静默搭车）：

1. `enabled` 要求 `[external_guard]` 也启用 —— excess 来自该链路，guard 关闭时 `GuardDecision.divergence_bps` 恒为 `None`，机制会静默退化成永久 0 偏移；
2. `cap_bps < external_guard.enter_bps` —— 尾部保留 guard 的压制语义；
3. band 预算 `spread + ladder + inventory_cap + cap_bps ≤ band_bps`（冻结基线 8+0+12+8 = 28 ≤ 30）。**`adaptive_spread` 启用时 spread 项取各档最大值** —— 否则 `max_spread_bps = 18` 会让预算变成 38 > 30 而漏过校验；
4. 标量有限、`lambda ≥ 0`、`cap_bps > 0`、`dead_zone_bps ≥ 0`。

**越线拒绝启动，而不是让它静默劣化。** 越 band 的价格会被 `clamp` 到 band 边沿（不是丢弃该侧），该侧机制随即失效且无任何告警；同时 center 继续漂移仍会触发撤单重挂到**同一个价格**的纯 churn。

## 遥测（只增不改）

- `cycle_summary.external_skew_shift_bps`（总是出现，含 0.0）。
- `external_skew` 事件：shift 进出死区或翻转符号时记录，风格同 `external_guard`。
- fill 事件增 `excess_bps_at_fill`：
  - **两臂都落**，与 `external_skew.enabled` 无关 —— 否则 baseline 臂没有对照读数；
  - **样本缺失写 `null` 而非 `0`** —— 0 是「无偏离」这个真实取值，必须与「没测到」可区分（有专门测试）；
  - fill 是异步到达的、不在 cycle 内，故新增 `ExternalExcessTelemetry` 持有最近样本并按 guard 的 `max_age_ms` **残余预算**过期。这不是第二份新鲜度规则，是同一阈值顺延。

## 配置

新增 [maker-external-skew-hype-candidate.toml](examples/maker-external-skew-hype-candidate.toml) = 冻结基线 `maker-guard-hype-candidate.toml` **逐字节照抄** + 仅追加 `[external_skew]`（enabled / λ=0.5 / cap=8 / dead_zone=1）。该性质由测试锁定，`diff` 只有一段新增。

## 测试

- **toggle-off 字节等价**：用对抗式配置（λ=7 / cap=99 / dead_zone=0 / excess=Some(40) 但 `enabled=false`）比对 actions 与 `ref_center.to_bits()` 逐位相等。
- **guard 激活期间仍施加偏移**（28 号文档复合语义定稿的回归锁）：危险侧不挂，存活侧价格被推向即将移动的 mark。
- **三处同锚**：下单后在同市况、同 excess 下重规划，断言全部 `Hold` 且无 `MarkMovedBeyondRefresh`。
- **band 边沿**：绕过校验时价格被夹到 band 边沿而非丢弃该侧。
- 配置解析（全字段 / 部分字段 / 未知字段拒绝）、四条红线各自的拒绝用例、死区 / clamp / 符号 / fail-open。

## CI（本分支实测）

| 命令 | 结果 |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0，0 warning |
| `cargo test --workspace` | exit 0，**578 passed / 0 failed** |

## Reviewer 注意

- **无 live 动作**，未改任何 live gate，未改动 `examples/maker-guard-hype-candidate.toml`（冻结基线）。
- 波及但非本机制的改动都是**结构体加字段的连带修复**：`replay.rs` / `volatility.rs` 补默认值；`events.rs` / `recovery.rs` / `recovery_flow.rs` 是把 `excess_bps_at_fill` 接进各条 fill 发射路径（新增 `FillEmissionContext` 以免参数过多）。
- **范围外、仍待决策**：28 号文档验收判据节的均值口径要不要换成尾部口径（尾部主导下均值估计不牢），以及 AS 诊断量的实测 σ。两者都不阻塞本 PR —— 机制默认关，判据在写授权文本时才需要定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
