### PR TITLE
docs(maker): external_skew 状态改为「已启用但未判定」（owner 2026-08-21 保留）

### DIFF
--- a/docs/18-maker-strategy-roadmap.md
+++ b/docs/18-maker-strategy-roadmap.md
@@ -17,8 +17,16 @@
 - **当前冻结 HYPE 基线**启用 `nonlinear_skew(boost=3, cap=12bps)` 与
   `external_guard(enter=10bps, exit=5bps)`；两者分别于 2026-07-25 和 2026-07-27
   判定 accepted，但当时的预注册判据没有把 PnL 作为晋级条件。
-- **`external_skew` 已实现但默认关闭。** 当前只有冻结候选配置，没有 accepted 判定；是否
-  使用 live 时间片验证，仍需 release owner 独立裁决和新的精确授权。
+- **`external_skew` 在跑，但从未被判定（owner 裁决 2026-08-21：保留，判定推迟）。**
+  它随 microprice A/B 进入生产——那一轮**两臂都带 `[external_skew]`**，所以那次判定
+  只回答了"在 external_skew 之上加 microprice 有没有用"，**从未隔离过 external_skew
+  自己**。当前 `examples/maker-microprice-hype-baseline.toml` 里 `enabled = true`。
+  owner 于 2026-08-21 裁决**暂不摘除、暂不补判定**，之后有窗口再回来看；
+  判据仍冻结在 [29](29-maker-external-skew-design.md)，不会失效。
+  **直接后果（读数时必须记住）**：在它开着的期间跑出来的任何窗口，读数里都含着一个
+  效果未知的机制。这尤其影响两件正欠窗口的事——band=30 的重新验证和 microprice 的
+  幅度重测（见 [30](30-maker-uptime-band-tightening-design.md)）。两者的结论都不能
+  被表述为"当前基线的效果"，只能表述为"含未判 external_skew 的基线的效果"。
 - **主要损耗是逆向选择。** 两轮数据中，spread capture 无法覆盖成交后 markout 与手续费；
   即使剔除最差 10% 成交，其余 90% 的单笔经济性仍约为负。
 - **当前瓶颈是诊断数据，不是缺少机制。** 下一优先级是纯观测的盘口深度、成交方向和
@@ -40,7 +48,7 @@
 | `external_guard` | accepted | 防御侧抑制已进入冻结 HYPE 基线；保持 fail-open 信号语义 |
 | 阶段 5-b：退出与账户风险 | implemented | typed trim/wind-down、残余仓位交接和默认关闭的账户硬熔断已落地 |
 | cleanup 残余判定硬化 | completed | WS 终态 success 优先、按单 REST status 兜底，未确认时继续 fail-closed |
-| `external_skew` | implemented, pending verdict | 默认关闭、关闭时等价；候选尚未获得 accepted 判定 |
+| `external_skew` | **enabled in live, unjudged** | 已在冻结基线里开启（`enabled = true`），但从未隔离判定——随 microprice A/B 以**两臂同开**的方式进入生产。owner 2026-08-21 裁决保留、判定推迟；判据仍冻结在 [29](29-maker-external-skew-design.md) |
 | `micro_price` | accepted（方向）/ 幅度未判 | A/B 于 2026-08-19 判 accepted 并提为默认基线配置（`52b0bea`）；判定成立于 band=40，band=30 下偏移会被 clamp 截断，**效果量需新窗口重测**（见 [30](30-maker-uptime-band-tightening-design.md)） |
 
 历史设计、运行手册与判定链见
@@ -85,9 +93,11 @@ symbol、敞口、配置和时间窗，不能复用于新的 live 运行。
    标签；先用 replay 证明不会把一种毒性换成另一种，再考虑立项。
 3. **降低退出执行成本**：库存退出目前发 `OrderType::Market`，每次付 4bps taker。改为
    ALO 挂单优先、亏损越阈值才 IOC 兜底，每次省约 3bps。纯成本项，不改变风险方向。
-4. **裁决 `external_skew`**：如决定继续，使用
-   [29-maker-external-skew-design.md](29-maker-external-skew-design.md) 的冻结单候选和预注册
-   判据，并重新记录授权；未裁决前保持默认关闭。
+4. **（推迟）隔离判定 `external_skew`**：owner 2026-08-21 裁决先保留启用、不补判定。
+   回来做的时候用 [29-maker-external-skew-design.md](29-maker-external-skew-design.md) 的
+   预注册判据（仍有效），但**臂定义已过期**——文中 baseline 臂是 microprice 晋级前的
+   `maker-guard-hype-candidate.toml`，需重挂到当前基线（baseline = 当前减
+   `external_skew`，candidate = 当前）并重新登记授权。
 
 盘口/流特征数据未积累到足够窗口前，不启动 OFI 或新的自动暂停机制。microprice 已实现
 并于 2026-08-19 判 accepted（方向），但其幅度在当前 band=30 下未判；纯观测遥测见

--- a/docs/29-maker-external-skew-design.md
+++ b/docs/29-maker-external-skew-design.md
@@ -1,8 +1,20 @@
 # 外部领先价连续偏移（`[external_skew]`）立项设计（2026-07-29 草案，2026-07-31 细化）
 
