### PR TITLE
feat(maker): 盘口深档/成交流/clamp 命中纯观测遥测 + band 回到 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `standx maker` now records observation-only market microstructure on `cycle_summary`: a `book` block (up to five depth levels per side, top-of-book sizes, touch spread, mark/mid divergence), a `tape` block summarizing the newly subscribed `public_trade` channel over a five-second window, and a `geometry` block reporting per-slot quote geometry — pre-clamp and post-clamp price, which bound was binding (eligibility band vs post-only no-cross), and the distance from each quote to the opposing touch. None of these fields feed quoting, cancellation, exit, or safety decisions, and the replay action sequence is unchanged.
+
+### Changed
+- The trade tape and depth copy live on a lock separate from the decision-critical mark/touch cache, and the `public_trade` subscription is excluded from feed freshness and reconnect logic, so a silent tape can never stall or rebuild the market feed.
+- `examples/maker-microprice-hype-baseline.toml` returns to `band_bps = 30.0`. Widening the strategy's own cancel band to 40 worked against the ±10bp in-band uptime constraint in `docs/30`; the accepted consequence is that fully stacked center offsets are now clamped at the band edge.
+
+### Fixed
+- Removed a panic path introduced in the resident market-feed loop: the accepted-update branch now carries its channel directly instead of re-deriving it behind an `expect`.
+
 ## [1.3.4] - 2026-07-31
 
 ### Fixed

