### PR TITLE
fix(sdk): quick-start doctest 不再打生产网络（no_run）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The SDK's quick-start documentation example is now compiled but not executed (`no_run`). It previously issued a real HTTP request to the production endpoint when `cargo test` ran, so a transient network failure could fail the workspace test gate with no test actually broken.
+
 ### Added
 - `standx maker` now records observation-only market microstructure on `cycle_summary`: a `book` block (up to five depth levels per side, top-of-book sizes, touch spread, mark/mid divergence), a `tape` block summarizing the newly subscribed `public_trade` channel over a five-second window, and a `geometry` block reporting per-slot quote geometry — pre-clamp and post-clamp price, which bound was binding (eligibility band vs post-only no-cross), and the distance from each quote to the opposing touch. None of these fields feed quoting, cancellation, exit, or safety decisions, and the replay action sequence is unchanged.
 

--- a/crates/standx-sdk/src/lib.rs
+++ b/crates/standx-sdk/src/lib.rs
@@ -10,7 +10,14 @@
 //!
 //! ## Quick Start
 //!
-//! ```rust
+//! `no_run`: this example is compiled and type-checked on every `cargo test`,
+//! but never executed. Running it would issue a real HTTP request to the
+//! production endpoint, which made the workspace test gate depend on network
+//! reachability — a transient DNS or connectivity blip failed `cargo test`
+//! with no test actually broken, which is worse than useless in CI and has
+//! already caused one misread gate result.
+//!
+//! ```rust,no_run
 //! use standx_sdk::client::StandXClient;
 //!
 //! #[tokio::main]


### PR DESCRIPTION
## 问题

`crates/standx-sdk/src/lib.rs` 的 quick-start 示例是工作区里**唯一**的 doctest，而它会真的发一次 HTTP 请求：

```
Error: HTTP request failed: 0 - error sending request for url
(https://perps.standx.com/api/query_symbol_market?symbol=BTC-USD)
```

于是 `cargo test --workspace` 的结果取决于网络可达性——一次瞬时 DNS 或连接抖动就能让整个测试门 `exit 1`，而**没有任何测试真的坏了**。这在 CI 上是纯噪声，昨天在一次 maker 改动的 review 里还导致过一次门结果误读（先报 1 failed，单独重跑即通过）。

## 改动

一行：` ```rust ` → ` ```rust,no_run `，外加一段注释说明为什么。

示例**仍然每次 `cargo test` 都编译和类型检查**——把 `StandXClient::new()` 或 `get_symbol_market` 的签名改坏，这个 doctest 依然会红。只是不再执行。输出从

```
test crates/standx-sdk/src/lib.rs - (line 13) ... ok
```

变成

```
test crates/standx-sdk/src/lib.rs - (line 20) - compile ... ok
```

## 验证

```
cargo test --workspace --offline        610 passed / 0 failed  (exit 0)
cargo clippy --workspace --all-targets -- -D warnings   exit 0
cargo fmt --all -- --check              exit 0
```

单独跑 `cargo test -p standx-sdk --doc --offline` → `1 passed`，且用例标为 `- compile`，确认已不再执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