-状态：**实现已合入、默认关闭，live 判定待 release owner 裁决**。实现提交 `13bef03` 保持
-toggle-off 等价；本文的候选配置和预注册判据不构成 live 授权。2026-08-01 复核结论仍是
-**保持待裁决，不降级、不关闭**。
+状态：**已在 live 基线中启用，但从未隔离判定；owner 2026-08-21 裁决保留、判定推迟。**
+
+- 它随 microprice A/B 进入生产，而那一轮**两臂都带 `[external_skew]`**（见
+  [handoff 参数表](handoff-microprice-ab-2026-08-13.md)），因此那次 accepted 判定
+  只属于 microprice，**不构成 external_skew 的判定**。当前
+  `examples/maker-microprice-hype-baseline.toml` 中 `enabled = true`。
+- **本文的预注册判据仍然有效且冻结**（primary：逐笔签名 markout@30s 改善 ≥2bps，
+  单侧 95% 下界 >0，4h block bootstrap；护栏：5s markout 不恶化 >1bps；AS 为诊断量）。
+- **但臂定义已过期**：下文 baseline 臂写的是 `maker-guard-hype-candidate.toml`，那是
+  microprice 晋级前的配置。回来跑时须重挂到当前基线（baseline = 当前减
+  `external_skew`，candidate = 当前），并按 [28](28-experiment-protocol.md) 重新登记
+  立项与授权。样本量口径不变：实测 ≈14.4 fills/h，两臂合计约 4 天 live。
+- 早前状态（供溯源）：实现提交 `13bef03` 保持 toggle-off 等价；2026-08-01 复核结论为
+  "保持待裁决，不降级、不关闭"。当时它确实是默认关闭的——**变成启用是后来随基线配置
+  一起发生的，没有独立决策记录**，这正是本次把状态写清的原因。
 
 - **2026-07-31 细化**四处（机制与配置面不变）：guard 激活期间的复合语义、band 预算
   红线、验收判据的统计功效口径、证据溯源。

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ runbook 统一放在 [archive/](archive/README.md)，不能作为新的 live 授
 | [16 - WebSocket 目标](16-ws-iteration-goals.md) | 当前 WS 架构、健康与验收边界 | 开发参考 |
 | [17 - WS canary 快速启动](17-ws-command-canary-quickstart.md) | 受控命令链 create/cancel 验证 | 操作手册 |
 | [18 - 当前状态与路线](18-maker-strategy-roadmap.md) | 机制判定、经济结论、优先级与长期不变量 | 当前策略状态真源 |
-| [29 - External skew 候选](29-maker-external-skew-design.md) | 默认关闭候选的设计和预注册判据 | 待裁决候选，不代表已授权 |
+| [29 - External skew 候选](29-maker-external-skew-design.md) | 设计与预注册判据（判据仍冻结有效） | **已在 live 启用但从未判定**；owner 2026-08-21 裁决保留、判定推迟 |
 | [30 - 带内 uptime 参数收缩](30-maker-uptime-band-tightening-design.md) | SIP-5A ±10bp 带内 uptime 的渐进参数收缩设计与预注册判据 | 待裁决序列，每步需 owner 裁决 |
 | [31 - Microprice 设计](31-maker-microprice-design.md) | 场内侧 touch-mid 中心偏移的设计与预注册判据 | 方向已判 accepted，幅度未判 |
 | [32 - 纯观测遥测](32-maker-observation-telemetry-design.md) | 盘口深档、成交流、clamp 命中与距盘口距离的观测字段设计 | 纯观测，不含策略授权 |


### PR DESCRIPTION
## 事实核对（当前 main）

| 位置 | 原本写着 | 实际情况 |
|---|---|---|
| `examples/maker-microprice-hype-baseline.toml:88` | — | `[external_skew] enabled = true` —— **它在跑** |
| docs/18 当前结论 / 机制判定表 / 优先级 4 | 「已实现但默认关闭」「pending verdict」「未裁决前保持默认关闭」 | 与现实不符 |
| docs/29 状态行 | 「实现已合入、默认关闭，live 判定待裁决」 | 与现实不符 |
| docs/README 索引 | 「待裁决候选，不代表已授权」 | 与现实不符 |
| `docs/evidence/` | — | **没有它的判定文件** |

**它是怎么上去的**：随 microprice A/B 进入生产，而那一轮**两臂都带 `[external_skew]`**（见 [handoff 参数表](docs/handoff-microprice-ab-2026-08-13.md)）。所以那次 accepted 判定只属于 microprice，**从未隔离过 external_skew 自己**。换句话说「变成启用」是跟着基线配置一起发生的，**没有独立决策记录**——这正是本 PR 存在的理由。

## 裁决

owner 2026-08-21：**保留启用、判定推迟**，之后有窗口再回来看。

本 PR 只把文档改成与现实一致，**不动任何代码或配置**。docs/18 是仓库自称的「当前状态真源」，让它继续写着与生产相反的话，比机制本身未判更危险。

## 随之必须说清的两件事（都写进文档了）

**1. 读数口径。** 在它开着的期间跑出来的任何窗口，读数里都含着一个效果未知的机制。这尤其影响两件正欠窗口的事——**band=30 的重新验证**和 **microprice 的幅度重测**。两者的结论只能表述为「含未判 `external_skew` 的基线的效果」，**不能**表述为「当前基线的效果」。

**2. 回来做时的前提。** docs/29 的预注册判据**仍然有效且冻结**：primary 是逐笔签名 markout@30s 改善 ≥2bps、单侧 95% 置信下界 >0、4h block bootstrap；护栏是 5s markout 不恶化 >1bps；AS 为诊断量。

**但臂定义已过期**——文中 baseline 臂写的是 `maker-guard-hype-candidate.toml`，那是 microprice 晋级**之前**的配置。回来跑时须重挂到当前基线（baseline = 当前减 `external_skew`，candidate = 当前），并按 [docs/28](docs/28-experiment-protocol.md) 重新登记立项与授权。样本量口径不变：实测 ≈14.4 fills/h，**两臂合计约 4 天 live**。

## 验证

文档改动，无代码。链接目标 `docs/handoff-microprice-ab-2026-08-13.md` 已确认存在。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