--- a/crates/standx-cli/src/commands/maker/cycle.rs
+++ b/crates/standx-cli/src/commands/maker/cycle.rs
@@ -268,6 +268,7 @@ pub(super) async fn maker_cycle(
         recovery,
         market_fallback_reason,
         ws_snapshot,
+        market_telemetry,
         max_divergence_bps,
         inventory_exit_pct,
         inventory_exit_qty,
@@ -706,6 +707,7 @@ pub(super) async fn maker_cycle(
     let external_skew_shift_bps = plan.external_skew_shift_bps;
     let micro_price_shift_bps = plan.micro_price_shift_bps;
     let inventory_skew_shift_bps = legacy_inventory_skew_shift_bps(mark, &plan);
+    let quote_geometry = plan.quote_geometry;
     if external_skew_transitioned(*external_skew_previous_shift_bps, external_skew_shift_bps) {
         emit_external_skew_transition(
             output_format,
@@ -1109,6 +1111,8 @@ pub(super) async fn maker_cycle(
         market_source,
         market_fallback_reason,
         ws_snapshot,
+        market_telemetry,
+        quote_geometry: &quote_geometry,
         position,
         starting_position,
         account: account_balance.as_ref(),
@@ -1176,6 +1180,7 @@ mod tests {
             ref_center: 100.04,
             external_skew_shift_bps: 4.0,
             micro_price_shift_bps: 0.0,
+            quote_geometry: Vec::new(),
         };
 
         assert_eq!(legacy_inventory_skew_shift_bps(100.0, &plan), 0.0);

--- a/crates/standx-cli/src/commands/maker/feed.rs
+++ b/crates/standx-cli/src/commands/maker/feed.rs
@@ -1,7 +1,10 @@
 use super::model::{optional_decimal, Decimal};
 use anyhow::Result;
 use standx_sdk::client::StandXClient;
+use standx_sdk::models::{OrderBook, Trade};
 use standx_sdk::websocket::{StandXWebSocket, WsMarketUpdate, WsMessage};
+use std::collections::VecDeque;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{watch, RwLock};
@@ -16,6 +19,191 @@ pub(super) struct FeedState {
     best_ask: Option<f64>,
     book_meta: Option<FeedMeta>,
     reconnect_issue: Option<WsSnapshotIssue>,
+}
+
+const BOOK_LEVEL_CAPACITY: usize = 5;
+const TRADE_TAPE_CAPACITY: usize = 256;
+const TRADE_TAPE_WINDOW: Duration = Duration::from_secs(5);
+const PUBLIC_TRADE_RAW_SAMPLE_LIMIT: usize = 50;
+
+/// Observation-only book depth and public trades. This deliberately has a
+/// different lock from [`FeedState`]: public trades may arrive much more often
+/// than maker cycles read the mark/touch cache, and telemetry must not contend
+/// with that decision-critical read path.
+pub(super) struct MarketTelemetry {
+    origin: Instant,
+    book: Option<BookObservation>,
+    tape: VecDeque<TradeObservation>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct BookObservation {
+    bid_levels: Vec<(f64, f64)>,
+    ask_levels: Vec<(f64, f64)>,
+    local_recv_ms: u64,
+    received_at: Instant,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct TradeObservation {
+    local_recv_ms: u64,
+    id: u64,
+    price: f64,
+    qty: f64,
+    side: Option<String>,
+    is_taker: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(super) struct BookTelemetrySnapshot {
+    pub(super) bid_levels: Option<Vec<(f64, f64)>>,
+    pub(super) ask_levels: Option<Vec<(f64, f64)>>,
+    pub(super) age_ms: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(super) struct TapeTelemetrySnapshot {
+    pub(super) count_5s: usize,
+    pub(super) buy_qty_5s: f64,
+    pub(super) sell_qty_5s: f64,
+    pub(super) unknown_qty_5s: f64,
+    pub(super) last_trade_age_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(super) struct MarketTelemetrySnapshot {
+    pub(super) book: BookTelemetrySnapshot,
+    pub(super) tape: TapeTelemetrySnapshot,
+}
+
+impl Default for MarketTelemetry {
+    fn default() -> Self {
+        Self::new(Instant::now())
+    }
+}
+
+impl MarketTelemetry {
+    fn new(origin: Instant) -> Self {
+        Self {
+            origin,
+            book: None,
+            tape: VecDeque::with_capacity(TRADE_TAPE_CAPACITY),
+        }
+    }
+
+    fn local_recv_ms(&self, received_at: Instant) -> u64 {
+        duration_millis(received_at.saturating_duration_since(self.origin))
+    }
+
+    fn observe_book(&mut self, book: &OrderBook, received_at: Instant) {
+        self.book = Some(BookObservation {
+            bid_levels: parse_depth_levels(&book.bids, true),
+            ask_levels: parse_depth_levels(&book.asks, false),
+            local_recv_ms: self.local_recv_ms(received_at),
+            received_at,
+        });
+    }
+
+    fn clear(&mut self) {
+        self.book = None;
+        self.tape.clear();
+    }
+
+    fn clear_book(&mut self) {
+        self.book = None;
+    }
+
+    fn observe_trade(&mut self, trade: &Trade, received_at: Instant) {
+        let (Some(price), Some(qty)) = (
+            optional_decimal(&trade.price, Decimal::Positive),
+            optional_decimal(&trade.qty, Decimal::Positive),
+        ) else {
+            return;
+        };
+        let local_recv_ms = self.tape.back().map_or_else(
+            || self.local_recv_ms(received_at),
+            |last| last.local_recv_ms.max(self.local_recv_ms(received_at)),
+        );
+        if self.tape.len() == TRADE_TAPE_CAPACITY {
+            self.tape.pop_front();
+        }
+        self.tape.push_back(TradeObservation {
+            local_recv_ms,
+            id: trade.id,
+            price,
+            qty,
+            side: trade.side.clone(),
+            is_taker: trade.is_buyer_taker,
+        });
+    }
+
+    pub(super) fn snapshot(
+        &self,
+        now: Instant,
+        expected_book_received_at: Option<Instant>,
+    ) -> MarketTelemetrySnapshot {
+        let now_ms = self.local_recv_ms(now);
+        let book = self
+            .book
+            .as_ref()
+            .filter(|book| expected_book_received_at == Some(book.received_at))
+            .map_or_else(BookTelemetrySnapshot::default, |book| {
+                BookTelemetrySnapshot {
+                    bid_levels: (!book.bid_levels.is_empty()).then(|| book.bid_levels.clone()),
+                    ask_levels: (!book.ask_levels.is_empty()).then(|| book.ask_levels.clone()),
+                    age_ms: Some(now_ms.saturating_sub(book.local_recv_ms)),
+                }
+            });
+        let mut tape = TapeTelemetrySnapshot {
+            last_trade_age_ms: self
+                .tape
+                .back()
+                .map(|trade| now_ms.saturating_sub(trade.local_recv_ms)),
+            ..TapeTelemetrySnapshot::default()
+        };
+        let window_ms = duration_millis(TRADE_TAPE_WINDOW);
+        for trade in self
+            .tape
+            .iter()
+            .filter(|trade| now_ms.saturating_sub(trade.local_recv_ms) <= window_ms)
+        {
+            tape.count_5s += 1;
+            match trade.side.as_deref().map(str::trim) {
+                Some(side) if side.eq_ignore_ascii_case("buy") => {
+                    tape.buy_qty_5s += trade.qty;
+                }
+                Some(side) if side.eq_ignore_ascii_case("sell") => {
+                    tape.sell_qty_5s += trade.qty;
+                }
+                _ => {
+                    // `is_buyer_taker` has a serde default. It is retained in
+                    // the tape but never used to invent a missing side.
+                    tape.unknown_qty_5s += trade.qty;
+                }
+            }
+        }
+        MarketTelemetrySnapshot { book, tape }
+    }
+}
+
+fn parse_depth_levels(levels: &[[String; 2]], bids: bool) -> Vec<(f64, f64)> {
+    let mut parsed: Vec<_> = levels
+        .iter()
+        .filter_map(|level| {
+            let price = optional_decimal(&level[0], Decimal::Positive)?;
+            let qty = optional_decimal(&level[1], Decimal::Positive)?;
+            Some((price, qty))
+        })
+        .collect();
+    parsed.sort_by(|left, right| {
+        if bids {
+            right.0.total_cmp(&left.0)
+        } else {
+            left.0.total_cmp(&right.0)
+        }
+    });
+    parsed.truncate(BOOK_LEVEL_CAPACITY);
+    parsed
 }
 
 #[derive(Clone)]
@@ -53,6 +241,10 @@ pub(super) struct AcquiredMarketSnapshot {
     pub(super) source: &'static str,
     pub(super) fallback_reason: Option<&'static str>,
     pub(super) ws_snapshot: Option<WsSnapshotDiagnostics>,
+    /// Exact WS book-cache version used for this acquisition. Observation
+    /// telemetry is rendered only when its independently locked depth copy
+    /// carries this same receive instant.
+    pub(super) book_received_at: Option<Instant>,
 }
 
 /// WS cache entries older than this fall back to REST for the cycle. REST
@@ -135,6 +327,12 @@ impl FeedSnapshotVersion {
 struct ChannelFreshness {
     price: Instant,
     book: Instant,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FreshnessChannel {
+    Price,
+    Book,
 }
 
 impl ChannelFreshness {
@@ -331,22 +529,30 @@ async fn reset_feed_state(state: &RwLock<FeedState>, issue: WsSnapshotIssue) {
 }
 
 /// Spawn the resident market-feed task: one public WS connection carrying
-/// `price` + `depth_book`, written into a shared cache. The outer loop wraps
-/// the SDK's internal 5-attempt reconnect — when the stream ends (attempts
-/// exhausted or clean close), it rebuilds the connection from scratch, since
-/// subscriptions only take effect when registered before `connect_managed()`.
+/// `price` + `depth_book` + observation-only `public_trade`, written into a
+/// decision cache and a separately locked bounded telemetry store. The outer
+/// loop wraps the SDK's internal 5-attempt reconnect — when the stream ends
+/// (attempts exhausted or clean close), it rebuilds the connection from
+/// scratch, since subscriptions only take effect when registered before
+/// `connect_managed()`.
+pub(super) struct SpawnedMarketFeed {
+    pub(super) state: Arc<RwLock<FeedState>>,
+    pub(super) telemetry: Arc<RwLock<MarketTelemetry>>,
+    pub(super) updates: watch::Receiver<u64>,
+    pub(super) handle: tokio::task::JoinHandle<()>,
+}
+
 pub(super) fn spawn_market_feed(
     symbol: String,
     verbose: bool,
     endpoints: standx_sdk::StandXEndpoints,
-) -> (
-    Arc<RwLock<FeedState>>,
-    watch::Receiver<u64>,
-    tokio::task::JoinHandle<()>,
-) {
+) -> SpawnedMarketFeed {
     let state = Arc::new(RwLock::new(FeedState::default()));
+    let telemetry = Arc::new(RwLock::new(MarketTelemetry::default()));
     let (tx, rx) = watch::channel(0u64);
     let state_task = state.clone();
+    let telemetry_task = telemetry.clone();
+    let public_trade_raw_sample_budget = Arc::new(AtomicUsize::new(PUBLIC_TRADE_RAW_SAMPLE_LIMIT));
 
     let handle = tokio::spawn(async move {
         let mut seq = 0u64;
@@ -361,8 +567,10 @@ pub(super) fn spawn_market_feed(
                     continue;
                 }
             };
+            let ws = ws.with_public_trade_raw_sample_budget(public_trade_raw_sample_budget.clone());
             let _ = ws.subscribe("price", Some(&symbol)).await;
             let _ = ws.subscribe("depth_book", Some(&symbol)).await;
+            let _ = ws.subscribe("public_trade", Some(&symbol)).await;
             let (mut events, connection_handle) = match ws.connect_managed().await {
                 Ok(connection) => connection,
                 Err(e) => {
@@ -379,6 +587,7 @@ pub(super) fn spawn_market_feed(
                         let Some(msg) = message else {
                             connection_handle.abort();
                             reset_feed_state(&state_task, WsSnapshotIssue::StreamEnded).await;
+                            telemetry_task.write().await.clear();
                             seq = seq.saturating_add(1);
                             let _ = tx.send(seq);
                             eprintln!("⚠️  market feed stream ended; rebuilding connection in 10s");
@@ -387,6 +596,7 @@ pub(super) fn spawn_market_feed(
                         match &msg {
                             WsMessage::Connected => {
                                 *state_task.write().await = FeedState::default();
+                                telemetry_task.write().await.clear();
                                 freshness = ChannelFreshness::new(Instant::now());
                                 seq = seq.saturating_add(1);
                                 let _ = tx.send(seq);
@@ -394,13 +604,28 @@ pub(super) fn spawn_market_feed(
                             }
                             WsMessage::Disconnected => {
                                 reset_feed_state(&state_task, WsSnapshotIssue::StreamEnded).await;
+                                telemetry_task.write().await.clear();
                                 seq = seq.saturating_add(1);
                                 let _ = tx.send(seq);
                                 continue;
                             }
                             _ => {}
                         }
-                        let accepted = match msg {
+                        match &msg {
+                            WsMessage::Trade(trade)
+                                if trade.symbol.as_deref().map_or(
+                                    true,
+                                    |trade_symbol| trade_symbol.eq_ignore_ascii_case(&symbol),
+                                ) =>
+                            {
+                                telemetry_task
+                                    .write()
+                                    .await
+                                    .observe_trade(trade, Instant::now());
+                            }
+                            _ => {}
+                        }
+                        let accepted = match &msg {
                             WsMessage::Price(update)
                                 if update.data.symbol.eq_ignore_ascii_case(&symbol) =>
                             {
@@ -410,13 +635,13 @@ pub(super) fn spawn_market_feed(
                                 {
                                     {
                                         let mut s = state_task.write().await;
-                                        if update_is_newer(s.mark_meta.as_ref(), &update) {
+                                        if update_is_newer(s.mark_meta.as_ref(), update) {
                                             s.mark = Some(mark);
-                                            s.mark_meta = Some(update_meta(&update));
+                                            s.mark_meta = Some(update_meta(update));
                                             if s.book_meta.is_some() {
                                                 s.reconnect_issue = None;
                                             }
-                                            Some((true, received_at))
+                                            Some((FreshnessChannel::Price, received_at))
                                         } else {
                                             None
                                         }
@@ -435,28 +660,33 @@ pub(super) fn spawn_market_feed(
                                 );
                                 if let (Some(best_bid), Some(best_ask)) = parsed {
                                     let mut s = state_task.write().await;
-                                    if update_is_newer(s.book_meta.as_ref(), &update) {
+                                    if update_is_newer(s.book_meta.as_ref(), update) {
                                         s.best_bid = best_bid;
                                         s.best_ask = best_ask;
-                                        s.book_meta = Some(update_meta(&update));
+                                        s.book_meta = Some(update_meta(update));
                                         if s.mark_meta.is_some() {
                                             s.reconnect_issue = None;
                                         }
-                                        Some((false, received_at))
+                                        drop(s);
+                                        telemetry_task
+                                            .write()
+                                            .await
+                                            .observe_book(&update.data, received_at);
+                                        Some((FreshnessChannel::Book, received_at))
                                     } else {
                                         None
                                     }
                                 } else {
+                                    telemetry_task.write().await.clear_book();
                                     None
                                 }
                             }
                             _ => None,
                         };
-                        if let Some((price, received_at)) = accepted {
-                            if price {
-                                freshness.price = received_at;
-                            } else {
-                                freshness.book = received_at;
+                        if let Some((channel, received_at)) = accepted {
+                            match channel {
+                                FreshnessChannel::Price => freshness.price = received_at,
+                                FreshnessChannel::Book => freshness.book = received_at,
                             }
                             seq = seq.saturating_add(1);
                             let _ = tx.send(seq);
@@ -469,6 +699,7 @@ pub(super) fn spawn_market_feed(
                         };
                         connection_handle.abort();
                         reset_feed_state(&state_task, issue).await;
+                        telemetry_task.write().await.clear();
                         seq = seq.saturating_add(1);
                         let _ = tx.send(seq);
                         eprintln!(
@@ -483,7 +714,12 @@ pub(super) fn spawn_market_feed(
         }
     });
 
-    (state, rx, handle)
+    SpawnedMarketFeed {
+        state,
+        telemetry,
+        updates: rx,
+        handle,
+    }
 }
 
 /// One market snapshot: WS cache when fresh, REST fallback otherwise
@@ -508,6 +744,7 @@ pub(super) async fn market_snapshot(
                     source: "ws",
                     fallback_reason: None,
                     ws_snapshot,
+                    book_received_at: s.book_meta.as_ref().map(|meta| meta.received_at),
                 });
             }
             Err(issue) => {
@@ -536,6 +773,7 @@ pub(super) async fn market_snapshot(
             source,
             fallback_reason: ws_issue,
             ws_snapshot,
+            book_received_at: None,
         },
     )
 }
@@ -628,6 +866,204 @@ mod tests {
         for value in ["0", "-1", "NaN", "not-a-price"] {
             assert_eq!(parse_optional_positive_price(Some(value)), None);
         }
+    }
+
+    #[test]
+    fn depth_telemetry_is_sorted_bounded_and_does_not_replace_touch_derivation() {
+        let book = OrderBook {
+            symbol: "BTC-USD".to_string(),
+            bids: vec![
+                ["101".to_string(), "NaN".to_string()],
+                ["99".to_string(), "1".to_string()],
+                ["100".to_string(), "2".to_string()],
+                ["98".to_string(), "3".to_string()],
+                ["97".to_string(), "4".to_string()],
+                ["96".to_string(), "5".to_string()],
+                ["95".to_string(), "6".to_string()],
+            ],
+            asks: vec![
+                ["102".to_string(), "bad".to_string()],
+                ["104".to_string(), "1".to_string()],
+                ["103".to_string(), "2".to_string()],
+                ["105".to_string(), "3".to_string()],
+                ["106".to_string(), "4".to_string()],
+                ["107".to_string(), "5".to_string()],
+                ["108".to_string(), "6".to_string()],
+            ],
+            timestamp: String::new(),
+        };
+
+        // Existing touch derivation considers only price validity. Telemetry
+        // additionally requires valid quantity and must never replace it.
+        assert_eq!(book.best_bid(), Some("101"));
+        assert_eq!(book.best_ask(), Some("102"));
+        assert_eq!(
+            parse_depth_levels(&book.bids, true),
+            vec![
+                (100.0, 2.0),
+                (99.0, 1.0),
+                (98.0, 3.0),
+                (97.0, 4.0),
+                (96.0, 5.0)
+            ]
+        );
+        assert_eq!(
+            parse_depth_levels(&book.asks, false),
+            vec![
+                (103.0, 2.0),
+                (104.0, 1.0),
+                (105.0, 3.0),
+                (106.0, 4.0),
+                (107.0, 5.0)
+            ]
+        );
+
+        let malformed = vec![
+            ["NaN".to_string(), "1".to_string()],
+            ["100".to_string(), "0".to_string()],
+            ["bad".to_string(), "bad".to_string()],
+        ];
+        assert!(parse_depth_levels(&malformed, true).is_empty());
+    }
+
+    #[test]
+    fn depth_telemetry_is_null_unless_it_matches_the_acquired_book_version() {
+        let origin = Instant::now();
+        let acquired_at = origin + Duration::from_millis(10);
+        let later_update_at = origin + Duration::from_millis(20);
+        let book = OrderBook {
+            symbol: "BTC-USD".to_string(),
+            bids: vec![["99.9".to_string(), "2.0".to_string()]],
+            asks: vec![["100.1".to_string(), "3.0".to_string()]],
+            timestamp: String::new(),
+        };
+        let mut telemetry = MarketTelemetry::new(origin);
+        telemetry.observe_book(&book, later_update_at);
+
+        let mismatched = telemetry.snapshot(later_update_at, Some(acquired_at));
+        assert_eq!(mismatched.book, BookTelemetrySnapshot::default());
+
+        let matched = telemetry.snapshot(later_update_at, Some(later_update_at));
+        assert_eq!(matched.book.bid_levels, Some(vec![(99.9, 2.0)]));
+        assert_eq!(matched.book.ask_levels, Some(vec![(100.1, 3.0)]));
+        assert_eq!(matched.book.age_ms, Some(0));
+    }
+
+    #[test]
+    fn public_trade_absence_or_activity_does_not_affect_feed_freshness_or_version() {
+        let now = Instant::now();
+        let state = FeedState {
+            mark: Some(100.0),
+            mark_meta: Some(meta(1, "2026-07-14T00:00:00Z", now)),
+            best_bid: Some(99.9),
+            best_ask: Some(100.1),
+            book_meta: Some(meta(2, "2026-07-14T00:00:00Z", now)),
+            reconnect_issue: None,
+        };
+        let freshness = ChannelFreshness::new(now);
+        let version = FeedSnapshotVersion {
+            mark_received_at: state.mark_meta.as_ref().unwrap().received_at,
+            book_received_at: state.book_meta.as_ref().unwrap().received_at,
+        };
+        let mut telemetry = MarketTelemetry::new(now);
+
+        assert_eq!(telemetry.snapshot(now, None).tape.count_5s, 0);
+        assert_eq!(
+            freshness.idle_issue(now + MARKET_FEED_IDLE_AFTER - Duration::from_millis(1)),
+            None
+        );
+        let mut price_and_book_only = ChannelFreshness::new(now);
+        for seconds in [10, 20, 30] {
+            let received_at = now + Duration::from_secs(seconds);
+            price_and_book_only.price = received_at;
+            price_and_book_only.book = received_at;
+            assert_eq!(
+                price_and_book_only
+                    .idle_issue(received_at + MARKET_FEED_IDLE_AFTER - Duration::from_millis(1)),
+                None
+            );
+        }
+        assert!(coherent_ws_snapshot(&state, now + Duration::from_secs(3)).is_ok());
+
+        let trade: Trade = serde_json::from_value(serde_json::json!({
+            "id": 7,
+            "price": "100.0",
+            "qty": "1.5",
+            "side": "buy",
+            "is_taker": true
+        }))
+        .unwrap();
+        telemetry.observe_trade(&trade, now + Duration::from_millis(10));
+
+        assert_eq!(
+            telemetry
+                .snapshot(now + Duration::from_millis(10), None)
+                .tape
+                .count_5s,
+            1
+        );
+        assert_eq!(
+            version,
+            FeedSnapshotVersion {
+                mark_received_at: state.mark_meta.as_ref().unwrap().received_at,
+                book_received_at: state.book_meta.as_ref().unwrap().received_at,
+            }
+        );
+        assert_eq!(
+            freshness.idle_issue(now + MARKET_FEED_IDLE_AFTER),
+            Some(WsSnapshotIssue::PriceAndBookIdle)
+        );
+    }
+
+    #[test]
+    fn trade_without_side_stays_unknown_instead_of_using_defaulted_taker_flag() {
+        let now = Instant::now();
+        let trade: Trade = serde_json::from_value(serde_json::json!({
+            "id": 8,
+            "price": "100.0",
+            "qty": "2.5"
+        }))
+        .unwrap();
+        assert_eq!(trade.side, None);
+        assert!(!trade.is_buyer_taker);
+
+        let mut telemetry = MarketTelemetry::new(now);
+        telemetry.observe_trade(&trade, now);
+        let snapshot = telemetry.snapshot(now, None);
+
+        assert_eq!(telemetry.tape.back().unwrap().side, None);
+        assert_eq!(snapshot.tape.buy_qty_5s, 0.0);
+        assert_eq!(snapshot.tape.sell_qty_5s, 0.0);
+        assert_eq!(snapshot.tape.unknown_qty_5s, 2.5);
+    }
+
+    #[test]
+    fn trade_tape_evicts_oldest_entries_at_fixed_capacity() {
+        let now = Instant::now();
+        let mut telemetry = MarketTelemetry::new(now);
+        for id in 0..300u64 {
+            let trade = Trade {
+                id,
+                time: String::new(),
+                price: "100.0".to_string(),
+                qty: "1.0".to_string(),
+                side: Some("sell".to_string()),
+                is_buyer_taker: id % 2 == 0,
+                fee_asset: None,
+                fee_qty: None,
+                pnl: None,
+                order_id: None,
+                symbol: Some("BTC-USD".to_string()),
+                value: None,
+            };
+            telemetry.observe_trade(&trade, now + Duration::from_millis(id));
+        }
+
+        assert_eq!(telemetry.tape.len(), TRADE_TAPE_CAPACITY);
+        let first = telemetry.tape.front().unwrap();
+        let last = telemetry.tape.back().unwrap();
+        assert_eq!((first.id, first.price, first.is_taker), (44, 100.0, true));
+        assert_eq!((last.id, last.price, last.is_taker), (299, 100.0, false));
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/output.rs
+++ b/crates/standx-cli/src/commands/maker/output.rs
@@ -1,4 +1,4 @@
-use super::feed::WsSnapshotDiagnostics;
+use super::feed::{MarketTelemetrySnapshot, WsSnapshotDiagnostics};
 use super::model::{optional_decimal, Decimal};
 use super::*;
 use standx_maker::{self as maker, Action, MakerConfig, MakerStats};
@@ -237,6 +237,8 @@ pub(super) struct CycleOutput<'a> {
     pub(super) market_source: &'static str,
     pub(super) market_fallback_reason: Option<&'static str>,
     pub(super) ws_snapshot: Option<&'a WsSnapshotDiagnostics>,
+    pub(super) market_telemetry: &'a MarketTelemetrySnapshot,
+    pub(super) quote_geometry: &'a [maker::QuoteGeometry],
     pub(super) position: f64,
     pub(super) starting_position: f64,
     pub(super) account: Option<&'a Balance>,
@@ -276,6 +278,8 @@ pub(super) fn emit_maker_cycle(output: CycleOutput<'_>) {
         market_source,
         market_fallback_reason,
         ws_snapshot,
+        market_telemetry,
+        quote_geometry,
         position,
         starting_position,
         account,
@@ -378,42 +382,52 @@ pub(super) fn emit_maker_cycle(output: CycleOutput<'_>) {
             }
             println!(
                 "{}",
-                with_exit_fields(
-                    with_guard_fields(
-                        with_size_skew_fields(
-                            with_spread_fields(
-                                serde_json::json!({
-                                    "ts": ts, "cycle": cycle, "mode": mode, "symbol": symbol,
-                                    "action": "cycle_summary",
-                                    "mark": format_decimals(mark, cfg.price_decimals),
-                                    "best_bid": best_bid, "best_ask": best_ask,
-                                    "market_source": market_source,
-                                    "market_fallback_reason": market_fallback_reason,
-                                    "ws_snapshot": ws_snapshot.map(ws_snapshot_json),
-                                    "position": position,
-                                    "starting_position": starting_position,
-                                    "account": account.map(account_json),
-                                    "holds": holds, "places": places, "cancels": cancels,
-                                    "fills": fills.len(),
-                                    "pnl": (pnl * 1e6).round() / 1e6,
-                                    "fills_total": stats.fills(),
-                                    "uptime_pct": (stats.uptime_pct() * 10.0).round() / 10.0,
-                                    "avg_capture_bps": (stats.avg_spread_capture_bps() * 100.0).round() / 100.0,
-                                    "performance": performance.map(performance_json),
-                                    "halted": halt_vol_bps.is_some(),
-                                    "vol_bps": halt_vol_bps.map(|v| (v * 100.0).round() / 100.0),
-                                }),
-                                spread_decision,
+                with_geometry_fields(
+                    with_book_fields(
+                        with_exit_fields(
+                            with_guard_fields(
+                                with_size_skew_fields(
+                                    with_spread_fields(
+                                        serde_json::json!({
+                                        "ts": ts, "cycle": cycle, "mode": mode, "symbol": symbol,
+                                        "action": "cycle_summary",
+                                        "mark": format_decimals(mark, cfg.price_decimals),
+                                        "best_bid": best_bid, "best_ask": best_ask,
+                                        "market_source": market_source,
+                                        "market_fallback_reason": market_fallback_reason,
+                                        "ws_snapshot": ws_snapshot.map(ws_snapshot_json),
+                                        "position": position,
+                                        "starting_position": starting_position,
+                                        "account": account.map(account_json),
+                                        "holds": holds, "places": places, "cancels": cancels,
+                                        "fills": fills.len(),
+                                        "pnl": (pnl * 1e6).round() / 1e6,
+                                        "fills_total": stats.fills(),
+                                        "uptime_pct": (stats.uptime_pct() * 10.0).round() / 10.0,
+                                        "avg_capture_bps": (stats.avg_spread_capture_bps() * 100.0).round() / 100.0,
+                                        "performance": performance.map(performance_json),
+                                        "halted": halt_vol_bps.is_some(),
+                                        "vol_bps": halt_vol_bps.map(|v| (v * 100.0).round() / 100.0),
+                                            }),
+                                        spread_decision,
+                                    ),
+                                    size_skew_decision,
+                                ),
+                                guard_decision,
+                                external_basis_bps,
+                                external_skew_shift_bps,
+                                micro_price_shift_bps,
+                                skew_shift_bps,
                             ),
-                            size_skew_decision,
+                            exit_status,
                         ),
-                        guard_decision,
-                        external_basis_bps,
-                        external_skew_shift_bps,
-                        micro_price_shift_bps,
-                        skew_shift_bps,
+                        market_telemetry,
+                        mark,
+                        best_bid,
+                        best_ask,
                     ),
-                    exit_status,
+                    quote_geometry,
+                    mark,
                 )
             );
         }
@@ -544,6 +558,123 @@ pub(super) fn emit_maker_cycle(output: CycleOutput<'_>) {
             }
         }
     }
+}
+
+/// Additive Part-A fields. The bounded source snapshot is observation-only;
+/// calculations here cannot feed back into planning, guards, or reconciliation.
+fn with_book_fields(
+    mut summary: serde_json::Value,
+    telemetry: &MarketTelemetrySnapshot,
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+) -> serde_json::Value {
+    let bid_qty_top = telemetry
+        .book
+        .bid_levels
+        .as_ref()
+        .and_then(|levels| levels.first())
+        .filter(|(price, _)| best_bid == Some(*price))
+        .map(|(_, qty)| *qty);
+    let ask_qty_top = telemetry
+        .book
+        .ask_levels
+        .as_ref()
+        .and_then(|levels| levels.first())
+        .filter(|(price, _)| best_ask == Some(*price))
+        .map(|(_, qty)| *qty);
+    let spread_bps = best_bid
+        .zip(best_ask)
+        .filter(|_| mark.is_finite() && mark > 0.0)
+        .and_then(|(bid, ask)| {
+            let spread = (ask - bid) / mark * 1e4;
+            spread.is_finite().then_some(spread)
+        });
+    let mark_mid_divergence_bps = best_bid
+        .zip(best_ask)
+        .filter(|_| mark.is_finite() && mark > 0.0)
+        .and_then(|(bid, ask)| {
+            let divergence = maker::mark_mid_divergence_bps(mark, bid, ask);
+            divergence.is_finite().then_some(divergence)
+        });
+    let object = summary
+        .as_object_mut()
+        .expect("cycle summary JSON must be an object");
+    object.insert(
+        "book".to_string(),
+        serde_json::json!({
+            "bid_levels": telemetry.book.bid_levels,
+            "ask_levels": telemetry.book.ask_levels,
+            "bid_qty_top": bid_qty_top,
+            "ask_qty_top": ask_qty_top,
+            "spread_bps": spread_bps,
+            "mark_mid_divergence_bps": mark_mid_divergence_bps,
+            "age_ms": telemetry.book.age_ms,
+        }),
+    );
+    object.insert(
+        "tape".to_string(),
+        serde_json::json!({
+            "count_5s": telemetry.tape.count_5s,
+            "buy_qty_5s": telemetry.tape.buy_qty_5s,
+            "sell_qty_5s": telemetry.tape.sell_qty_5s,
+            "unknown_qty_5s": telemetry.tape.unknown_qty_5s,
+            "last_trade_age_ms": telemetry.tape.last_trade_age_ms,
+        }),
+    );
+    summary
+}
+
+/// Additive Part-B quote-geometry diagnostics. These values are produced by
+/// the pure planner and are never fed back into quote or safety decisions.
+fn with_geometry_fields(
+    mut summary: serde_json::Value,
+    geometry: &[maker::QuoteGeometry],
+    mark: f64,
+) -> serde_json::Value {
+    let min_distance_to_touch_bps = geometry
+        .iter()
+        .filter_map(|quote| quote.distance_to_touch_bps)
+        .filter(|distance| distance.is_finite())
+        .reduce(f64::min);
+    let count = |outcome| {
+        geometry
+            .iter()
+            .filter(|quote| quote.outcome == outcome)
+            .count()
+    };
+    let quotes: Vec<_> = geometry
+        .iter()
+        .map(|quote| {
+            let raw_bps = maker::side_distance_to_mark_bps(quote.side, quote.raw_price, mark);
+            let final_bps = quote
+                .final_price
+                .map(|price| maker::side_distance_to_mark_bps(quote.side, price, mark));
+            serde_json::json!({
+                "side": quote.side,
+                "level": quote.level,
+                "outcome": quote.outcome.as_str(),
+                "raw_bps": raw_bps,
+                "final_bps": final_bps,
+                "dist_touch_bps": quote.distance_to_touch_bps,
+                "band_edge_bps": quote.band_edge_bps,
+            })
+        })
+        .collect();
+    let object = summary
+        .as_object_mut()
+        .expect("cycle summary JSON must be an object");
+    object.insert(
+        "geometry".to_string(),
+        serde_json::json!({
+            "min_distance_to_touch_bps": min_distance_to_touch_bps,
+            "clamped_to_touch": count(maker::QuoteGeometryOutcome::ClampedToTouch),
+            "clamped_to_band": count(maker::QuoteGeometryOutcome::ClampedToBand),
+            "dropped_infeasible": count(maker::QuoteGeometryOutcome::DroppedInfeasible),
+            "quotes": quotes,
+        }),
+    );
+    summary
 }
 
 /// Stage 5-b exit fields, additive and top-level like the other wrappers.
@@ -1543,6 +1674,149 @@ mod tests {
         assert_eq!(json["adaptive_spread_tier"], 2);
         assert_eq!(json["effective_spread_bps"], 18.0);
         assert_eq!(json["effective_refresh_bps"], 6.0);
+    }
+
+    #[test]
+    fn cycle_summary_book_and_tape_fields_are_additive_and_top_level() {
+        let base = serde_json::json!({
+            "action": "cycle_summary",
+            "vol_bps": null,
+            "best_bid": 99.9,
+            "best_ask": 100.1,
+        });
+        let original = base.clone();
+        let telemetry = MarketTelemetrySnapshot {
+            book: super::super::feed::BookTelemetrySnapshot {
+                bid_levels: Some(vec![(99.9, 2.0), (99.8, 3.0)]),
+                ask_levels: Some(vec![(100.1, 4.0), (100.2, 5.0)]),
+                age_ms: Some(125),
+            },
+            tape: super::super::feed::TapeTelemetrySnapshot {
+                count_5s: 3,
+                buy_qty_5s: 1.25,
+                sell_qty_5s: 2.5,
+                unknown_qty_5s: 0.75,
+                last_trade_age_ms: Some(50),
+            },
+        };
+
+        let json = with_book_fields(base, &telemetry, 100.0, Some(99.9), Some(100.1));
+
+        for (key, value) in original.as_object().unwrap() {
+            assert_eq!(&json[key], value, "existing field changed: {key}");
+        }
+        assert_eq!(
+            json.as_object().unwrap().len(),
+            original.as_object().unwrap().len() + 2
+        );
+        assert_eq!(
+            json["book"]["bid_levels"][0],
+            serde_json::json!([99.9, 2.0])
+        );
+        assert_eq!(
+            json["book"]["ask_levels"][0],
+            serde_json::json!([100.1, 4.0])
+        );
+        assert_eq!(json["book"]["bid_qty_top"], 2.0);
+        assert_eq!(json["book"]["ask_qty_top"], 4.0);
+        assert!((json["book"]["spread_bps"].as_f64().unwrap() - 20.0).abs() < 1e-9);
+        assert_eq!(json["book"]["mark_mid_divergence_bps"], 0.0);
+        assert_eq!(json["book"]["age_ms"], 125);
+        assert_eq!(json["tape"]["count_5s"], 3);
+        assert_eq!(json["tape"]["buy_qty_5s"], 1.25);
+        assert_eq!(json["tape"]["sell_qty_5s"], 2.5);
+        assert_eq!(json["tape"]["unknown_qty_5s"], 0.75);
+        assert_eq!(json["tape"]["last_trade_age_ms"], 50);
+        assert!(json.get("bid_levels").is_none());
+        assert!(json.get("count_5s").is_none());
+    }
+
+    #[test]
+    fn cycle_summary_book_and_tape_observation_gaps_are_null_or_zero() {
+        let json = with_book_fields(
+            serde_json::json!({"action": "cycle_summary"}),
+            &MarketTelemetrySnapshot::default(),
+            100.0,
+            None,
+            None,
+        );
+
+        assert!(json["book"]["bid_levels"].is_null());
+        assert!(json["book"]["ask_levels"].is_null());
+        assert!(json["book"]["bid_qty_top"].is_null());
+        assert!(json["book"]["ask_qty_top"].is_null());
+        assert!(json["book"]["spread_bps"].is_null());
+        assert!(json["book"]["mark_mid_divergence_bps"].is_null());
+        assert!(json["book"]["age_ms"].is_null());
+        assert_eq!(json["tape"]["count_5s"], 0);
+        assert_eq!(json["tape"]["unknown_qty_5s"], 0.0);
+        assert!(json["tape"]["last_trade_age_ms"].is_null());
+    }
+
+    #[test]
+    fn cycle_summary_geometry_fields_are_additive_and_top_level() {
+        let base = serde_json::json!({
+            "action": "cycle_summary",
+            "places": 1,
+            "best_ask": 100.0,
+        });
+        let original = base.clone();
+        let geometry = vec![
+            maker::QuoteGeometry {
+                side: OrderSide::Buy,
+                level: 0,
+                raw_price: 99.9,
+                final_price: Some(99.99),
+                outcome: maker::QuoteGeometryOutcome::ClampedToTouch,
+                distance_to_touch_bps: Some(1.0),
+                band_edge_bps: 20.0,
+            },
+            maker::QuoteGeometry {
+                side: OrderSide::Sell,
+                level: 0,
+                raw_price: 100.3,
+                final_price: Some(100.2),
+                outcome: maker::QuoteGeometryOutcome::ClampedToBand,
+                distance_to_touch_bps: Some(21.0),
+                band_edge_bps: 20.0,
+            },
+            maker::QuoteGeometry {
+                side: OrderSide::Buy,
+                level: 1,
+                raw_price: 99.8,
+                final_price: None,
+                outcome: maker::QuoteGeometryOutcome::DroppedInfeasible,
+                distance_to_touch_bps: None,
+                band_edge_bps: 20.0,
+            },
+        ];
+
+        let json = with_geometry_fields(base, &geometry, 100.0);
+
+        for (key, value) in original.as_object().unwrap() {
+            assert_eq!(&json[key], value, "existing field changed: {key}");
+        }
+        assert_eq!(
+            json.as_object().unwrap().len(),
+            original.as_object().unwrap().len() + 1
+        );
+        assert_eq!(json["geometry"]["min_distance_to_touch_bps"], 1.0);
+        assert_eq!(json["geometry"]["clamped_to_touch"], 1);
+        assert_eq!(json["geometry"]["clamped_to_band"], 1);
+        assert_eq!(json["geometry"]["dropped_infeasible"], 1);
+        assert_eq!(json["geometry"]["quotes"].as_array().unwrap().len(), 3);
+        assert_eq!(json["geometry"]["quotes"][0]["side"], "buy");
+        assert_eq!(json["geometry"]["quotes"][0]["outcome"], "clamped_to_touch");
+        assert!((json["geometry"]["quotes"][0]["raw_bps"].as_f64().unwrap() - 10.0).abs() < 1e-9);
+        assert!((json["geometry"]["quotes"][0]["final_bps"].as_f64().unwrap() - 1.0).abs() < 1e-9);
+        assert_eq!(json["geometry"]["quotes"][0]["dist_touch_bps"], 1.0);
+        assert_eq!(json["geometry"]["quotes"][0]["band_edge_bps"], 20.0);
+        // Dropped slots still carry the band edge; only the fill-risk distance
+        // is unknowable without a resting price.
+        assert_eq!(json["geometry"]["quotes"][2]["band_edge_bps"], 20.0);
+        assert!(json["geometry"]["quotes"][2]["dist_touch_bps"].is_null());
+        assert!(json.get("clamped_to_touch").is_none());
+        assert!(json.get("quotes").is_none());
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/pipeline.rs
+++ b/crates/standx-cli/src/commands/maker/pipeline.rs
@@ -1,4 +1,4 @@
-use super::feed::WsSnapshotDiagnostics;
+use super::feed::{MarketTelemetrySnapshot, WsSnapshotDiagnostics};
 use super::{ORDER_HISTORY_LIMIT, TRADE_LOOKBACK_LIMIT};
 use crate::cli::OutputFormat;
 use anyhow::Result;
@@ -140,6 +140,9 @@ pub(super) struct CycleRequest<'a> {
     /// Observation-only metadata from the public WS cache. This never feeds
     /// strategy, safety, or source-selection decisions.
     pub(super) ws_snapshot: Option<&'a WsSnapshotDiagnostics>,
+    /// Observation-only bounded book/tape snapshot. It is consumed solely by
+    /// cycle-summary rendering and never by maker planning or safety logic.
+    pub(super) market_telemetry: &'a MarketTelemetrySnapshot,
     pub(super) max_divergence_bps: f64,
     pub(super) inventory_exit_pct: f64,
     pub(super) inventory_exit_qty: f64,

--- a/crates/standx-cli/src/commands/maker/replay.rs
+++ b/crates/standx-cli/src/commands/maker/replay.rs
@@ -3,6 +3,8 @@
 use crate::cli::OutputFormat;
 use anyhow::{Context, Result};
 use serde::Deserialize;
+#[cfg(test)]
+use standx_maker::DesiredQuote;
 use standx_maker::{
     run_replay, Action, AdaptiveSpreadConfig, ExecutionCosts, FillRole, MakerConfig,
     MarketSnapshot, PerformanceFill, ReplayCycle, ReplayEvent, ReplayResult, ReplaySettings,
@@ -601,6 +603,65 @@ mod tests {
         assert_eq!(first, second);
         assert_eq!(first.cycles.len(), 2);
         assert_eq!(first.performance.passive_fills, 1);
+        assert_eq!(
+            first.cycles[0].plan.as_ref().unwrap().actions,
+            vec![
+                Action::Place(DesiredQuote {
+                    side: OrderSide::Buy,
+                    level: 0,
+                    price: 99.95,
+                    qty: 1.0,
+                }),
+                Action::Place(DesiredQuote {
+                    side: OrderSide::Sell,
+                    level: 0,
+                    price: 100.05,
+                    qty: 1.0,
+                }),
+            ]
+        );
+        assert_eq!(
+            first.cycles[1].plan.as_ref().unwrap().actions,
+            vec![
+                Action::Place(DesiredQuote {
+                    side: OrderSide::Buy,
+                    level: 0,
+                    price: 100.04,
+                    qty: 1.0,
+                }),
+                Action::Place(DesiredQuote {
+                    side: OrderSide::Sell,
+                    level: 0,
+                    price: 100.16,
+                    qty: 1.0,
+                }),
+            ]
+        );
+        assert!(first.cycles.iter().all(|cycle| {
+            cycle
+                .plan
+                .as_ref()
+                .is_some_and(|plan| plan.quote_geometry.len() == 2)
+        }));
+        // The expected bytes below are pinned literals that predate the
+        // observation-only `quote_geometry` field. Asserting against them is
+        // what proves geometry did not perturb the action sequence; comparing
+        // a geometry-cleared clone against itself would prove nothing.
+        let action_bytes: Vec<Vec<u8>> = first
+            .cycles
+            .iter()
+            .flat_map(|cycle| cycle.plan.as_ref().unwrap().actions.iter())
+            .map(|action| serde_json::to_vec(&action_json(action)).unwrap())
+            .collect();
+        assert_eq!(
+            action_bytes,
+            vec![
+                br#"{"kind":"place","level":0,"price":99.95,"qty":1.0,"side":"buy"}"#.to_vec(),
+                br#"{"kind":"place","level":0,"price":100.05,"qty":1.0,"side":"sell"}"#.to_vec(),
+                br#"{"kind":"place","level":0,"price":100.04,"qty":1.0,"side":"buy"}"#.to_vec(),
+                br#"{"kind":"place","level":0,"price":100.16,"qty":1.0,"side":"sell"}"#.to_vec(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/cycle_flow.rs
@@ -94,6 +94,7 @@ impl MakerRuntime {
         let performance_epoch_ms = self.loop_state.performance_epoch_ms;
         let market_data_health_started = self.market.health_started;
         let feed = &self.market.feed;
+        let market_telemetry = &self.market.telemetry;
         let exit = 'execute: {
             // Work phase raced against Ctrl+C so a slow API call can be
             // interrupted (mirrors run_watch_loop).
@@ -211,6 +212,13 @@ impl MakerRuntime {
                 } else {
                     maker::MarketDataMode::Active
                 };
+                let market_telemetry_snapshot = match market_telemetry.as_ref() {
+                    Some(telemetry) => telemetry
+                        .read()
+                        .await
+                        .snapshot(std::time::Instant::now(), market.book_received_at),
+                    None => super::super::feed::MarketTelemetrySnapshot::default(),
+                };
                 // Normalize the leader feed against THIS cycle's mark. A
                 // missing/stale sample yields None and the guard fails open.
                 let cycle_external_divergence = match self.loop_state.external_feed.as_ref() {
@@ -246,6 +254,7 @@ impl MakerRuntime {
                         recovery: recovery_cycle,
                         market_fallback_reason,
                         ws_snapshot: market.ws_snapshot.as_ref(),
+                        market_telemetry: &market_telemetry_snapshot,
                         max_divergence_bps: args.max_divergence_bps,
                         inventory_exit_pct: args.inventory_exit_pct,
                         inventory_exit_qty: args.inventory_exit_qty,

--- a/crates/standx-cli/src/commands/maker/runtime/state.rs
+++ b/crates/standx-cli/src/commands/maker/runtime/state.rs
@@ -1,4 +1,4 @@
-use super::super::feed::FeedState;
+use super::super::feed::{FeedState, MarketTelemetry};
 use super::*;
 
 pub(super) struct RuntimeDeps {
@@ -70,6 +70,9 @@ pub(super) struct RuntimeLoopState {
 
 pub(super) struct RuntimeMarketState {
     pub(super) feed: Option<std::sync::Arc<tokio::sync::RwLock<FeedState>>>,
+    /// Bounded, observation-only book/tape state on a lock separate from the
+    /// decision-critical mark/touch cache.
+    pub(super) telemetry: Option<std::sync::Arc<tokio::sync::RwLock<MarketTelemetry>>>,
     pub(super) updates: Option<tokio::sync::watch::Receiver<u64>>,
     pub(super) market_watchdog_updates: Option<tokio::sync::watch::Receiver<u64>>,
     pub(super) feed_handle: Option<tokio::task::JoinHandle<()>>,
@@ -134,12 +137,16 @@ impl MakerRuntime {
             live_session,
         } = startup;
 
-        let (feed, updates, feed_handle) = if args.no_ws {
-            (None, None, None)
+        let (feed, telemetry, updates, feed_handle) = if args.no_ws {
+            (None, None, None, None)
         } else {
-            let (state, rx, handle) =
-                spawn_market_feed(symbol.clone(), args.verbose, endpoints.clone());
-            (Some(state), Some(rx), Some(handle))
+            let spawned = spawn_market_feed(symbol.clone(), args.verbose, endpoints.clone());
+            (
+                Some(spawned.state),
+                Some(spawned.telemetry),
+                Some(spawned.updates),
+                Some(spawned.handle),
+            )
         };
         let market_watchdog_updates = updates.as_ref().cloned();
 
@@ -308,6 +315,7 @@ impl MakerRuntime {
             },
             market: RuntimeMarketState {
                 feed,
+                telemetry,
                 updates,
                 market_watchdog_updates,
                 feed_handle,

--- a/crates/standx-maker/src/lib.rs
+++ b/crates/standx-maker/src/lib.rs
@@ -142,6 +142,56 @@ pub struct DesiredQuote {
     pub qty: f64,
 }
 
+/// Observation-only result of constructing one configured quote-ladder slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuoteGeometryOutcome {
+    Placed,
+    ClampedToBand,
+    ClampedToTouch,
+    DroppedInfeasible,
+    DroppedBelowMinQty,
+    DroppedDuplicate,
+    SuppressedPosition,
+    SuppressedGuard,
+}
+
+impl QuoteGeometryOutcome {
+    /// Stable snake-case label used by cycle-summary telemetry.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Placed => "placed",
+            Self::ClampedToBand => "clamped_to_band",
+            Self::ClampedToTouch => "clamped_to_touch",
+            Self::DroppedInfeasible => "dropped_infeasible",
+            Self::DroppedBelowMinQty => "dropped_below_min_qty",
+            Self::DroppedDuplicate => "dropped_duplicate",
+            Self::SuppressedPosition => "suppressed_position",
+            Self::SuppressedGuard => "suppressed_guard",
+        }
+    }
+}
+
+/// Observation-only geometry for one configured quote slot.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuoteGeometry {
+    pub side: OrderSide,
+    pub level: u32,
+    /// Ladder price before the eligibility-band and post-only clamps.
+    pub raw_price: f64,
+    /// Price after clamp and directional tick rounding; `None` when dropped.
+    pub final_price: Option<f64>,
+    pub outcome: QuoteGeometryOutcome,
+    /// Distance from the same-side opposing touch, in bps of mark: buys use
+    /// `(best_ask - price) / mark * 1e4`, sells use
+    /// `(price - best_bid) / mark * 1e4`; `None` when that side of the touch
+    /// is missing.
+    pub distance_to_touch_bps: Option<f64>,
+    /// Side-aware distance from mark to this side's eligibility-band edge, in
+    /// bps of mark. Emitted so offline analysis can tell at a glance whether
+    /// the band or the touch was the binding bound.
+    pub band_edge_bps: f64,
+}
+
 /// Which policy asked for an inventory-reducing order.
 ///
 /// Stage 5-b separates the two normal exit policies so evidence never has to
@@ -660,6 +710,8 @@ pub struct CyclePlan {
     /// In-venue touch-mid component actually applied to the shared quote center
     /// this cycle (0 when disabled or inside the dead zone).
     pub micro_price_shift_bps: f64,
+    /// Observation-only quote-ladder geometry. Planning never reads this field.
+    pub quote_geometry: Vec<QuoteGeometry>,
 }
 
 /// Build a deterministic quote/exit plan after the caller has synchronized
@@ -732,39 +784,54 @@ pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> Cyc
     });
     // Wind-down never places new quotes, even once flat: the session must
     // converge to flat instead of re-accumulating inventory.
-    let desired = if halted || !market_active || inventory_exit.is_some() || input.wind_down {
-        Vec::new()
-    } else {
-        let raw = compute_desired_quotes(
-            cfg,
-            input.market.mark,
-            input.market.best_bid,
-            input.market.best_ask,
-            input.position,
-            input.size_skew,
-            input.nonlinear_skew,
-            total_shift_bps,
-            input.guard,
-        );
-        cap_desired_exposure(cfg, input.position, &raw, input.pending_slots)
-    };
+    let (desired, mut quote_geometry) =
+        if halted || !market_active || inventory_exit.is_some() || input.wind_down {
+            (Vec::new(), Vec::new())
+        } else {
+            let mut generated = compute_desired_quotes_with_geometry(
+                cfg,
+                input.market.mark,
+                input.market.best_bid,
+                input.market.best_ask,
+                input.position,
+                input.size_skew,
+                input.nonlinear_skew,
+                total_shift_bps,
+                input.guard,
+            );
+            let capped =
+                cap_desired_exposure(cfg, input.position, &generated.quotes, input.pending_slots);
+            mark_exposure_suppressed(&mut generated.geometry, &capped);
+            (capped, generated.geometry)
+        };
+
+    let actions = reconcile(
+        cfg,
+        input.market.mark,
+        input.position,
+        input.market.best_bid,
+        input.market.best_ask,
+        &desired,
+        input.resting,
+        input.cycle,
+        input.nonlinear_skew,
+        total_shift_bps,
+    );
+    overlay_resting_quote_geometry(
+        &mut quote_geometry,
+        input.resting,
+        &actions,
+        input.market.mark,
+        input.market.best_bid,
+        input.market.best_ask,
+        cfg.band_bps,
+    );
 
     CyclePlan {
         requested_inventory_exit,
         inventory_exit,
         exit_suppression,
-        actions: reconcile(
-            cfg,
-            input.market.mark,
-            input.position,
-            input.market.best_bid,
-            input.market.best_ask,
-            &desired,
-            input.resting,
-            input.cycle,
-            input.nonlinear_skew,
-            total_shift_bps,
-        ),
+        actions,
         inventory_ref_center: quote_center(
             cfg,
             input.nonlinear_skew,
@@ -781,6 +848,7 @@ pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> Cyc
         ),
         external_skew_shift_bps: external_shift_bps,
         micro_price_shift_bps: micro_shift_bps,
+        quote_geometry,
     }
 }
 
@@ -792,6 +860,7 @@ pub fn plan_cycle(cfg: &MakerConfig, input: CycleInput<'_>, halted: bool) -> Cyc
 /// are dropped; duplicate prices after clamping/rounding are collapsed (outer
 /// level wins nothing — the inner level is kept).
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub(crate) fn compute_desired_quotes(
     cfg: &MakerConfig,
     mark: f64,
@@ -803,20 +872,50 @@ pub(crate) fn compute_desired_quotes(
     external_shift_bps: f64,
     guard: GuardDecision,
 ) -> Vec<DesiredQuote> {
-    let mut out = Vec::new();
+    compute_desired_quotes_with_geometry(
+        cfg,
+        mark,
+        best_bid,
+        best_ask,
+        position,
+        size_skew,
+        nonlinear_skew,
+        external_shift_bps,
+        guard,
+    )
+    .quotes
+}
+
+#[derive(Debug, Default)]
+struct DesiredQuotesWithGeometry {
+    quotes: Vec<DesiredQuote>,
+    geometry: Vec<QuoteGeometry>,
+}
+
+/// Construct desired quotes and their diagnostics in one pass so clamp
+/// telemetry cannot drift from the prices used by reconciliation.
+#[allow(clippy::too_many_arguments)]
+fn compute_desired_quotes_with_geometry(
+    cfg: &MakerConfig,
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    position: f64,
+    size_skew: SizeSkewDecision,
+    nonlinear_skew: NonlinearSkewConfig,
+    external_shift_bps: f64,
+    guard: GuardDecision,
+) -> DesiredQuotesWithGeometry {
+    let mut result = DesiredQuotesWithGeometry::default();
     if !mark.is_finite()
         || mark <= 0.0
         || best_bid.is_some_and(|price| !price.is_finite() || price <= 0.0)
         || best_ask.is_some_and(|price| !price.is_finite() || price <= 0.0)
     {
-        return out;
+        return result;
     }
 
     let qty = round_to_decimals(cfg.size, cfg.qty_decimals);
-    if qty < cfg.min_order_qty || qty <= 0.0 {
-        return out;
-    }
-
     let tick = cfg.price_tick();
     // Band eligibility is defined around the TRUE mark, not the skewed center.
     let band_lo = mark * (1.0 - cfg.band_bps / 1e4);
@@ -828,11 +927,44 @@ pub(crate) fn compute_desired_quotes(
     // rather than moving the band with it.
     let center = quote_center(cfg, nonlinear_skew, external_shift_bps, mark, position);
 
+    if qty < cfg.min_order_qty || qty <= 0.0 {
+        for side in [OrderSide::Buy, OrderSide::Sell] {
+            for level in 0..cfg.levels {
+                let raw_price = raw_quote_price(cfg, center, side, level);
+                result.geometry.push(quote_geometry(
+                    side,
+                    level,
+                    raw_price,
+                    None,
+                    QuoteGeometryOutcome::DroppedBelowMinQty,
+                    mark,
+                    best_bid,
+                    best_ask,
+                    band_lo,
+                    band_hi,
+                ));
+            }
+        }
+        return result;
+    }
+
     let suppress_buy = position >= cfg.max_position;
     let suppress_sell = position <= -cfg.max_position;
 
     for side in [OrderSide::Buy, OrderSide::Sell] {
         if (side == OrderSide::Buy && suppress_buy) || (side == OrderSide::Sell && suppress_sell) {
+            push_suppressed_geometry(
+                &mut result.geometry,
+                cfg,
+                center,
+                mark,
+                best_bid,
+                best_ask,
+                band_lo,
+                band_hi,
+                side,
+                QuoteGeometryOutcome::SuppressedPosition,
+            );
             continue;
         }
         // External-price guard: the endangered side's quotes are stale against
@@ -840,6 +972,18 @@ pub(crate) fn compute_desired_quotes(
         // cycle. Resting quotes on that side cancel via the SideSuppressed
         // path; the guard releases once StandX's mark catches up.
         if guard.active && guard.endangered == Some(side) {
+            push_suppressed_geometry(
+                &mut result.geometry,
+                cfg,
+                center,
+                mark,
+                best_bid,
+                best_ask,
+                band_lo,
+                band_hi,
+                side,
+                QuoteGeometryOutcome::SuppressedGuard,
+            );
             continue;
         }
         let side_qty = if size_skew.active && size_skew.add_side == Some(side) {
@@ -852,24 +996,30 @@ pub(crate) fn compute_desired_quotes(
         };
         let mut last_price: Option<f64> = None;
         for level in 0..cfg.levels {
-            let offset_bps = cfg.spread_bps + level as f64 * cfg.level_step_bps;
-            let raw_price = match side {
-                OrderSide::Buy => center * (1.0 - offset_bps / 1e4),
-                OrderSide::Sell => center * (1.0 + offset_bps / 1e4),
-            };
+            let raw_price = raw_quote_price(cfg, center, side, level);
 
             // Intersect the eligibility band with the post-only no-cross
             // interval. If no tick can satisfy both, omit this side instead of
             // emitting a quote outside the band or relying on ALO rejection.
-            let (price_lo, price_hi) = match side {
-                OrderSide::Buy => (
-                    band_lo,
-                    best_ask.map_or(band_hi, |ask| band_hi.min(ask - tick)),
-                ),
-                OrderSide::Sell => (
-                    best_bid.map_or(band_lo, |bid| band_lo.max(bid + tick)),
-                    band_hi,
-                ),
+            let (price_lo, price_hi, lower_is_touch, upper_is_touch) = match side {
+                OrderSide::Buy => {
+                    let touch_hi = best_ask.map(|ask| ask - tick);
+                    (
+                        band_lo,
+                        touch_hi.map_or(band_hi, |bound| band_hi.min(bound)),
+                        false,
+                        touch_hi.is_some_and(|bound| bound <= band_hi),
+                    )
+                }
+                OrderSide::Sell => {
+                    let touch_lo = best_bid.map(|bid| bid + tick);
+                    (
+                        touch_lo.map_or(band_lo, |bound| band_lo.max(bound)),
+                        band_hi,
+                        touch_lo.is_some_and(|bound| bound >= band_lo),
+                        false,
+                    )
+                }
             };
             let price_tolerance = tick * 1e-6;
             if !raw_price.is_finite()
@@ -877,9 +1027,36 @@ pub(crate) fn compute_desired_quotes(
                 || !price_hi.is_finite()
                 || price_lo > price_hi + price_tolerance
             {
+                result.geometry.push(quote_geometry(
+                    side,
+                    level,
+                    raw_price,
+                    None,
+                    QuoteGeometryOutcome::DroppedInfeasible,
+                    mark,
+                    best_bid,
+                    best_ask,
+                    band_lo,
+                    band_hi,
+                ));
                 continue;
             }
 
+            let mut outcome = if raw_price < price_lo {
+                if lower_is_touch {
+                    QuoteGeometryOutcome::ClampedToTouch
+                } else {
+                    QuoteGeometryOutcome::ClampedToBand
+                }
+            } else if raw_price > price_hi {
+                if upper_is_touch {
+                    QuoteGeometryOutcome::ClampedToTouch
+                } else {
+                    QuoteGeometryOutcome::ClampedToBand
+                }
+            } else {
+                QuoteGeometryOutcome::Placed
+            };
             let mut price = raw_price.clamp(price_lo, price_hi);
 
             // Directional tick rounding: away from mark, so rounding never
@@ -893,8 +1070,18 @@ pub(crate) fn compute_desired_quotes(
             // band boundary is not tick-aligned. Snap back to the nearest
             // valid tick, then re-check every constraint.
             if price < price_lo {
+                outcome = if lower_is_touch {
+                    QuoteGeometryOutcome::ClampedToTouch
+                } else {
+                    QuoteGeometryOutcome::ClampedToBand
+                };
                 price = ceil_to_decimals(price_lo, cfg.price_decimals);
             } else if price > price_hi {
+                outcome = if upper_is_touch {
+                    QuoteGeometryOutcome::ClampedToTouch
+                } else {
+                    QuoteGeometryOutcome::ClampedToBand
+                };
                 price = floor_to_decimals(price_hi, cfg.price_decimals);
             }
 
@@ -905,16 +1092,52 @@ pub(crate) fn compute_desired_quotes(
                 || best_ask.is_some_and(|ask| side == OrderSide::Buy && price >= ask)
                 || best_bid.is_some_and(|bid| side == OrderSide::Sell && price <= bid)
             {
+                result.geometry.push(quote_geometry(
+                    side,
+                    level,
+                    raw_price,
+                    None,
+                    QuoteGeometryOutcome::DroppedInfeasible,
+                    mark,
+                    best_bid,
+                    best_ask,
+                    band_lo,
+                    band_hi,
+                ));
                 continue;
             }
 
             // Collapse duplicate levels (clamping can flatten the ladder).
             if last_price == Some(price) {
+                result.geometry.push(quote_geometry(
+                    side,
+                    level,
+                    raw_price,
+                    None,
+                    QuoteGeometryOutcome::DroppedDuplicate,
+                    mark,
+                    best_bid,
+                    best_ask,
+                    band_lo,
+                    band_hi,
+                ));
                 continue;
             }
             last_price = Some(price);
 
-            out.push(DesiredQuote {
+            result.geometry.push(quote_geometry(
+                side,
+                level,
+                raw_price,
+                Some(price),
+                outcome,
+                mark,
+                best_bid,
+                best_ask,
+                band_lo,
+                band_hi,
+            ));
+            result.quotes.push(DesiredQuote {
                 side,
                 level,
                 price,
@@ -923,7 +1146,160 @@ pub(crate) fn compute_desired_quotes(
         }
     }
 
-    out
+    result
+}
+
+fn raw_quote_price(cfg: &MakerConfig, center: f64, side: OrderSide, level: u32) -> f64 {
+    let offset_bps = cfg.spread_bps + level as f64 * cfg.level_step_bps;
+    match side {
+        OrderSide::Buy => center * (1.0 - offset_bps / 1e4),
+        OrderSide::Sell => center * (1.0 + offset_bps / 1e4),
+    }
+}
+
+/// Side-aware distance from mark, in bps of mark: positive means "away from
+/// mark in the direction that earns" (a buy below mark, a sell above it).
+/// Public so telemetry renders the same convention the ladder was built with
+/// instead of reimplementing it.
+pub fn side_distance_to_mark_bps(side: OrderSide, price: f64, mark: f64) -> f64 {
+    match side {
+        OrderSide::Buy => (mark - price) / mark * 1e4,
+        OrderSide::Sell => (price - mark) / mark * 1e4,
+    }
+}
+
+fn distance_to_touch_bps(
+    side: OrderSide,
+    price: f64,
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+) -> Option<f64> {
+    let distance = match side {
+        OrderSide::Buy => (best_ask? - price) / mark * 1e4,
+        OrderSide::Sell => (price - best_bid?) / mark * 1e4,
+    };
+    distance.is_finite().then_some(distance)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn quote_geometry(
+    side: OrderSide,
+    level: u32,
+    raw_price: f64,
+    final_price: Option<f64>,
+    outcome: QuoteGeometryOutcome,
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    band_lo: f64,
+    band_hi: f64,
+) -> QuoteGeometry {
+    let band_edge = match side {
+        OrderSide::Buy => band_lo,
+        OrderSide::Sell => band_hi,
+    };
+    QuoteGeometry {
+        side,
+        level,
+        raw_price,
+        final_price,
+        outcome,
+        distance_to_touch_bps: final_price
+            .and_then(|price| distance_to_touch_bps(side, price, mark, best_bid, best_ask)),
+        band_edge_bps: side_distance_to_mark_bps(side, band_edge, mark),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_suppressed_geometry(
+    geometry: &mut Vec<QuoteGeometry>,
+    cfg: &MakerConfig,
+    center: f64,
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    band_lo: f64,
+    band_hi: f64,
+    side: OrderSide,
+    outcome: QuoteGeometryOutcome,
+) {
+    for level in 0..cfg.levels {
+        geometry.push(quote_geometry(
+            side,
+            level,
+            raw_quote_price(cfg, center, side, level),
+            None,
+            outcome,
+            mark,
+            best_bid,
+            best_ask,
+            band_lo,
+            band_hi,
+        ));
+    }
+}
+
+fn mark_exposure_suppressed(geometry: &mut [QuoteGeometry], desired: &[DesiredQuote]) {
+    for row in geometry.iter_mut().filter(|row| row.final_price.is_some()) {
+        if desired
+            .iter()
+            .any(|quote| quote.side == row.side && quote.level == row.level)
+        {
+            continue;
+        }
+        row.outcome = QuoteGeometryOutcome::SuppressedPosition;
+        row.final_price = None;
+        row.distance_to_touch_bps = None;
+    }
+}
+
+/// Merge the quote observed resting at the start of the cycle into its slot.
+/// Holds use current resting geometry; placements keep their generated clamp
+/// outcome; cancel-only slots keep a non-`Placed` generated outcome or add the
+/// resting row when no such diagnostic exists. This action-aware precedence
+/// keeps at most one row per slot.
+fn overlay_resting_quote_geometry(
+    geometry: &mut Vec<QuoteGeometry>,
+    resting: &[RestingQuote],
+    actions: &[Action],
+    mark: f64,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    band_bps: f64,
+) {
+    let band_lo = mark * (1.0 - band_bps / 1e4);
+    let band_hi = mark * (1.0 + band_bps / 1e4);
+    for quote in resting {
+        let held = actions.iter().any(|action| {
+            matches!(action, Action::Hold { side, level, .. } if *side == quote.side && *level == quote.level)
+        });
+        let placed = actions.iter().any(
+            |action| matches!(action, Action::Place(desired) if desired.side == quote.side && desired.level == quote.level),
+        );
+        let row = quote_geometry(
+            quote.side,
+            quote.level,
+            quote.price,
+            Some(quote.price),
+            QuoteGeometryOutcome::Placed,
+            mark,
+            best_bid,
+            best_ask,
+            band_lo,
+            band_hi,
+        );
+        if let Some(existing) = geometry
+            .iter_mut()
+            .find(|existing| existing.side == quote.side && existing.level == quote.level)
+        {
+            if held || (!placed && existing.outcome == QuoteGeometryOutcome::Placed) {
+                *existing = row;
+            }
+        } else {
+            geometry.push(row);
+        }
+    }
 }
 
 /// Limit a desired ladder so that all quotes on either side filling cannot

--- a/crates/standx-maker/src/lib_tests.rs
+++ b/crates/standx-maker/src/lib_tests.rs
@@ -157,6 +157,83 @@ fn basic_two_sided() {
     assert_eq!(find(&quotes, OrderSide::Buy, 0).qty, 0.01);
 }
 
+#[test]
+fn cycle_plan_actions_are_identical_with_geometry_sidecar_present() {
+    let c = cfg();
+    let market = MarketSnapshot {
+        mark: 100.1,
+        best_bid: Some(100.0),
+        best_ask: Some(100.2),
+    };
+    let generated = compute_desired_quotes_with_geometry(
+        &c,
+        market.mark,
+        market.best_bid,
+        market.best_ask,
+        0.0,
+        SizeSkewDecision::INACTIVE,
+        NonlinearSkewConfig::default(),
+        0.0,
+        GuardDecision::INACTIVE,
+    );
+    let desired = cap_desired_exposure(&c, 0.0, &generated.quotes, &[]);
+    let actions_without_geometry = reconcile(
+        &c,
+        market.mark,
+        0.0,
+        market.best_bid,
+        market.best_ask,
+        &desired,
+        &[],
+        0,
+        NonlinearSkewConfig::default(),
+        0.0,
+    );
+    let plan = plan_cycle(
+        &c,
+        CycleInput {
+            cycle: 0,
+            market,
+            position: 0.0,
+            resting: &[],
+            pending_slots: &[],
+            market_data_mode: MarketDataMode::Active,
+            active_exit_enabled: false,
+            inventory_exit_pct: 0.0,
+            inventory_exit_qty: 0.0,
+            size_skew: SizeSkewDecision::INACTIVE,
+            nonlinear_skew: NonlinearSkewConfig::default(),
+            external_skew: Default::default(),
+            external_excess_bps: None,
+            micro_price: Default::default(),
+            guard: GuardDecision::INACTIVE,
+            wind_down: false,
+            qty_tolerance: 0.0005,
+        },
+        false,
+    );
+
+    assert!(!plan.quote_geometry.is_empty());
+    assert_eq!(plan.actions, actions_without_geometry);
+    assert_eq!(
+        plan.actions,
+        vec![
+            Action::Place(DesiredQuote {
+                side: OrderSide::Buy,
+                level: 0,
+                price: 99.99,
+                qty: 0.01,
+            }),
+            Action::Place(DesiredQuote {
+                side: OrderSide::Sell,
+                level: 0,
+                price: 100.21,
+                qty: 0.01,
+            }),
+        ]
+    );
+}
+
 // 2. Spread wider than band: clamp to band edges, not dropped.
 #[test]
 fn band_clamp() {
@@ -194,6 +271,24 @@ fn rounding_reenters_band() {
     let buy = find(&quotes, OrderSide::Buy, 0);
     assert!(buy.price >= 99.8, "price {} left the band", buy.price);
     assert_eq!(buy.price, 100.0);
+
+    let generated = compute_desired_quotes_with_geometry(
+        &c,
+        100.0,
+        None,
+        None,
+        0.0,
+        SizeSkewDecision::INACTIVE,
+        NonlinearSkewConfig::default(),
+        0.0,
+        GuardDecision::INACTIVE,
+    );
+    let buy = generated
+        .geometry
+        .iter()
+        .find(|quote| quote.side == OrderSide::Buy && quote.level == 0)
+        .unwrap();
+    assert_eq!(buy.outcome, QuoteGeometryOutcome::ClampedToBand);
 }
 
 // 5. No-cross clamp on both sides.
@@ -214,6 +309,72 @@ fn no_cross_clamp() {
     let quotes = desired(&cfg(), 100.0, Some(100.15), Some(100.20), 0.0);
     let sell = find(&quotes, OrderSide::Sell, 0);
     assert_eq!(sell.price, 100.16);
+}
+
+#[test]
+fn geometry_distinguishes_touch_clamp_and_infeasible_interval() {
+    let c = cfg();
+    let generated = compute_desired_quotes_with_geometry(
+        &c,
+        100.0,
+        Some(99.83),
+        Some(99.85),
+        0.0,
+        SizeSkewDecision::INACTIVE,
+        NonlinearSkewConfig::default(),
+        0.0,
+        GuardDecision::INACTIVE,
+    );
+    let buy = generated
+        .geometry
+        .iter()
+        .find(|quote| quote.side == OrderSide::Buy && quote.level == 0)
+        .unwrap();
+    assert_eq!(buy.outcome, QuoteGeometryOutcome::ClampedToTouch);
+    assert_eq!(buy.final_price, Some(99.84));
+    assert!((buy.distance_to_touch_bps.unwrap() - 1.0).abs() < 1e-9);
+
+    // When the no-cross ceiling exactly coincides with the band ceiling, the
+    // touch is still a binding bound and must win the diagnostic label.
+    let coincident = compute_desired_quotes_with_geometry(
+        &c,
+        100.0,
+        Some(100.19),
+        Some(100.21),
+        0.0,
+        SizeSkewDecision::INACTIVE,
+        NonlinearSkewConfig::default(),
+        100.0,
+        GuardDecision::INACTIVE,
+    );
+    let buy = coincident
+        .geometry
+        .iter()
+        .find(|quote| quote.side == OrderSide::Buy && quote.level == 0)
+        .unwrap();
+    assert_eq!(buy.outcome, QuoteGeometryOutcome::ClampedToTouch);
+
+    // The buy interval is [99.80, 99.78]: the band floor is above the
+    // post-only ceiling (`best_ask - tick`), so the level is unplaceable.
+    let infeasible = compute_desired_quotes_with_geometry(
+        &c,
+        100.0,
+        Some(99.77),
+        Some(99.79),
+        0.0,
+        SizeSkewDecision::INACTIVE,
+        NonlinearSkewConfig::default(),
+        0.0,
+        GuardDecision::INACTIVE,
+    );
+    let buy = infeasible
+        .geometry
+        .iter()
+        .find(|quote| quote.side == OrderSide::Buy && quote.level == 0)
+        .unwrap();
+    assert_eq!(buy.outcome, QuoteGeometryOutcome::DroppedInfeasible);
+    assert_eq!(buy.final_price, None);
+    assert_eq!(buy.distance_to_touch_bps, None);
 }
 
 #[test]
@@ -286,6 +447,188 @@ fn reconcile_hold_within_refresh() {
     if let Action::Hold { age_cycles, .. } = &actions[0] {
         assert_eq!(*age_cycles, 7);
     }
+}
+
+#[test]
+fn cycle_plan_reports_resting_quote_distance_to_current_touch() {
+    let c = cfg();
+    let rest = [resting(OrderSide::Buy, 0, 99.85, 100.0)];
+    let plan = plan_cycle(
+        &c,
+        CycleInput {
+            cycle: 7,
+            market: MarketSnapshot {
+                mark: 100.0,
+                best_bid: Some(99.89),
+                best_ask: Some(99.92),
+            },
+            position: 0.0,
+            resting: &rest,
+            pending_slots: &[],
+            market_data_mode: MarketDataMode::Active,
+            active_exit_enabled: false,
+            inventory_exit_pct: 0.0,
+            inventory_exit_qty: 0.0,
+            size_skew: Default::default(),
+            nonlinear_skew: Default::default(),
+            external_skew: Default::default(),
+            external_excess_bps: None,
+            micro_price: Default::default(),
+            guard: Default::default(),
+            wind_down: false,
+            qty_tolerance: 0.0005,
+        },
+        false,
+    );
+
+    assert!(plan.actions.iter().any(|action| matches!(
+        action,
+        Action::Hold {
+            side: OrderSide::Buy,
+            level: 0,
+            price: 99.85,
+            ..
+        }
+    )));
+    assert_eq!(plan.quote_geometry.len(), 2);
+    let buy = plan
+        .quote_geometry
+        .iter()
+        .find(|quote| quote.side == OrderSide::Buy && quote.level == 0)
+        .unwrap();
+    assert_eq!(buy.outcome, QuoteGeometryOutcome::Placed);
+    assert_eq!(buy.final_price, Some(99.85));
+    assert!((buy.distance_to_touch_bps.unwrap() - 7.0).abs() < 1e-9);
+
+    // The newly generated buy would be pinned one tick below the ask, but the
+    // older quote is still safely held. Geometry must describe the actual
+    // resting price (5 bps away), not the hypothetical replacement (1 bp).
+    let closing_touch = plan_cycle(
+        &c,
+        CycleInput {
+            cycle: 8,
+            market: MarketSnapshot {
+                mark: 100.0,
+                best_bid: Some(99.88),
+                best_ask: Some(99.90),
+            },
+            position: 0.0,
+            resting: &rest,
+            pending_slots: &[],
+            market_data_mode: MarketDataMode::Active,
+            active_exit_enabled: false,
+            inventory_exit_pct: 0.0,
+            inventory_exit_qty: 0.0,
+            size_skew: Default::default(),
+            nonlinear_skew: Default::default(),
+            external_skew: Default::default(),
+            external_excess_bps: None,
+            micro_price: Default::default(),
+            guard: Default::default(),
+            wind_down: false,
+            qty_tolerance: 0.0005,
+        },
+        false,
+    );
+    assert!(closing_touch.actions.iter().any(|action| matches!(
+        action,
+        Action::Hold {
+            side: OrderSide::Buy,
+            level: 0,
+            price: 99.85,
+            ..
+        }
+    )));
+    let buy = closing_touch
+        .quote_geometry
+        .iter()
+        .find(|quote| quote.side == OrderSide::Buy && quote.level == 0)
+        .unwrap();
+    assert_eq!(buy.outcome, QuoteGeometryOutcome::Placed);
+    assert_eq!(buy.final_price, Some(99.85));
+    assert!((buy.distance_to_touch_bps.unwrap() - 5.0).abs() < 1e-9);
+    assert_eq!(closing_touch.quote_geometry.len(), 2);
+}
+
+#[test]
+fn cycle_plan_preserves_replacement_geometry_and_reports_cancel_only_resting() {
+    let c = cfg();
+    let rest = [resting(OrderSide::Buy, 0, 99.90, 100.0)];
+    let input = CycleInput {
+        cycle: 8,
+        market: MarketSnapshot {
+            mark: 100.0,
+            best_bid: Some(99.88),
+            best_ask: Some(99.90),
+        },
+        position: 0.0,
+        resting: &rest,
+        pending_slots: &[],
+        market_data_mode: MarketDataMode::Active,
+        active_exit_enabled: false,
+        inventory_exit_pct: 0.0,
+        inventory_exit_qty: 0.0,
+        size_skew: Default::default(),
+        nonlinear_skew: Default::default(),
+        external_skew: Default::default(),
+        external_excess_bps: None,
+        micro_price: Default::default(),
+        guard: Default::default(),
+        wind_down: false,
+        qty_tolerance: 0.0005,
+    };
+
+    let running = plan_cycle(&c, input, false);
+    assert!(running.actions.iter().any(|action| matches!(
+        action,
+        Action::Cancel {
+            side: OrderSide::Buy,
+            level: 0,
+            price: 99.90,
+            reason: CancelReason::WouldCross,
+            ..
+        }
+    )));
+    assert!(running.actions.iter().any(
+        |action| matches!(action, Action::Place(quote) if quote.side == OrderSide::Buy && quote.level == 0 && quote.price == 99.89)
+    ));
+    let buy = running
+        .quote_geometry
+        .iter()
+        .find(|quote| quote.side == OrderSide::Buy && quote.level == 0)
+        .unwrap();
+    assert_eq!(buy.outcome, QuoteGeometryOutcome::ClampedToTouch);
+    assert_eq!(buy.final_price, Some(99.89));
+    assert!((buy.distance_to_touch_bps.unwrap() - 1.0).abs() < 1e-9);
+    assert_eq!(running.quote_geometry.len(), 2);
+
+    let infeasible = plan_cycle(
+        &c,
+        CycleInput {
+            market: MarketSnapshot {
+                mark: 100.0,
+                best_bid: Some(99.77),
+                best_ask: Some(99.79),
+            },
+            ..input
+        },
+        false,
+    );
+    let buy = infeasible
+        .quote_geometry
+        .iter()
+        .find(|quote| quote.side == OrderSide::Buy && quote.level == 0)
+        .unwrap();
+    assert_eq!(buy.outcome, QuoteGeometryOutcome::DroppedInfeasible);
+    assert_eq!(buy.final_price, None);
+    assert_eq!(infeasible.quote_geometry.len(), 2);
+
+    let halted = plan_cycle(&c, input, true);
+    assert_eq!(halted.quote_geometry.len(), 1);
+    let buy = &halted.quote_geometry[0];
+    assert_eq!(buy.outcome, QuoteGeometryOutcome::Placed);
+    assert_eq!(buy.final_price, Some(99.90));
+    assert_eq!(buy.distance_to_touch_bps, Some(0.0));
 }
 
 // 9. Drift beyond refresh -> Cancel(mark_moved) + Place, cancel first.

--- a/crates/standx-sdk/src/websocket.rs
+++ b/crates/standx-sdk/src/websocket.rs
@@ -6,6 +6,7 @@ use crate::error::{Error, Result};
 use crate::models::*;
 use futures_util::{SinkExt, StreamExt};
 use serde::de::DeserializeOwned;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{mpsc, RwLock};
@@ -118,6 +119,7 @@ pub struct StandXWebSocket {
     #[allow(dead_code)]
     symbol: Option<String>,
     verbose: bool,
+    public_trade_raw_sample_budget: Option<Arc<AtomicUsize>>,
 }
 
 impl StandXWebSocket {
@@ -161,6 +163,7 @@ impl StandXWebSocket {
             channel: String::new(),
             symbol: None,
             verbose,
+            public_trade_raw_sample_budget: None,
         })
     }
 
@@ -197,6 +200,7 @@ impl StandXWebSocket {
             channel: String::new(),
             symbol: None,
             verbose,
+            public_trade_raw_sample_budget: None,
         })
     }
 
@@ -225,7 +229,16 @@ impl StandXWebSocket {
             channel: String::new(),
             symbol: None,
             verbose: false,
+            public_trade_raw_sample_budget: None,
         })
+    }
+
+    /// Opt into a process-shared, bounded stderr sample of exact
+    /// `public_trade` frames. Parsing and typed trade delivery remain
+    /// unchanged; exhausting the budget simply disables further samples.
+    pub fn with_public_trade_raw_sample_budget(mut self, budget: Arc<AtomicUsize>) -> Self {
+        self.public_trade_raw_sample_budget = Some(budget);
+        self
     }
 
     /// Connect and start the WebSocket client
@@ -245,12 +258,22 @@ impl StandXWebSocket {
         let subscriptions = self.subscriptions.clone();
         let reconnect_attempts = self.reconnect_attempts.clone();
         let verbose = self.verbose;
+        let public_trade_raw_sample_budget = self.public_trade_raw_sample_budget.clone();
 
         let handle = tokio::spawn(async move {
             loop {
                 *state.write().await = WsState::Connecting;
 
-                match connect_and_run(&url, token.as_deref(), &subscriptions, &tx, verbose).await {
+                match connect_and_run(
+                    &url,
+                    token.as_deref(),
+                    &subscriptions,
+                    &tx,
+                    verbose,
+                    public_trade_raw_sample_budget.as_deref(),
+                )
+                .await
+                {
                     Ok(_) => {
                         *reconnect_attempts.write().await = 0;
                     }
@@ -323,6 +346,7 @@ async fn connect_and_run(
     subscriptions: &Arc<RwLock<Vec<String>>>,
     message_tx: &mpsc::Sender<WsMessage>,
     verbose: bool,
+    public_trade_raw_sample_budget: Option<&AtomicUsize>,
 ) -> Result<()> {
     let ws_url = url.to_string();
     if verbose {
@@ -500,6 +524,10 @@ async fn connect_and_run(
                                     }
                                 }
                                 "public_trade" => {
+                                    if take_public_trade_raw_sample(public_trade_raw_sample_budget)
+                                    {
+                                        eprintln!("public_trade raw sample: {text}");
+                                    }
                                     if let Ok(trade) =
                                         serde_json::from_value::<Trade>(data["data"].clone())
                                     {
@@ -598,6 +626,16 @@ async fn connect_and_run(
     Ok(())
 }
 
+fn take_public_trade_raw_sample(budget: Option<&AtomicUsize>) -> bool {
+    budget.is_some_and(|budget| {
+        budget
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -605,6 +643,18 @@ mod tests {
     #[test]
     fn test_ws_state() {
         assert_ne!(WsState::Connected, WsState::Disconnected);
+    }
+
+    #[test]
+    fn public_trade_raw_sample_budget_is_exact_and_bounded() {
+        let budget = AtomicUsize::new(50);
+
+        for _ in 0..50 {
+            assert!(take_public_trade_raw_sample(Some(&budget)));
+        }
+        assert!(!take_public_trade_raw_sample(Some(&budget)));
+        assert!(!take_public_trade_raw_sample(None));
+        assert_eq!(budget.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/docs/18-maker-strategy-roadmap.md
+++ b/docs/18-maker-strategy-roadmap.md
@@ -41,6 +41,7 @@
 | 阶段 5-b：退出与账户风险 | implemented | typed trim/wind-down、残余仓位交接和默认关闭的账户硬熔断已落地 |
 | cleanup 残余判定硬化 | completed | WS 终态 success 优先、按单 REST status 兜底，未确认时继续 fail-closed |
 | `external_skew` | implemented, pending verdict | 默认关闭、关闭时等价；候选尚未获得 accepted 判定 |
+| `micro_price` | accepted（方向）/ 幅度未判 | A/B 于 2026-08-19 判 accepted 并提为默认基线配置（`52b0bea`）；判定成立于 band=40，band=30 下偏移会被 clamp 截断，**效果量需新窗口重测**（见 [30](30-maker-uptime-band-tightening-design.md)） |
 
 历史设计、运行手册与判定链见
 [2026-07 Maker 归档](archive/2026-07-maker/)。归档中的精确授权文本只证明当时获准的
@@ -83,7 +84,9 @@ symbol、敞口、配置和时间窗，不能复用于新的 live 运行。
    [29-maker-external-skew-design.md](29-maker-external-skew-design.md) 的冻结单候选和预注册
    判据，并重新记录授权；未裁决前保持默认关闭。
 
-盘口/流特征数据未积累到足够窗口前，不启动 microprice、OFI 或新的自动暂停机制。
+盘口/流特征数据未积累到足够窗口前，不启动 OFI 或新的自动暂停机制。microprice 已实现
+并于 2026-08-19 判 accepted（方向），但其幅度在当前 band=30 下未判；纯观测遥测见
+[32](32-maker-observation-telemetry-design.md)。
 
 ## 长期不变量
 

--- a/docs/30-maker-uptime-band-tightening-design.md
+++ b/docs/30-maker-uptime-band-tightening-design.md
@@ -49,6 +49,39 @@ band clamp）回放各参数组合，统计双边带内占比。模型校准：�
 关键读数：先动 band 收益最小（49%）且先推高撤单；spread 是最大杠杆且撤单
 不变；三步叠加恰好落在目标线上，撤单 +58%。
 
+## 变更记录：band 回到 30（2026-08-19）
+
+microprice A/B 判定 accepted 后（`52b0bea`，P(delta>0)=93.3%），被提为新默认基线的
+配置带着 `band_bps = 40.0` 进入 `examples/maker-microprice-hype-baseline.toml`——
+band 之所以被放宽到 40，是为了让 `spread(8) + nonlinear.cap(12) + external.cap(8)
++ micro.cap(6) = 34` 的叠加偏移永不触碰 band clamp（原配置注释）。
+
+那与本文的约束方向相反：本文自 2026-08-04 起把 ±10bp 双边带内 uptime 定为**约束
+条件**，根因 #1 正是「band 是场馆合格带的 3 倍」，分阶段方案是 30→12。放到 40 等于
+把策略自有撤单带放到场馆带的 4 倍。
+
+**owner 裁决 2026-08-19：band 改回 30.0**，作为本文分阶段方案的起点状态恢复。
+后果已写进配置注释：candidate 侧叠加偏移上限 34 > 30，**band clamp 会真的绑定并
+截断中心偏移**，这是接受的代价，不是 bug。
+
+副作用与边界：
+
+- 该配置改动构成新的变更点；按下节规则，下一轮开跑即新窗口，manifest 需记录
+  UTC 时间戳与新的配置 sha256，不与 band=40 期间的读数拼接判读。
+- `examples/maker-microprice-hype-baseline.arch-20260819.toml` 保持 `band_bps = 40.0`
+  不动——它是 pre-microprice 基线的**归档快照**，记录当时的实际配置。
+- `docs/handoff-microprice-ab-2026-08-13.md` 的参数表（band 40/40）同样保持不动：
+  那是已判定实验的**运行记录**，改写会伪造当时真实跑的参数。
+**owner 裁决 2026-08-19（续）：接受「机制方向已判定、幅度需重测」。**
+`52b0bea` 的 accepted 判定（P(delta>0)=93.3%）成立于 band=40、叠加偏移永不被截断的
+条件下；band=30 下 microprice 的有效偏移在叠加态会被 band clamp 削掉，因此该判定
+只结转**方向**，不结转**效果量**。band=30 下的幅度需要新窗口重测，且重测前不得
+把 +0.72bps 之类的读数用于任何规模或收益推断。
+
+- band 从 40 回到 30 会同时改变 clamp 行为，因此
+  [32-maker-observation-telemetry-design.md](32-maker-observation-telemetry-design.md)
+  的 `ClampedToBand` / `ClampedToTouch` 计数在两个 band 设定下不可直接比较。
+
 ## 分阶段方案（每步单行配置变更）
 
 每步变更 `maker-external-skew-hype-candidate.toml` 的**一行**，其余配置（含全部

--- a/docs/32-maker-observation-telemetry-design.md
+++ b/docs/32-maker-observation-telemetry-design.md
@@ -1,0 +1,237 @@
+# 阶段 7：纯观测遥测——盘口几何、clamp 命中、成交流
+
+## 状态
+
+`planned` / 纯观测。不改变任何报价、撤单、退出或停机决策；不引入新的停报来源。
+对应 [18-maker-strategy-roadmap.md](18-maker-strategy-roadmap.md)「当前优先级 1」。
+
+## 背景与问题
+
+两轮 live 读数把亏损定位到逆向选择（`capture 2.8 - markout 3.2 - fee 1 ≈ -1.4bps/笔`），
+但我们**缺少描述逆选物理成因的字段**。三个具体盲区：
+
+1. **被吃风险的物理量是「距 best 的距离」，我们全部几何量锚在 mark 上。**
+   对 best 只有一个硬不穿越检查（[`quote_crosses_touch`](../crates/standx-maker/src/lib.rs) ）。
+   全仓 `grep distance|to_touch` 在 maker 路径零命中。
+
+2. **`desired_quotes` 的 no-cross clamp 会把报价钉到距 best 一个 tick 处，且无任何记录。**
+   [`crates/standx-maker/src/lib.rs`](../crates/standx-maker/src/lib.rs) 的 ladder 里
+   `buy` 的可行上界是 `min(band_hi, best_ask - tick)`，`raw_price.clamp(price_lo, price_hi)`
+   之后我们可能挂在全场最危险的价位；可行区间为空时则直接 `continue` 丢弃这一档。
+   两种结果目前都不产生 reason code、不产生字段，离线无法区分
+   「这一轮没挂」和「这一轮被钉在盘口挂了」。
+
+3. **盘口与成交流数据被丢弃。** `depth_book` 推送带多档量，
+   [`feed.rs`](../crates/standx-cli/src/commands/maker/feed.rs) 只 parse `best_bid/best_ask`；
+   `public_trade` 频道在 SDK 里**已经**能解析（`websocket.rs` 已把它映射到
+   `WsMessage::Trade`），但 maker feed 从未订阅。因此「身前深度多少」「深度是否
+   在成交前撤走」「taker 方向」三个问题都无法回答。
+
+第 3 条还有一个边界条件必须记住：**身前挂单集体撤走导致我们暴露于盘口时，
+不会有任何成交推送**。所以成交流不能单独作为观测口径，必须同时有深度快照。
+
+## 硬约束（实现必须逐条满足）
+
+1. **零决策影响。** 新字段不得被 `preflight_cycle`、`plan_cycle`、`reconcile`、
+   guard/skew/vol 任何分支读取。`public_trade` 与深档量都只进日志。
+2. **replay 逐 action 等价。** 现有 ndjson 回放的 `Action` 序列必须字节级不变。
+   新字段可以进入 `CyclePlan`（确定性、可离线重算），但不得改变任何既有字段。
+3. **不新增停报/重连来源（fail-open）。** 尤其是：
+   - `public_trade` **不得**进入 `ChannelFreshness`（否则安静的成交流会每 15s
+     触发 idle watchdog 重建连接，凭空造出一个 outage 源）；
+   - `coherent_ws_snapshot` / `FeedSnapshotVersion` 不得要求第三个频道推进；
+   - 订阅失败、解析失败、字段缺失一律降级为「无观测」，继续正常报价。
+4. **有界内存。** 成交 tape 与盘口环形缓冲必须定长，不得随运行时长增长。
+5. **不与热路径抢锁。** 每周期 `feed.read().await` 是报价热路径。成交 tape 与
+   深档写入**不要**放进 `FeedState`，用独立的锁/结构，避免高频 tape 写入
+   拖慢 mark/book 读取。
+6. **JSON 向后兼容。** 沿用现有 `with_*_fields` 追加式惯例
+   （见 `output.rs` 的 `with_guard_fields` / `with_size_skew_fields`），
+   字段一律 top-level 追加、缺失为 `null`。
+
+## Part A：feed 侧盘口深档 + 成交流（对应「第 3 项」）
+
+### A1. 深档保留
+
+- 深档保留在 A2 的独立结构里（**不是** `FeedState`，见硬约束 5）：
+  `bid_levels: Vec<(f64, f64)>` / `ask_levels: Vec<(f64, f64)>`，每侧最多保留 **5 档**（与 REST `get_depth(symbol, Some(5))` 对齐），按价格排序，
+  非有限/非正值丢弃。`OrderBook.bids/asks` 已是完整向量，无需改 SDK。
+- 现有 `best_bid/best_ask` 字段与推导方式**保持不变**，不要改成从新 vec 取首档，
+  以免动到决策输入。
+- 深档为空或解析失败时保留旧值不是必需的——置空即可（观测缺失优于错误观测）。
+
+### A2. `public_trade` 订阅与 tape
+
+- `spawn_market_feed` 增加 `ws.subscribe("public_trade", Some(&symbol))`。
+  SDK 侧无需改动（`websocket.rs` 已 dispatch `public_trade` → `WsMessage::Trade`）。
+  确认：maker 的自有成交走独立的 `account_stream.rs`（`AccountEvent::Trade`），
+  与 `WsMessage::Trade` **无冲突**。
+- 新增独立结构（不放进 `FeedState`，见硬约束 5）：
+  定长环形 tape，容量 **256 条**，每条记录
+  `{ local_recv_ms（单调）, id, price, qty, side（Option）, is_taker（原样） }`。
+- **字段可信度警告：** `models::Trade` 的 `is_buyer_taker` 带 `#[serde(default)]`
+  且 `side: Option<String>`。缺字段会静默变成 `false`，那是**伪造的方向信息**。
+  因此：
+  - 首个交付版本额外记录一个**原始 JSON 采样**（前 N=50 条 `public_trade`
+    原文写入 stderr 或独立日志行，仅一次性诊断用），先证实 venue 实际推送的
+    形状，再决定离线是否可信任 `side`/`is_taker`；
+  - `side` 缺失时写 `null`，**不要**用 `is_taker` 反推方向。
+
+### A3. cycle_summary 追加字段
+
+新增 `with_book_fields(...)`，在 `cycle_summary` 上追加：
+
+```
+"book": {
+  "bid_levels": [[price, qty], ...],   // 最多 5，观测缺失为 null
+  "ask_levels": [[price, qty], ...],
+  "bid_qty_top": qty, "ask_qty_top": qty,
+  "spread_bps": (best_ask-best_bid)/mark*1e4,
+  "mark_mid_divergence_bps": ...,      // 复用 lib.rs 已有 mark_mid_divergence_bps
+  "age_ms": ...
+},
+"tape": {
+  "count_5s": n, "buy_qty_5s": q, "sell_qty_5s": q, "unknown_qty_5s": q,
+  "last_trade_age_ms": ...
+}
+```
+
+`tape` 的窗口统计在 CLI 侧按 tape 的单调时间戳现算，不落每笔明细到
+`cycle_summary`（明细留在 tape，必要时另行落盘）。
+
+## Part B：报价几何与 clamp 命中（对应「第 2 项」）
+
+### B1. 在 `desired_quotes` 里产出诊断，放进 `CyclePlan`
+
+**裁决（2026-08-19，owner）**：诊断放进 `CyclePlan`（`standx-maker` 纯逻辑层），
+不在 CLI 侧另算。理由：诊断必须来自**真正执行 clamp 的那段代码**，否则一定会和实际
+行为漂移；放进 `CyclePlan` 还能让现有 replay 直接在历史 trace 上重算这些字段。
+代价是动了 pure crate 的公开结构，因此 Part B 必须附带专门的 replay 逐 action 等价测试。
+
+新增（`standx-maker`，pure）：
+
+```rust
+pub enum QuoteGeometryOutcome {
+    Placed,                  // 进入 desired
+    ClampedToBand,           // 被 band 边界拉回
+    ClampedToTouch,          // 被 no-cross 上界拉回（危险来源）
+    DroppedInfeasible,       // price_lo > price_hi，整档丢弃
+    DroppedBelowMinQty,
+    DroppedDuplicate,        // clamp 后与上一档同价被折叠
+    SuppressedPosition,
+    SuppressedGuard,
+}
+
+pub struct QuoteGeometry {
+    pub side: OrderSide,
+    pub level: u32,
+    pub raw_price: f64,          // clamp 前
+    pub final_price: Option<f64>,// clamp/rounding 后（丢弃时 None）
+    pub outcome: QuoteGeometryOutcome,
+    pub distance_to_touch_bps: Option<f64>, // 同侧对手盘口距离，bps of mark
+    pub band_edge_bps: f64,
+}
+```
+
+- `CyclePlan` 增加 `pub quote_geometry: Vec<QuoteGeometry>`（追加字段）。
+- **同时覆盖 resting 报价**：`reconcile` 每周期对每个在场报价也产出一条
+  （`outcome: Placed`，`distance_to_touch_bps` 按当轮盘口重算），
+  否则我们只看得到「新挂时的距离」而看不到「挂着时距离被盘口逼近」。
+  实现上可以在 `plan_cycle` 末尾统一补，不必侵入 `reconcile`。
+- `distance_to_touch_bps` 定义（**写进 doc comment，避免离线口径混用**）：
+  买单为 `(best_ask - price) / mark * 1e4`，卖单为 `(price - best_bid) / mark * 1e4`；
+  盘口缺该侧时为 `None`。
+
+### B2. cycle_summary 追加字段
+
+新增 `with_geometry_fields(...)`：
+
+```
+"geometry": {
+  "min_distance_to_touch_bps": ...,   // 当轮所有 desired+resting 的最小值
+  "clamped_to_touch": n,              // 本轮命中次数
+  "clamped_to_band": n,
+  "dropped_infeasible": n,
+  "quotes": [ {side, level, outcome, raw_bps, final_bps, dist_touch_bps, band_edge_bps}, ... ]
+}
+```
+
+`raw_bps` / `final_bps` 由 `standx-maker` 的 `side_distance_to_mark_bps`（已 pub）渲染，
+CLI 侧不得重写这个符号约定——那正是 B1 裁决要避免的漂移。原本收在结构体里的
+`distance_to_mark_bps` 已删除：它只是 `final_bps`（挂上时）或 `raw_bps`（被丢弃时）的
+折叠值，可由发出的这一对完全推导。
+
+`quotes` 明细在 `levels=1` 下最多 2 条，体积可接受；若将来 levels 变大，
+只保留聚合项，明细降级为最危险的一条。
+
+## Part C：成交时刻的盘口观测（对应 roadmap「成交前后 best bid/ask 数量」）
+
+- 沿用 `excess_bps_at_fill` 的既有手法：runtime state 里持有最近一次
+  `BookObservation`，在 emit fill 的**全部**站点带上。
+  已知站点：`runtime/cycle_flow.rs`（4 处）、`runtime/recovery_flow.rs`（3 处）、
+  `recovery.rs` 的 `FillEmission`。
+- **用一个结构体而不是多个标量字段**（避免 8 处各加 4 个参数）：
+
+```rust
+pub(super) struct BookAtFill {
+    best_bid: Option<f64>, best_ask: Option<f64>,
+    bid_qty_top: Option<f64>, ask_qty_top: Option<f64>,
+    bid_levels_qty_5: Option<f64>, ask_levels_qty_5: Option<f64>,
+    observation_age_ms: Option<u64>,
+    tape_count_5s: Option<u32>,
+    tape_last_side: Option<String>,
+}
+```
+
+- `observation_age_ms` 必须落盘：成交事件走 account stream，盘口走 public feed，
+  两者异步；不带 age 的盘口快照在离线分析里不可用。
+- **本轮不做**成交后（post-fill）盘口窗口。`performance.markout_*` 已有从 mark
+  起算的 markout 窗口，post-fill 盘口需要延迟 emit，复杂度不值当，留待下一轮。
+
+## 交付顺序
+
+1. **Part A**（feed 深档 + tape + `with_book_fields`）——Part C 依赖它的观测源。
+2. **Part B**（quote geometry，纯 `standx-maker` + 一个 output wrapper）——与 A 独立。
+3. **Part C**（成交时刻观测穿线）。
+
+三部分可分别提 PR；每个 PR 独立满足下面的验收要求。
+
+## 测试与验收要求
+
+每个 PR 必须包含：
+
+- **replay 等价证明**：用现有 ndjson trace 跑 `run_replay`，断言 `Action` 序列
+  与改动前逐条相同（Part B 需要专门的等价测试，因为它动了 `CyclePlan`）。
+- **fail-open 单测**：
+  - `public_trade` 完全无推送时，feed 不触发 idle 重建、不影响 `coherent_ws_snapshot`；
+  - 深档缺失/畸形时 `best_bid/best_ask` 与既有行为一致；
+  - `Trade` 缺 `side` 字段时记为 `null`，不写入 `false` 方向。
+- **clamp 命中单测**（Part B）：构造 `best_ask - tick < band_hi` 的输入，
+  断言产出 `ClampedToTouch` 且 `distance_to_touch_bps` 等于 1 tick 对应 bps；
+  构造 `price_lo > price_hi` 断言 `DroppedInfeasible`。
+- **JSON 追加性单测**：沿用 `cycle_summary_*_fields_are_additive_and_top_level`
+  的现有测试形状。
+- **有界性单测**：tape 写入 300 条后长度仍为 256。
+
+提交前按 roadmap 要求跑全套：
+
+```bash
+HOME=/tmp/standx-test-home CARGO_HOME=~/.cargo cargo test --workspace --offline
+cargo clippy --workspace --all-targets --offline -- -D warnings
+cargo fmt --all -- --check
+```
+
+## 明确不做（out of scope）
+
+- 不加 min-distance-to-touch **门控**（那是策略改动，需要单独立项与预注册判据）；
+- 不改 `band_bps` / `spread_bps` / `refresh_bps` 任何默认值；
+- 不把 tape 或深档接入任何决策、guard 或 skew；
+- 不做 post-fill 盘口窗口；
+- 不改 symbol、size、`max_position`。
+
+## 后续（本文不授权）
+
+字段积累一个完整窗口后，离线回归 `distance_to_touch_bps` / `clamped_to_touch`
+对成交概率与 markout 的解释力。若解释力显著高于现有 `mid_bias_bps`
+（filled rho ≈ -0.53），再按 [28-experiment-protocol.md](28-experiment-protocol.md)
+立项 min-distance 门控候选。

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,8 @@ runbook 统一放在 [archive/](archive/README.md)，不能作为新的 live 授
 | [18 - 当前状态与路线](18-maker-strategy-roadmap.md) | 机制判定、经济结论、优先级与长期不变量 | 当前策略状态真源 |
 | [29 - External skew 候选](29-maker-external-skew-design.md) | 默认关闭候选的设计和预注册判据 | 待裁决候选，不代表已授权 |
 | [30 - 带内 uptime 参数收缩](30-maker-uptime-band-tightening-design.md) | SIP-5A ±10bp 带内 uptime 的渐进参数收缩设计与预注册判据 | 待裁决序列，每步需 owner 裁决 |
+| [31 - Microprice 设计](31-maker-microprice-design.md) | 场内侧 touch-mid 中心偏移的设计与预注册判据 | 方向已判 accepted，幅度未判 |
+| [32 - 纯观测遥测](32-maker-observation-telemetry-design.md) | 盘口深档、成交流、clamp 命中与距盘口距离的观测字段设计 | 纯观测，不含策略授权 |
 
 ## 生产操作与实验
 

--- a/examples/maker-microprice-hype-baseline.toml
+++ b/examples/maker-microprice-hype-baseline.toml
@@ -1,15 +1,19 @@
 # Stage 3 v1 + external_guard + external_skew + microprice A/B, HYPE-USD.
 # Baseline: nonlinear + external_guard + external_skew, NO microprice.
 # Candidate: same baseline + [microprice] enabled.
-# Band widened to 40bps to accommodate microprice cap=6.
-# Band budget: spread(8) + nonlinear.cap(12) + external.cap(8) = 28 <= 40  (baseline)
-#             spread(8) + nonlinear.cap(12) + external.cap(8) + micro.cap(6) = 34 <= 40  (candidate)
+# Band kept at 30bps (owner decision 2026-08-19): docs/30 made ±10bp two-sided
+# in-band uptime a CONSTRAINT, and widening the strategy's own cancel band moves
+# the wrong way. The band is deliberately allowed to bind.
+# Band budget: spread(8) + nonlinear.cap(12) + external.cap(8) = 28 <= 30  (baseline)
+#             spread(8) + nonlinear.cap(12) + external.cap(8) + micro.cap(6) = 34 > 30 (candidate)
+#             -> on fully stacked shifts the candidate arm's center offset IS
+#                clamped to the band edge. That truncation is accepted, not a bug.
 #
 # Safety: microprice is fail-open (missing signal -> shift=0, quoting continues).
 # Guardrails: capture drop >1bps, cancel rate +50%, position p95 up, uptime -2pp.
 
 spread_bps = 8.0
-band_bps = 40.0
+band_bps = 30.0
 size = 0.1
 levels = 1
 level_step_bps = 2.0
@@ -88,7 +92,7 @@ dead_zone_bps = 1.0
 
 # ─── Field-side mid-bias microprice shift (docs/31) ───
 # Aggressive start: cap=6, lambda=0.5, dead_zone=0.5.
-# Band widened to 40 to accommodate the larger shift range.
+# Band stays at 30, so a fully stacked shift is clamped to the band edge.
 # Fail-open: signal missing/non-finite -> shift=0.
 [microprice]
 enabled = true


### PR DESCRIPTION
## 为什么

roadmap 优先级 1。两轮 live 读数把亏损定位到逆向选择（`capture 2.8 - markout 3.2 - fee 1 ≈ -1.4bps/笔`），但描述其物理成因的字段一个都没有：

1. 被吃风险的物理量是**距 best 的距离**，而我们所有几何量锚在 mark 上——全仓 `grep distance|to_touch` 在 maker 路径零命中。
2. `desired_quotes` 的 no-cross clamp 会把报价**钉到距 best 一个 tick** 处（`min(band_hi, best_ask - tick)`），可行区间为空时又直接丢弃，两种结果都不留痕迹，离线分不出"这轮没挂"和"这轮被钉在盘口挂了"。
3. `depth_book` 推的多档量被丢掉；`public_trade` 在 SDK 里早就能解析，但 maker feed 从未订阅。

设计与硬约束见 [docs/32](docs/32-maker-observation-telemetry-design.md)。

## 改了什么

**Part A — feed 侧**
- 订阅 `public_trade`；`depth_book` 每侧保留 5 档
- `MarketTelemetry` 用**独立锁**，不放进 `FeedState`：tape 写入不与每周期报价热路径抢锁（写 depth 前先 `drop` FeedState 锁，从不跨锁持有）
- `public_trade` **不进** `ChannelFreshness` / `coherent_ws_snapshot` / `FeedSnapshotVersion`——安静的成交流不会触发 15s idle 重建，不会变成新的 outage 源
- tape 定长 256；`public_trade` 原文 stderr 采样上限 50，用来证实 venue 实际推的字段形状
- `Trade.is_buyer_taker` 带 `#[serde(default)]`，缺字段会静默变 `false`，所以缺 `side` 一律记 unknown，**绝不反推方向**
- `cycle_summary` 追加 `book` / `tape` 两块

**Part B — 报价几何（纯逻辑层）**
- `CyclePlan.quote_geometry`：clamp 前后价、归因、`distance_to_touch_bps`
- 诊断出自**真正执行 clamp 的那段代码**（owner 裁决 2026-08-19），所以 replay 能在历史 trace 上重算；代价是本 PR 附带字节 pin 死的 action 等价测试
- `ClampedToTouch` / `ClampedToBand` 按"哪个界来自盘口"归因，两界重合判给 touch（有专门测试）
- 在场报价每周期也产出一行，用**当轮**盘口重算距离——否则只看得到新挂时的距离，看不到盘口逼近在场单
- `side_distance_to_mark_bps` 提为 `pub`，CLI 不再重写符号约定
- `cycle_summary` 追加 `geometry` 块（聚合 + 明细，含 `band_edge_bps`）

**顺带**
- 去掉 feed 常驻循环里新增的 `expect` panic 路径
- `band_bps 40 → 30`（owner 裁决 2026-08-19）：docs/30 已把 ±10bp 带内 uptime 定为**约束条件**，放宽到 40 方向相反。后果写进配置注释——candidate 侧叠加偏移 `34 > 30` 会被 band clamp 真的截断，这是接受的代价
- microprice 的 accepted 判定成立于 band=40、偏移永不被截断的条件下，因此**只结转方向、不结转效果量**；docs/18 补上缺失的 `micro_price` 行并改掉与已合并实现矛盾的 line 86；docs/31 补进索引

## 安全边界

- 新字段**不被** `preflight_cycle` / `plan_cycle` / `reconcile` / guard / skew / vol 任何分支读取；`quote_geometry` 的读取点只有 `cycle.rs → output.rs` 和 replay 测试
- 订阅失败、解析失败、字段缺失一律降级为"无观测"，继续正常报价
- tape 与深档有界，不随运行时长增长
- JSON 沿用现有 `with_*_fields` 追加式惯例，字段缺失为 `null`

## 验证

```
cargo test --workspace --offline        610 passed / 0 failed
cargo clippy --workspace --all-targets -- -D warnings   pass
cargo fmt --all -- --check              pass
python3 -m py_compile scripts/openobserve_dashboard.py  pass
```

replay 等价由 `replay.rs` 里**早于本 PR 的字面期望值**保证（geometry 不扰动 action 序列）。clamp 归因与 action 序列都做过 mutation 检查（改坏能让对应测试变红）。

## 已知取舍（不阻塞，留作 follow-up）

- `book` 块要求遥测那份深档与本轮决策用的 book **瞬间精确一致**才渲染，否则整块 `null`，REST 回退时恒为 `null`。换来的是"深度与决策所用盘口对齐"的强保证。**开跑后第一件事是统计 `book: null` 占比**；若占比可观，就把严格匹配从"门"降级成"标记"（照常渲染 + `matches_decision_book` 布尔）。副作用：`age_ms` 有值时恒为 ~0
- `DroppedInfeasible` 一个标签盖了两种成因：可行区间为空 vs rounding 之后穿过盘口
- 每个 slot 只有一行：撤旧挂新时只看到新单的几何；resting 行与新挂行的 outcome 都是 `placed`，没有 `is_resting` 标记
- `ClampedToBand` / `ClampedToTouch` 的计数在 band=40 与 band=30 下**不可直接比较**（已记进 docs/30）

## 不在本 PR

Part C（成交时刻盘口观测）、min-distance-to-touch **门控**（那是策略改动，需单独立项与预注册判据）、任何 `spread_bps` / `refresh_bps` 默认值改动、symbol/size/`max_position` 改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
