### PR TITLE
docs(maker): 撤下 runbook/canary 记录里的真实姓名，改用角色代号

### DIFF
--- a/docs/19-maker-stage2-live-ab-runbook.md
+++ b/docs/19-maker-stage2-live-ab-runbook.md
@@ -1,7 +1,7 @@
 # Maker Stage 2 v0 live canary and A/B runbook
 
 This runbook merges the renewed live gate with Stage 2 rollout. It does not
-record a pass by itself. The named online operator is **wujunlin**. Live work
+record a pass by itself. The named online operator is **the release owner**. Live work
 must not begin until the release record contains this exact authorization:
 
 > 授权执行 XAG-USD size=0.01 max_position=0.2 的阶段2 canary 与2小时A/B
@@ -65,7 +65,7 @@ A successful HTTP response without receiver confirmation is not a pass.
 
 ## Emergency procedure
 
-At least wujunlin must have authenticated venue access throughout the first 30
+At least the release owner must have authenticated venue access throughout the first 30
 minutes. On any unknown fill, residual maker order, failed reconnect/reconcile,
 missing webhook or non-zero terminal position:
 
@@ -78,7 +78,7 @@ missing webhook or non-zero terminal position:
    /opt/standx/bin/standx --output json account positions --symbol XAG-USD
    ```
 
-3. If a residual position remains after stop-loss or cleanup, wujunlin reads
+3. If a residual position remains after stop-loss or cleanup, the release owner reads
    its exact side and quantity, submits one manually reviewed opposite-side
    `--reduce-only` order, and rechecks orders and positions. Never infer the
    quantity from configured `max_position`; never submit an automated flatten.

--- a/docs/21-maker-stage3-live-ab-runbook.md
+++ b/docs/21-maker-stage3-live-ab-runbook.md
@@ -5,7 +5,7 @@
 相同，本文只记录阶段 3 的差异与本次授权；未提及的章节（应急处置、webhook
 探针、bounded canary 判定顺序）以 19 号手册为准，symbol 一律替换为 HYPE-USD。
 
-Named online operator：**wujunlin**。Live work must not begin until the
+Named online operator：**release owner**。Live work must not begin until the
 release record contains this exact authorization:
 
 > 授权执行 HYPE-USD size=0.1 max_position=1.0 的阶段3 canary 与4小时A/B

--- a/docs/23-maker-stage3v1-live-ab-runbook.md
+++ b/docs/23-maker-stage3v1-live-ab-runbook.md
@@ -7,7 +7,7 @@
 相同，本文只记录 v1 的差异与本次授权；未提及的章节（应急处置、webhook
 探针、bounded canary 判定顺序）以 19 号手册为准，symbol 一律为 HYPE-USD。
 
-Named online operator：**wujunlin**。Live work must not begin until the
+Named online operator：**release owner**。Live work must not begin until the
 release record contains this exact authorization:
 
 > 授权执行 HYPE-USD size=0.1 max_position=1.0 的阶段3v1组合候选 canary 与4小时A/B

--- a/docs/evidence/maker-stage3-canary-2026-07-21.md
+++ b/docs/evidence/maker-stage3-canary-2026-07-21.md
@@ -5,7 +5,7 @@
 [21-maker-stage3-live-ab-runbook.md](../21-maker-stage3-live-ab-runbook.md)。
 
 - Release commit：`c4fc893fb86d8c16193017a6dd047b097c57b2d0`（工作树干净）
-- Named operator：wujunlin
+- Named operator：release owner
 - 授权文本（release record）：
 
   > 授权执行 HYPE-USD size=0.1 max_position=1.0 的阶段3 canary 与4小时A/B

--- a/docs/evidence/maker-stage3v1-canary-2026-07-22.md
+++ b/docs/evidence/maker-stage3v1-canary-2026-07-22.md
@@ -8,7 +8,7 @@
 
 - Release commit：`45311e79e7b211d662e8c37b993a47118aa62c06`（工作树干净，
   仅未跟踪的 `.mimocode/` 本地目录）
-- Named operator：wujunlin
+- Named operator：release owner
 - 授权文本（release record，2026-07-22 会话中给出）：
 
   > 授权执行 HYPE-USD size=0.1 max_position=1.0 的阶段3v1组合候选 canary 与4小时A/B

--- a/docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md
+++ b/docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md
@@ -62,7 +62,7 @@ profile `ab`), per the release owner's instruction "在docker中执行".
   `test_id=stage2-webhook-ccf00583cabf` (stop_loss, position_risk, equity,
   margin; all HTTP 2xx). Receiver confirmation: **confirmed** by the release
   owner — all four messages received in the feishu receiver.
-- Named operator wujunlin confirmed ready with authenticated venue access for
+- Named operator (release owner) confirmed ready with authenticated venue access for
   the first 30 minutes of the canary window.
 
 ## Canary evidence
@@ -200,7 +200,7 @@ Consider adding those paths to `.dockerignore` after the A/B window.
   Dockerfile clean-source gate passed at build. Config hashes unchanged
   (baseline `3df955e9…`, candidate `30fdd415…`); validate-only preflight
   passed 2026-07-17T05:2xZ.
-- Operator wujunlin re-confirmed ready for the canary window.
+- The release owner re-confirmed ready for the canary window.
 
 ### Retry canary (new binary) — passed 2026-07-17T05:35Z
 
@@ -281,7 +281,7 @@ throughout).
   fills_total=11 unchanged since 08:38Z). Residual orders UNKNOWN — the
   final quote pair could not be cancelled (auth), so one bid+ask pair of
   0.01 XAG each may still be resting on the book.
-- Handoff to operator (wujunlin): 1) `standx auth login` on the host to
+- Handoff to the release owner: 1) `standx auth login` on the host to
   refresh credentials.enc; 2) verify `account orders`/`account positions`;
   3) cancel any residual sxmk- orders and flatten the -0.01 if still
   present; 4) only then consider a fresh A/B launch (preflight requires


### PR DESCRIPTION
## 为什么

用户要求复查项目文档里是否留有 StandX 官方/内部资料或信息。复查范围：docs/、README、部署配置样例、git 提交历史。

发现的唯一一项需要处理的内容：**6 个公开文档把团队成员的真实姓名 "wujunlin" 写成 "Named online operator"，绑定到具体的实盘授权与应急撤单职责**。这类把真名和"谁能操作实盘资金"绑在一起的内部人员信息，不应该留在公开仓库里被搜索引擎或 grep 直接命中。

其余复查项均确认无泄露：
- `deploy/*.env.example` 里的密码/token/webhook 全是占位符（`ReplaceMe-123!`、`hooks.example.com/.../REPLACE`），无真实凭据
- 无真实 JWT / PEM 私钥落地在任何被 git 跟踪的文件里
- README 里的 EVM 地址是作者主动公开的赞助收款地址，非泄露
- `docs/15-openobserve.md` 里的 `192.168.193.65` 是 RFC1918 私网地址，公网不可达
- 其余判决文档里出现的都是角色代号（`release owner`、`BossX`），不是真名

## 改了什么

把 6 个文件里 9 处 "wujunlin" 替换为文档里本来就在用的角色代号 **release owner**，不改变文档的可读性和判决记录完整性：

- `docs/19-maker-stage2-live-ab-runbook.md`
- `docs/21-maker-stage3-live-ab-runbook.md`
- `docs/23-maker-stage3v1-live-ab-runbook.md`
- `docs/evidence/maker-stage3-canary-2026-07-21.md`
- `docs/evidence/maker-stage3v1-canary-2026-07-22.md`
- `docs/evidence/maker-strategy-stage-2-canary-ab-2026-07-17.md`

## 审阅要点 / 已知限制

**范围有意收窄，未动 git 历史。** 提交历史里本来就带着同一个人的作者邮箱（`wujunlin@Mac-Studio.local`、`junlin@standx.com` 等），`git log` 依然能查到同一个真名。真正"处理掉"需要 `git filter-repo` 一类的历史改写——这是破坏性操作，会改变所有 commit hash、需要协作者重新 clone，未经用户对此单独明确同意，本次不做。这次改动只覆盖文档正文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)